### PR TITLE
fix: add clock_gettime and clock_nanosleep to VMM seccomp allowlist

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -130,6 +130,8 @@ mod seccomp {
             libc::SYS_tgkill as u32,
             libc::SYS_getpid as u32,
             libc::SYS_getrandom as u32,
+            libc::SYS_clock_gettime as u32,
+            libc::SYS_clock_nanosleep as u32,
             libc::SYS_sched_getaffinity as u32,
             libc::SYS_sched_yield as u32,
             libc::SYS_set_robust_list as u32,


### PR DESCRIPTION
SYS_clock_gettime was missing from the seccomp allowlist, causing sandbox-runner to panic with EPERM on native Linux kernels.

Rust >= 1.74 changed Instant::now() on Linux to use CLOCK_BOOTTIME instead of CLOCK_MONOTONIC. Since clock_gettime was not in the allowlist at all, the seccomp filter returned EPERM, which Rust's unwrap() turned into a panic.

This only manifested on native Linux kernels (e.g. bare metal, KVM/Proxmox VMs). WSL2 does not enforce prctl(PR_SET_SECCOMP) argument filters the same way, which is why it worked there.

Fixes: sandbox-runner panics with 'Operation not permitted' on native Linux when starting microVM."

**Example error (Hetzner Ubuntu 24.04.2 LTS, Docker version 28.2.2, build e6534b4)** 

> sandbox-runner  | [entrypoint] EGRESS_GATEWAY_URL: egress_gateway -> 172.20.0.7
sandbox-runner  | [entrypoint] SANDBOX_FORWARD_TARGET: egress_gateway -> 172.20.0.7
sandbox-runner  | [launcher] RLIMIT_NOFILE soft=1048576 hard=1048576 target=65536
sandbox-runner  | [launcher] Booting microVM: vcpus=2 ram=2048MiB rootfs=/sandbox-rootfs
sandbox-runner  | [launcher] Guest entrypoint: /sandbox_api/entrypoint.sh
sandbox-runner  | [launcher] Mounted /host-packages as virtio-fs 'packages'
sandbox-runner  | [launcher] Port map: 2000:2000
sandbox-runner  | [launcher] Guest RLIMIT_NOFILE target: 65536
sandbox-runner  | [launcher] VMM seccomp filter applied (74 syscalls allowed, ioctl restricted to KVM+terminal)
sandbox-runner  | [launcher] Starting microVM...
sandbox-runner  |
sandbox-runner  | thread '<unnamed>' (18446744073709551615) panicked at library/std/src/sys/pal/unix/time.rs:101:68:
sandbox-runner  | called `Result::unwrap()` on an `Err` value: Os { code: 1, kind: PermissionDenied, message: "Operation not permitted" }
sandbox-runner  | note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
sandbox-runner  |
sandbox-runner  | thread '<unnamed>' (18446744073709551615) panicked at library/core/src/panicking.rs:225:5:
sandbox-runner  | panic in a function that cannot unwind
sandbox-runner  | stack backtrace:
sandbox-runner  |    0:     0x74cec64a6ec2 - <unknown>
sandbox-runner  |    1:     0x74cec64bbfaa - <unknown>
sandbox-runner  |    2:     0x74cec64ad706 - <unknown>
sandbox-runner  |    3:     0x74cec648fab4 - <unknown>
sandbox-runner  |    4:     0x74cec64a12ce - <unknown>
sandbox-runner  |    5:     0x74cec64a148b - <unknown>
sandbox-runner  |    6:     0x74cec648fb9a - <unknown>
sandbox-runner  |    7:     0x74cec6487bd9 - <unknown>
sandbox-runner  |    8:     0x74cec649035d - <unknown>
sandbox-runner  |    9:     0x74cec620a74d - <unknown>
sandbox-runner  |   10:     0x74cec620a6cb - <unknown>
sandbox-runner  |   11:     0x74cec620a857 - <unknown>
sandbox-runner  |   12:     0x74cec6227656 - krun_start_enter
sandbox-runner  |   13:     0x5edfdf94fbfc - <unknown>
sandbox-runner  |   14:     0x5edfdf95d799 - <unknown>
sandbox-runner  |   15:     0x5edfdf9508d5 - <unknown>
sandbox-runner  |   16:     0x74cec5fdb5b5 - __libc_start_call_main
sandbox-runner  |   17:     0x74cec5fdb668 - __libc_start_main_alias_1
sandbox-runner  |   18:     0x5edfdf94e415 - <unknown>
sandbox-runner  |   19:                0x0 - <unknown>
sandbox-runner  | thread caused non-unwinding panic. aborting.