### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,14 @@ jobs:
       run:
         working-directory: api
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.13
 
       - name: Cache Bun packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-codeapi-api-bun-1.3.13-${{ hashFiles('api/bun.lock') }}
@@ -75,14 +75,14 @@ jobs:
       run:
         working-directory: service
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.13
 
       - name: Cache Bun packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-codeapi-service-bun-1.3.13-${{ hashFiles('service/bun.lock') }}

--- a/.github/workflows/open-sync-pr.yml
+++ b/.github/workflows/open-sync-pr.yml
@@ -16,7 +16,7 @@ jobs:
   open-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Open PR from sync/main if none exists
         env:


### PR DESCRIPTION
Pins the actions in both workflows to the commit SHA each tag points at right now, version left as a trailing comment so Dependabot can still bump them.

| Action | Tag | SHA |
|---|---|---|
| `actions/checkout` | v6 | `df4cb1c069e1874edd31b4311f1884172cec0e10` |
| `oven-sh/setup-bun` | v2 | `0c5077e51419868618aeaa5fe8019c62421857d6` |
| `actions/cache` | v5 | `27d5ce7f107fe9357f9df03efb73ab90386fccae` |

the only one that really matters is `oven-sh/setup-bun`, it's third-party so a repointed tag would run in CI. the `actions/*` ones are github-owned, pinned just for consistency. blast radius is small anyway, CI runs with a read-only token and there are no actions secrets in the repo.

heads up, this repo is published from the ai monorepo so the next sync will revert these unless the same pin lands upstream. not enforcing sha pinning at the repo level for that reason, the branch protection + required checks cover main either way.