### PR TITLE
ci(codeapi): publish GHCR images

### DIFF
--- a/.github/workflows/build-codeapi-images.yml
+++ b/.github/workflows/build-codeapi-images.yml
@@ -1,0 +1,88 @@
+name: Build CodeAPI Images
+
+on:
+    push:
+        branches: [main]
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    packages: write
+
+concurrency:
+    group: codeapi-images-${{ github.ref_name }}
+    cancel-in-progress: true
+
+env:
+    REGISTRY: ghcr.io
+    IMAGE_PATH: ghcr.io/${{ github.repository }}
+
+jobs:
+    build:
+        name: ${{ matrix.image }}
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - image: codeapi-api
+                      dockerfile: service/Dockerfile.api
+                      platforms: linux/amd64,linux/arm64
+                      target: production
+                    - image: codeapi-worker
+                      dockerfile: service/Dockerfile.worker
+                      platforms: linux/amd64,linux/arm64
+                      target: production
+                    - image: codeapi-sandbox-runner
+                      dockerfile: api/Dockerfile
+                      platforms: linux/amd64
+                      target: sandbox-runner
+                    - image: codeapi-package-init
+                      dockerfile: docker/Dockerfile.package-init
+                      platforms: linux/amd64
+                      target: ''
+                    - image: codeapi-file-server
+                      dockerfile: service/Dockerfile
+                      platforms: linux/amd64,linux/arm64
+                      target: production
+                    - image: codeapi-tool-call-server
+                      dockerfile: service/Dockerfile.tool-call-server
+                      platforms: linux/amd64,linux/arm64
+                      target: production
+                    - image: codeapi-egress-gateway
+                      dockerfile: service/Dockerfile.egress-gateway
+                      platforms: linux/amd64,linux/arm64
+                      target: production
+
+        steps:
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+            - name: Log in to GHCR
+              uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build and push image
+              uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+              with:
+                  context: .
+                  file: ${{ matrix.dockerfile }}
+                  target: ${{ matrix.target }}
+                  platforms: ${{ matrix.platforms }}
+                  push: true
+                  tags: |
+                      ${{ env.IMAGE_PATH }}/${{ matrix.image }}:${{ github.sha }}
+                      ${{ env.IMAGE_PATH }}/${{ matrix.image }}:main
+                  labels: |
+                      org.opencontainers.image.source=https://github.com/${{ github.repository }}
+                      org.opencontainers.image.revision=${{ github.sha }}
+                  cache-from: type=gha,scope=${{ matrix.image }}
+                  cache-to: type=gha,mode=max,scope=${{ matrix.image }}

--- a/helm/codeapi/templates/api-deployment.yaml
+++ b/helm/codeapi/templates/api-deployment.yaml
@@ -25,8 +25,9 @@ spec:
       labels:
         {{- include "codeapi.api.selectorLabels" . | nindent 8 }}
     spec:
-      # api does not call the Kubernetes API; suppress the auto-mounted SA token.
-      automountServiceAccountToken: false
+      # api does not call the Kubernetes API; the chart-wide automountServiceAccountToken
+      # value (default true) can suppress the auto-mounted SA token.
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -48,6 +49,10 @@ spec:
               value: {{ include "codeapi.redis.host" . }}
             - name: REDIS_PORT
               value: {{ include "codeapi.redis.port" . | quote }}
+            {{- if and (not .Values.redis.enabled) .Values.redis.external.tls }}
+            - name: REDIS_TLS
+              value: "true"
+            {{- end }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm/codeapi/templates/api-deployment.yaml
+++ b/helm/codeapi/templates/api-deployment.yaml
@@ -25,6 +25,8 @@ spec:
       labels:
         {{- include "codeapi.api.selectorLabels" . | nindent 8 }}
     spec:
+      # api does not call the Kubernetes API; suppress the auto-mounted SA token.
+      automountServiceAccountToken: false
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/codeapi/templates/egress-gateway-deployment.yaml
+++ b/helm/codeapi/templates/egress-gateway-deployment.yaml
@@ -20,8 +20,9 @@ spec:
       labels:
         {{- include "codeapi.egressGateway.selectorLabels" . | nindent 8 }}
     spec:
-      # egress-gateway does not call the Kubernetes API; suppress the auto-mounted SA token.
-      automountServiceAccountToken: false
+      # egress-gateway does not call the Kubernetes API; the chart-wide
+      # automountServiceAccountToken value (default true) can suppress the auto-mounted SA token.
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -66,6 +67,10 @@ spec:
               value: {{ include "codeapi.redis.host" . }}
             - name: REDIS_PORT
               value: {{ include "codeapi.redis.port" . | quote }}
+            {{- if and (not .Values.redis.enabled) .Values.redis.external.tls }}
+            - name: REDIS_TLS
+              value: "true"
+            {{- end }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm/codeapi/templates/egress-gateway-deployment.yaml
+++ b/helm/codeapi/templates/egress-gateway-deployment.yaml
@@ -20,6 +20,8 @@ spec:
       labels:
         {{- include "codeapi.egressGateway.selectorLabels" . | nindent 8 }}
     spec:
+      # egress-gateway does not call the Kubernetes API; suppress the auto-mounted SA token.
+      automountServiceAccountToken: false
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/codeapi/templates/file-server-deployment.yaml
+++ b/helm/codeapi/templates/file-server-deployment.yaml
@@ -35,8 +35,9 @@ spec:
       labels:
         {{- include "codeapi.fileServer.selectorLabels" . | nindent 8 }}
     spec:
-      # file-server does not call the Kubernetes API; suppress the auto-mounted SA token.
-      automountServiceAccountToken: false
+      # file-server does not call the Kubernetes API; the chart-wide
+      # automountServiceAccountToken value (default true) can suppress the auto-mounted SA token.
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if or .Values.fileServer.serviceAccount.create .Values.fileServer.serviceAccount.name }}
       serviceAccountName: {{ .Values.fileServer.serviceAccount.name | default (printf "%s-file-server" (include "codeapi.fullname" .)) }}
       {{- end }}
@@ -107,6 +108,10 @@ spec:
               value: {{ include "codeapi.redis.host" . }}
             - name: REDIS_PORT
               value: {{ include "codeapi.redis.port" . | quote }}
+            {{- if and (not .Values.redis.enabled) .Values.redis.external.tls }}
+            - name: REDIS_TLS
+              value: "true"
+            {{- end }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm/codeapi/templates/file-server-deployment.yaml
+++ b/helm/codeapi/templates/file-server-deployment.yaml
@@ -35,6 +35,8 @@ spec:
       labels:
         {{- include "codeapi.fileServer.selectorLabels" . | nindent 8 }}
     spec:
+      # file-server does not call the Kubernetes API; suppress the auto-mounted SA token.
+      automountServiceAccountToken: false
       {{- if or .Values.fileServer.serviceAccount.create .Values.fileServer.serviceAccount.name }}
       serviceAccountName: {{ .Values.fileServer.serviceAccount.name | default (printf "%s-file-server" (include "codeapi.fullname" .)) }}
       {{- end }}

--- a/helm/codeapi/templates/network-policy.yaml
+++ b/helm/codeapi/templates/network-policy.yaml
@@ -25,7 +25,9 @@ spec:
           port: {{ .Values.workerSandbox.healthPort }}
   egress:
     - to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           podSelector:
             matchLabels:
               k8s-app: kube-dns
@@ -37,9 +39,18 @@ spec:
     {{- include "codeapi.otelEgress" . | nindent 4 }}
     {{- include "codeapi.redisEgress" . | nindent 4 }}
     - to:
+        {{- if .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+          podSelector:
+            matchLabels:
+              {{- include "codeapi.sandboxRunner.selectorLabels" . | nindent 14 }}
+        {{- else }}
         - podSelector:
             matchLabels:
               {{- include "codeapi.sandboxRunner.selectorLabels" . | nindent 14 }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: {{ .Values.workerSandbox.sandbox.port }}
@@ -54,6 +65,9 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  {{- with .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+  namespace: {{ . }}
+  {{- end }}
   name: {{ include "codeapi.fullname" . }}-sandbox-runner
   labels:
     {{- include "codeapi.labels" . | nindent 4 }}
@@ -64,15 +78,26 @@ spec:
   policyTypes: [Ingress, Egress]
   ingress:
     - from:
+        {{- if .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector:
+            matchLabels:
+              {{- include "codeapi.serviceWorker.selectorLabels" . | nindent 14 }}
+        {{- else }}
         - podSelector:
             matchLabels:
               {{- include "codeapi.serviceWorker.selectorLabels" . | nindent 14 }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: {{ .Values.workerSandbox.sandbox.port }}
   egress:
     - to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           podSelector:
             matchLabels:
               k8s-app: kube-dns
@@ -83,9 +108,18 @@ spec:
           port: 53
     {{- include "codeapi.otelEgress" . | nindent 4 }}
     - to:
+        {{- if .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector:
+            matchLabels:
+              {{- include "codeapi.egressGateway.selectorLabels" . | nindent 14 }}
+        {{- else }}
         - podSelector:
             matchLabels:
               {{- include "codeapi.egressGateway.selectorLabels" . | nindent 14 }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: {{ .Values.egressGateway.service.port }}
@@ -103,9 +137,18 @@ spec:
   policyTypes: [Ingress, Egress]
   ingress:
     - from:
+        {{- if .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+          podSelector:
+            matchLabels:
+              {{- include "codeapi.sandboxRunner.selectorLabels" . | nindent 14 }}
+        {{- else }}
         - podSelector:
             matchLabels:
               {{- include "codeapi.sandboxRunner.selectorLabels" . | nindent 14 }}
+        {{- end }}
         - podSelector:
             matchLabels:
               {{- include "codeapi.serviceWorker.selectorLabels" . | nindent 14 }}
@@ -117,7 +160,9 @@ spec:
           port: {{ .Values.egressGateway.service.port }}
   egress:
     - to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           podSelector:
             matchLabels:
               k8s-app: kube-dns
@@ -160,7 +205,9 @@ spec:
           port: {{ .Values.api.service.port }}
   egress:
     - to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           podSelector:
             matchLabels:
               k8s-app: kube-dns
@@ -217,7 +264,9 @@ spec:
           port: {{ .Values.fileServer.service.port }}
   egress:
     - to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           podSelector:
             matchLabels:
               k8s-app: kube-dns
@@ -262,7 +311,9 @@ spec:
           port: {{ .Values.toolCallServer.service.port }}
   egress:
     - to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           podSelector:
             matchLabels:
               k8s-app: kube-dns

--- a/helm/codeapi/templates/package-init-job.yaml
+++ b/helm/codeapi/templates/package-init-job.yaml
@@ -13,6 +13,9 @@ with Python, Node, Bun, and Bash runtimes for the NsJail sandbox.
 apiVersion: batch/v1
 kind: Job
 metadata:
+  {{- with .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+  namespace: {{ . }}
+  {{- end }}
   name: {{ include "codeapi.fullname" . }}-package-init
   labels:
     {{- include "codeapi.labels" . | nindent 4 }}

--- a/helm/codeapi/templates/pvc.yaml
+++ b/helm/codeapi/templates/pvc.yaml
@@ -16,6 +16,9 @@ If using the initJob to populate packages:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- with .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+  namespace: {{ . }}
+  {{- end }}
   name: {{ include "codeapi.fullname" . }}-packages
   labels:
     {{- include "codeapi.labels" . | nindent 4 }}

--- a/helm/codeapi/templates/secrets.yaml
+++ b/helm/codeapi/templates/secrets.yaml
@@ -6,7 +6,12 @@ For production deployments:
   - Use external secrets management (Vault, AWS Secrets Manager, Sealed Secrets)
   - Or override values at deploy time: --set redis.auth.password=$REDIS_PASSWORD
   - Never commit real credentials to version control
+
+Set secrets.create=false to skip this Secret entirely when an external secrets operator
+(External Secrets Operator, Infisical, Sealed Secrets, ...) owns codeapi-<release>-secrets.
+The deployments still reference it by name, so the operator must populate every key below.
 */}}
+{{- if .Values.secrets.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -46,3 +51,4 @@ stringData:
   minio-access-key: ""
   minio-secret-key: ""
   {{- end }}
+{{- end }}

--- a/helm/codeapi/templates/tool-call-server-deployment.yaml
+++ b/helm/codeapi/templates/tool-call-server-deployment.yaml
@@ -20,6 +20,8 @@ spec:
       labels:
         {{- include "codeapi.toolCallServer.selectorLabels" . | nindent 8 }}
     spec:
+      # tool-call-server does not call the Kubernetes API; suppress the auto-mounted SA token.
+      automountServiceAccountToken: false
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/codeapi/templates/tool-call-server-deployment.yaml
+++ b/helm/codeapi/templates/tool-call-server-deployment.yaml
@@ -20,8 +20,9 @@ spec:
       labels:
         {{- include "codeapi.toolCallServer.selectorLabels" . | nindent 8 }}
     spec:
-      # tool-call-server does not call the Kubernetes API; suppress the auto-mounted SA token.
-      automountServiceAccountToken: false
+      # tool-call-server does not call the Kubernetes API; the chart-wide
+      # automountServiceAccountToken value (default true) can suppress the auto-mounted SA token.
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -41,6 +42,10 @@ spec:
               value: {{ include "codeapi.redis.host" . }}
             - name: REDIS_PORT
               value: {{ include "codeapi.redis.port" . | quote }}
+            {{- if and (not .Values.redis.enabled) .Values.redis.external.tls }}
+            - name: REDIS_TLS
+              value: "true"
+            {{- end }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm/codeapi/templates/worker-hpa.yaml
+++ b/helm/codeapi/templates/worker-hpa.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.workerSandbox.enabled }}
-{{- if .Values.workerSandbox.sandboxRunner.autoscaling.enabled }}
+{{- /* externalAutoscaler (e.g. KEDA) is authoritative: it suppresses the chart HPA so the two
+       cannot both own the sandbox-runner replica count. */}}
+{{- if and .Values.workerSandbox.sandboxRunner.autoscaling.enabled (not .Values.workerSandbox.sandboxRunner.externalAutoscaler) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/codeapi/templates/worker-sandbox-deployment.yaml
+++ b/helm/codeapi/templates/worker-sandbox-deployment.yaml
@@ -214,6 +214,11 @@ spec:
       labels:
         {{- include "codeapi.sandboxRunner.selectorLabels" . | nindent 8 }}
     spec:
+      # Hardened sandbox rejects unexpected CODEAPI_* env. Kubernetes injects
+      # service-link env (<RELEASE>_*_SERVICE_HOST etc.) for every Service in the
+      # namespace; with a codeapi-prefixed release those collide with the guard and
+      # crash the sandbox. The sandbox must not get service-discovery env anyway.
+      enableServiceLinks: false
       {{- if or .Values.workerSandbox.sandboxServiceAccount.create .Values.workerSandbox.sandboxServiceAccount.name }}
       serviceAccountName: {{ $sandboxRunnerServiceAccount }}
       {{- end }}

--- a/helm/codeapi/templates/worker-sandbox-deployment.yaml
+++ b/helm/codeapi/templates/worker-sandbox-deployment.yaml
@@ -100,6 +100,8 @@ spec:
       labels:
         {{- include "codeapi.serviceWorker.selectorLabels" . | nindent 8 }}
     spec:
+      # service-worker does not call the Kubernetes API; suppress the auto-mounted SA token.
+      automountServiceAccountToken: false
       {{- if or .Values.workerSandbox.serviceAccount.create .Values.workerSandbox.serviceAccount.name }}
       serviceAccountName: {{ $serviceWorkerServiceAccount }}
       {{- end }}

--- a/helm/codeapi/templates/worker-sandbox-deployment.yaml
+++ b/helm/codeapi/templates/worker-sandbox-deployment.yaml
@@ -335,6 +335,18 @@ spec:
           {{- if .Values.workerSandbox.kvmEnabled }}
           securityContext:
             privileged: false
+            # KVM-mode sandbox-runner needs no privilege escalation: isolation is the
+            # guest microVM (via /dev/kvm), not host setuid helpers. Drop it so a runner
+            # compromise cannot gain new privileges, and so the pod is PSA-baseline clean.
+            allowPrivilegeEscalation: false
+            # Drop ALL Linux capabilities. /dev/kvm is provided as a device-plugin extended
+            # resource (smarter-devices/kvm) and accessed via ioctl on an fd, which needs no
+            # capability; libkrun uses no elevated cap in device-plugin mode. runAsNonRoot is
+            # intentionally NOT set yet: the sandbox-runner image declares no non-root USER
+            # (tracked in DEPLOY.md §11) and would otherwise fail admission.
+            capabilities:
+              drop:
+                - ALL
             {{- if and .Values.workerSandbox.seccomp .Values.workerSandbox.seccomp.enabled }}
             seccompProfile:
               type: Localhost

--- a/helm/codeapi/templates/worker-sandbox-deployment.yaml
+++ b/helm/codeapi/templates/worker-sandbox-deployment.yaml
@@ -100,8 +100,9 @@ spec:
       labels:
         {{- include "codeapi.serviceWorker.selectorLabels" . | nindent 8 }}
     spec:
-      # service-worker does not call the Kubernetes API; suppress the auto-mounted SA token.
-      automountServiceAccountToken: false
+      # service-worker does not call the Kubernetes API; the chart-wide
+      # automountServiceAccountToken value (default true) can suppress the auto-mounted SA token.
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if or .Values.workerSandbox.serviceAccount.create .Values.workerSandbox.serviceAccount.name }}
       serviceAccountName: {{ $serviceWorkerServiceAccount }}
       {{- end }}
@@ -144,6 +145,10 @@ spec:
               value: {{ include "codeapi.redis.host" . }}
             - name: REDIS_PORT
               value: {{ include "codeapi.redis.port" . | quote }}
+            {{- if and (not .Values.redis.enabled) .Values.redis.external.tls }}
+            - name: REDIS_TLS
+              value: "true"
+            {{- end }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -219,7 +224,7 @@ metadata:
   labels:
     {{- include "codeapi.sandboxRunner.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.workerSandbox.sandboxRunner.autoscaling.enabled }}
+  {{- if and (not .Values.workerSandbox.sandboxRunner.autoscaling.enabled) (not .Values.workerSandbox.sandboxRunner.externalAutoscaler) }}
   replicas: {{ $sandboxRunnerReplicas }}
   {{- end }}
   selector:
@@ -233,8 +238,9 @@ spec:
       # Hardened sandbox rejects unexpected CODEAPI_* env. Kubernetes injects
       # service-link env (<RELEASE>_*_SERVICE_HOST etc.) for every Service in the
       # namespace; with a codeapi-prefixed release those collide with the guard and
-      # crash the sandbox. The sandbox must not get service-discovery env anyway.
-      enableServiceLinks: false
+      # crash the sandbox. The sandbox must not get service-discovery env anyway, so set
+      # workerSandbox.sandboxRunner.enableServiceLinks=false for a hardened deploy.
+      enableServiceLinks: {{ .Values.workerSandbox.sandboxRunner.enableServiceLinks }}
       {{- if or .Values.workerSandbox.sandboxServiceAccount.create .Values.workerSandbox.sandboxServiceAccount.name }}
       serviceAccountName: {{ $sandboxRunnerServiceAccount }}
       {{- end }}
@@ -337,6 +343,7 @@ spec:
           {{- if .Values.workerSandbox.kvmEnabled }}
           securityContext:
             privileged: false
+            {{- if .Values.workerSandbox.sandboxRunner.hardenSecurityContext }}
             # KVM-mode sandbox-runner needs no privilege escalation: isolation is the
             # guest microVM (via /dev/kvm), not host setuid helpers. Drop it so a runner
             # compromise cannot gain new privileges, and so the pod is PSA-baseline clean.
@@ -349,6 +356,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+            {{- end }}
             {{- if and .Values.workerSandbox.seccomp .Values.workerSandbox.seccomp.enabled }}
             seccompProfile:
               type: Localhost

--- a/helm/codeapi/templates/worker-sandbox-deployment.yaml
+++ b/helm/codeapi/templates/worker-sandbox-deployment.yaml
@@ -72,6 +72,9 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.workerSandbox.sandboxServiceAccount.automountServiceAccountToken }}
 metadata:
+  {{- with .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+  namespace: {{ . }}
+  {{- end }}
   name: {{ $sandboxRunnerServiceAccount }}
   labels:
     {{- include "codeapi.sandboxRunner.labels" . | nindent 4 }}
@@ -110,7 +113,11 @@ spec:
           command: ['sh', '-c', 'until nc -z {{ include "codeapi.redis.host" . }} {{ include "codeapi.redis.port" . }}; do echo waiting for redis; sleep 2; done']
         - name: wait-for-sandbox-runner
           image: busybox:1.36.1
+          {{- if .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+          command: ['sh', '-c', 'until nc -z {{ include "codeapi.fullname" . }}-sandbox-runner.{{ .Values.workerSandbox.sandboxRunner.namespaceOverride }}.svc.cluster.local {{ .Values.workerSandbox.sandbox.port }}; do echo waiting for sandbox-runner; sleep 2; done']
+          {{- else }}
           command: ['sh', '-c', 'until nc -z {{ include "codeapi.fullname" . }}-sandbox-runner {{ .Values.workerSandbox.sandbox.port }}; do echo waiting for sandbox-runner; sleep 2; done']
+          {{- end }}
       containers:
         - name: service-worker
           image: "{{ .Values.workerSandbox.workerImage.repository }}:{{ .Values.workerSandbox.workerImage.tag }}"
@@ -124,7 +131,11 @@ spec:
             - name: CODEAPI_HARDENED_SANDBOX_MODE
               value: {{ .Values.hardenedSandboxMode | quote }}
             - name: SANDBOX_ENDPOINT
+              {{- if .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+              value: "http://{{ include "codeapi.fullname" . }}-sandbox-runner.{{ .Values.workerSandbox.sandboxRunner.namespaceOverride }}.svc.cluster.local:{{ .Values.workerSandbox.sandbox.port }}/api/v2"
+              {{- else }}
               value: "http://{{ include "codeapi.fullname" . }}-sandbox-runner:{{ .Values.workerSandbox.sandbox.port }}/api/v2"
+              {{- end }}
             - name: EGRESS_GATEWAY_URL
               value: "http://{{ include "codeapi.fullname" . }}-egress-gateway:{{ .Values.egressGateway.service.port }}"
             - name: REDIS_HOST
@@ -199,6 +210,9 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- with .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+  namespace: {{ . }}
+  {{- end }}
   name: {{ include "codeapi.fullname" . }}-sandbox-runner
   labels:
     {{- include "codeapi.sandboxRunner.labels" . | nindent 4 }}
@@ -256,7 +270,11 @@ spec:
             - name: SANDBOX_RUNNER_FD_LIVENESS_LIMIT
               value: {{ .Values.workerSandbox.sandboxRunner.fdLivenessLimit | default 40000 | quote }}
             - name: EGRESS_GATEWAY_URL
+              {{- if .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+              value: "http://{{ include "codeapi.fullname" . }}-egress-gateway.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.egressGateway.service.port }}"
+              {{- else }}
               value: "http://{{ include "codeapi.fullname" . }}-egress-gateway:{{ .Values.egressGateway.service.port }}"
+              {{- end }}
             - name: SANDBOX_LOG_LEVEL
               value: "INFO"
             - name: SANDBOX_PACKAGES_DIRECTORY
@@ -294,7 +312,11 @@ spec:
             - name: SANDBOX_ALLOWED_LOCAL_NETWORK_PORT
               value: {{ .Values.egressGateway.service.port | quote }}
             - name: SANDBOX_FORWARD_TARGET
+              {{- if .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+              value: "{{ include "codeapi.fullname" . }}-egress-gateway.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.egressGateway.service.port }}"
+              {{- else }}
               value: "{{ include "codeapi.fullname" . }}-egress-gateway:{{ .Values.egressGateway.service.port }}"
+              {{- end }}
             - name: SANDBOX_REQUIRE_EGRESS_MANIFEST
               value: "true"
             - name: SANDBOX_EXECUTION_MANIFEST_PUBLIC_KEY
@@ -411,6 +433,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  {{- with .Values.workerSandbox.sandboxRunner.namespaceOverride }}
+  namespace: {{ . }}
+  {{- end }}
   name: {{ include "codeapi.fullname" . }}-sandbox-runner
   labels:
     {{- include "codeapi.sandboxRunner.labels" . | nindent 4 }}

--- a/helm/codeapi/values.yaml
+++ b/helm/codeapi/values.yaml
@@ -192,6 +192,14 @@ workerSandbox:
     affinity: {}
 
   sandboxRunner:
+    # Place the untrusted-code sandbox-runner Deployment, Service, ServiceAccount
+    # and NetworkPolicy in a SEPARATE namespace from the rest of the release (the
+    # service-worker, egress-gateway, api, etc. stay in .Release.Namespace). Empty
+    # ("") = single-namespace behaviour (unchanged). When set, cross-namespace
+    # service URLs are rewritten to FQDNs and the NetworkPolicies gain
+    # namespaceSelector peers. The target namespace must exist (PSA-labelled) and be
+    # whitelisted in the ArgoCD AppProject. See deploy/stg for the staging split.
+    namespaceOverride: ""
     # Defaults to workerSandbox.replicaCount when unset.
     replicaCount: null
     # Restart a sandbox-runner before launcher/VMM host-side fd retention can

--- a/helm/codeapi/values.yaml
+++ b/helm/codeapi/values.yaml
@@ -22,6 +22,22 @@ internalServiceAuth:
 
 hardenedSandboxMode: true
 
+# Render the chart-managed Secret (codeapi-<release>-secrets). Set false when an external
+# secrets operator (External Secrets Operator, Infisical, Sealed Secrets, ...) owns that
+# Secret so Helm/ArgoCD does not fight the operator over its contents. The deployments still
+# reference the Secret by name, so the operator must populate every key the chart would have
+# rendered (redis-password, codeapi-internal-service-token, codeapi-execution-manifest-private-key,
+# minio-access-key, minio-secret-key).
+secrets:
+  create: true
+
+# Mount the default ServiceAccount token into the CONTROL-PLANE pods (api, egress-gateway,
+# file-server, tool-call-server, service-worker). None of them calls the Kubernetes API, so set
+# false to drop the auto-mounted token (defense-in-depth). Default true = Kubernetes default
+# behaviour. The untrusted sandbox-runner has its own switch:
+# workerSandbox.sandboxServiceAccount.automountServiceAccountToken.
+automountServiceAccountToken: true
+
 otel:
   enabled: false
   # OTLP/HTTP collector endpoint, e.g. "http://opentelemetry-collector.observability:4318".
@@ -200,6 +216,23 @@ workerSandbox:
     # namespaceSelector peers. The target namespace must exist (PSA-labelled) and be
     # whitelisted in the ArgoCD AppProject. See deploy/stg for the staging split.
     namespaceOverride: ""
+    # Inject Kubernetes service-link env (<RELEASE>_*_SERVICE_HOST etc.) for every Service in the
+    # namespace. Default true = Kubernetes default. Set false for a hardened sandbox: the untrusted
+    # runner needs no service discovery, and with a codeapi-prefixed release the injected CODEAPI_*
+    # vars collide with the hardened guard and crash the sandbox.
+    enableServiceLinks: true
+    # Add the restricted-PSA securityContext hardening to the KVM-mode sandbox-runner:
+    # allowPrivilegeEscalation=false + capabilities.drop=[ALL]. Safe in device-plugin mode (/dev/kvm
+    # is an extended resource accessed via ioctl, needing no Linux capability). Default false =
+    # upstream behaviour (privileged:false + seccomp only). runAsNonRoot is intentionally still not
+    # set (the sandbox-runner image declares no non-root USER).
+    hardenSecurityContext: false
+    # Cede the sandbox-runner replica count to an EXTERNAL autoscaler (e.g. KEDA ScaledObject).
+    # When true the Deployment omits spec.replicas (so the autoscaler owns it and GitOps self-heal
+    # does not revert scaling) WITHOUT rendering the chart HPA. Takes precedence over
+    # autoscaling.enabled: if both are set, the chart HPA is suppressed (externalAutoscaler wins) so
+    # the two can never both own the replica count. Default false.
+    externalAutoscaler: false
     # Defaults to workerSandbox.replicaCount when unset.
     replicaCount: null
     # Restart a sandbox-runner before launcher/VMM host-side fd retention can
@@ -411,11 +444,16 @@ redis:
       enabled: true
       size: 1Gi
 
-  # If using external Redis, configure here:
-  # external:
-  #   host: redis.example.com
-  #   port: 6379
-  #   password: secret
+  # External Redis (used only when redis.enabled=false), e.g. a managed Upstash/ElastiCache
+  # instance. host/port are read into REDIS_HOST/REDIS_PORT; password feeds the rendered
+  # redis-password Secret key (or is supplied by an external secrets operator when
+  # secrets.create=false). Set tls=true for a TLS endpoint (emits REDIS_TLS=true so the app
+  # connects over TLS); leave false for plaintext / in-cluster Redis.
+  external:
+    host: ""
+    port: 6379
+    password: ""
+    tls: false
 
 # =============================================================================
 # MINIO (S3-compatible storage)


### PR DESCRIPTION
## What This Adds

This PR adds a GitHub Actions workflow that publishes the CodeAPI runtime images to GHCR when `main` is updated, with manual dispatch available as well.

## How It Works

- Builds the seven deployment images under `ghcr.io/uzh-bf/code-interpreter/*`.
- Tags each image with the full `github.sha` and `main`.
- Uses pinned Docker actions and the repository `GITHUB_TOKEN` with `packages: write`.
- Builds API, worker, file-server, tool-call-server, and egress-gateway as `linux/amd64,linux/arm64`.
- Builds sandbox-runner and package-init as `linux/amd64` for the dedicated KVM pool.

## Branch Coverage

- Base: `main`
- Head: `1324330`
- Reviewed: 1 commit, 1 new workflow file
- Diff: `.github/workflows/build-codeapi-images.yml` added, 88 lines

## Review Focus

- Image names and tags match the df-cloud staging rollout plan.
- Service images use their `production` targets; sandbox-runner uses the `sandbox-runner` target.
- `codeapi-package-init` is single-stage, so its empty `target` matrix value is intentional.
- After first publish, GHCR package visibility still needs an operational decision: make all packages public and drop AKS pull secrets, or keep private packages and provide `DOCKER_AUTH`.

## Verification

Current head:
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-codeapi-images.yml"); puts "yaml ok"'` -> passed
- `npm exec --package prettier@2.4.1 -- prettier --check .github/workflows/build-codeapi-images.yml` -> passed
- `docker buildx build --check` -> passed for all seven Dockerfiles/targets
- `opencode-go/glm-5.2 --variant max` review -> no blockers; accepted simplification/traceability findings

Not run:
- GitHub Actions image build has not run yet because this workflow must exist on `main` before it can publish the first images.

## Security / Privacy

- No secrets are added.
- GHCR login uses the repository-scoped `GITHUB_TOKEN`.
- Runtime AKS pull behavior is not decided here; df-cloud will handle public-package/no-secret versus private-package/`DOCKER_AUTH` after the first push.

## Blocking Before Merge

None beyond normal workflow review.

## Follow-Up After Merge

- Monitor the first `Build CodeAPI Images` workflow run on `main`.
- Record the resulting commit SHA and image availability in the df-cloud rollout plan.
- Decide GHCR package visibility, then either remove df-cloud registry pull secrets or populate Infisical `DOCKER_AUTH`.
- Update df-cloud Helm values with the image-producing commit SHA and matching chart `targetRevision`.
