### PR TITLE
feat(sandbox): add geospatial Python packages

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -63,7 +63,7 @@ All prefixed with `SANDBOX_` unless noted:
 
 Runtimes are auto-discovered from `/pkgs` at startup. Each package provides `compile` and `run` shell scripts. Currently tested and supported:
 
-- **Python** 3.14 -- includes `matplotlib`, `numpy`, `pandas`, `scipy`, `statsmodels`, chDB (`chdb`), and other scientific packages
+- **Python** 3.14 -- includes `matplotlib`, `numpy`, `pandas`, `scipy`, `statsmodels`, chDB (`chdb`), geospatial (`geopandas`, `rasterio`, `rioxarray`, `pyproj`), and other scientific packages
 - **Node.js** 24 -- runs `.js` files with curated offline npm packages
 - **Bun** (JavaScript/TypeScript) -- runs `.js`, `.ts`, and `.bun` files with the same curated offline package set
 

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -209,7 +209,15 @@ install_python_packages() {
         fonttools \
         pytesseract \
         pdfminer \
-        vsdx; then
+        vsdx \
+        rasterio \
+        rioxarray \
+        geopandas \
+        pyogrio \
+        pyproj \
+        osmnx \
+        folium \
+        gpxpy; then
         python_packages_installed=true
     else
         echo "ERROR: Python package installation failed"

--- a/docker/package-init.sh
+++ b/docker/package-init.sh
@@ -92,6 +92,7 @@ packages_ready() {
     [ -d "/pkgs/python/${PYTHON_VERSION}/lib/python${PYTHON_SITE_VERSION}/site-packages/markitdown" ] &&
     [ -d "/pkgs/python/${PYTHON_VERSION}/lib/python${PYTHON_SITE_VERSION}/site-packages/chdb" ] &&
     [ -d "/pkgs/python/${PYTHON_VERSION}/lib/python${PYTHON_SITE_VERSION}/site-packages/statsmodels" ] &&
+    [ -d "/pkgs/python/${PYTHON_VERSION}/lib/python${PYTHON_SITE_VERSION}/site-packages/rasterio" ] &&
     [ -f "/pkgs/node/${NODE_VERSION}/.package-installed" ] &&
     js_packages_ready "/pkgs/node/${NODE_VERSION}" &&
     [ -f "/pkgs/bun/${BUN_VERSION}/.package-installed" ] &&

--- a/docker/package-init.sh
+++ b/docker/package-init.sh
@@ -229,7 +229,15 @@ if [ -f "$PIP_PATH" ]; then
         fonttools \
         pytesseract \
         pdfminer \
-        vsdx; then
+        vsdx \
+        rasterio \
+        rioxarray \
+        geopandas \
+        pyogrio \
+        pyproj \
+        osmnx \
+        folium \
+        gpxpy; then
         echo "ERROR: Python package installation failed"
         INSTALL_FAILED=true
     else

--- a/test-sandbox.sh
+++ b/test-sandbox.sh
@@ -174,6 +174,21 @@ test_statsmodels() {
     fi
 }
 
+test_geospatial() {
+    log_info "Testing geospatial stack import and reprojection..."
+    result=$(execute_sandbox '{"language":"python","version":"3.14.4","files":[{"content":"import geopandas as gpd\nimport rasterio\nfrom shapely.geometry import Point\ngdf = gpd.GeoDataFrame(geometry=[Point(-74.006, 40.7128)], crs=\"EPSG:4326\").to_crs(\"EPSG:26918\")\nprint(round(float(gdf.geometry.iloc[0].x), 2))"}]}')
+
+    stdout=$(echo "$result" | jq -r '.run.stdout // empty')
+    if [[ "$stdout" =~ ^[0-9.-]+ ]]; then
+        log_success "geospatial: got '$stdout'"
+        return 0
+    else
+        log_error "geospatial: expected numeric UTM 18N easting, got '$stdout'"
+        echo "$result" | jq .
+        return 1
+    fi
+}
+
 test_chdb() {
     log_info "Testing chDB import and query..."
     result=$(execute_sandbox '{"language":"python","version":"3.14.4","files":[{"content":"import chdb\nprint(chdb.query(\"SELECT sum(number) FROM numbers(5)\", \"CSV\"))"}]}')
@@ -400,6 +415,7 @@ FAILED=0
 test_basic_python || FAILED=$((FAILED + 1))
 test_numpy || FAILED=$((FAILED + 1))
 test_statsmodels || FAILED=$((FAILED + 1))
+test_geospatial || FAILED=$((FAILED + 1))
 test_chdb || FAILED=$((FAILED + 1))
 test_file_write || FAILED=$((FAILED + 1))
 test_network_blocked || FAILED=$((FAILED + 1))

--- a/test-sandbox.sh
+++ b/test-sandbox.sh
@@ -179,11 +179,14 @@ test_geospatial() {
     result=$(execute_sandbox '{"language":"python","version":"3.14.4","files":[{"content":"import geopandas as gpd\nimport rasterio\nfrom shapely.geometry import Point\ngdf = gpd.GeoDataFrame(geometry=[Point(-74.006, 40.7128)], crs=\"EPSG:4326\").to_crs(\"EPSG:26918\")\nprint(round(float(gdf.geometry.iloc[0].x), 2))"}]}')
 
     stdout=$(echo "$result" | jq -r '.run.stdout // empty')
-    if [[ "$stdout" =~ ^[0-9.-]+ ]]; then
-        log_success "geospatial: got '$stdout'"
+    code=$(echo "$result" | jq -r '.run.code // empty')
+    easting=$(echo "$stdout" | head -1 | tr -d '\r')
+    if [[ "$code" == "0" ]] && [[ "$easting" =~ ^[0-9]+(\.[0-9]+)?$ ]] &&
+        awk -v e="$easting" 'BEGIN { exit !(e > 100000 && e < 900000) }'; then
+        log_success "geospatial: UTM 18N easting '$easting'"
         return 0
     else
-        log_error "geospatial: expected numeric UTM 18N easting, got '$stdout'"
+        log_error "geospatial: expected UTM 18N easting in 100000..900000 with exit 0, got code='$code' stdout='$stdout'"
         echo "$result" | jq .
         return 1
     fi


### PR DESCRIPTION
Adds a geospatial stack to the sandbox Python image so agents can do DEM/terrain and routing work — read raster tiles, reproject, run least-cost paths, and export results.

| Package | Role |
|---|---|
| `rasterio` | windowed DEM tile reads |
| `rioxarray` | CRS-aware arrays, clip, reproject |
| `geopandas` | boundaries, land status, vector attributes |
| `pyogrio` | fast vector IO (hard dependency of geopandas 1.x) |
| `pyproj` | reprojection |
| `osmnx` | OSM trail/road extracts |
| `folium` | map output for inspecting results |
| `gpxpy` | GPX export |

`numpy`, `scipy` and `scikit-image` are already installed — `scikit-image` supplies `MCP_Geometric` for least-cost paths, so no addition was needed there.

## Why bake them in

The sandbox runs under `clone_newnet: true` (`api/config/sandbox.cfg:25`), so there is no network at execution time and nothing is `pip install`-able by the user. A package is either in the image or unavailable.

## Wheel availability

Every package resolves to a `cp314` manylinux wheel on **both x86_64 and aarch64**, or is pure Python — no source builds are introduced, so the `pip install` in `install_python_packages` cannot start compiling GDAL and fail the image build.

`richdem` was considered and **excluded**: it publishes an sdist only, with no wheels for any Python version. It would compile from source against GDAL headers and set `INSTALL_FAILED=true`.

## Size

Marginal installed cost is **~263 MB**, concentrated in three packages that each vendor their own native stack:

| Package | Installed | Notes |
|---|---|---|
| `rasterio` | 110 MB | bundles `libgdal` 27.5 MB + sqlite + crypto |
| `pyogrio` | 99 MB | bundles a second, separate `libgdal` 76.8 MB |
| `pyproj` | 32 MB | bundles `libproj` + `libcurl` + datum grids |
| all others | ~22 MB | geopandas, osmnx, folium, rioxarray, gpxpy, shapely, xarray, branca, affine, cligj |

The two independent GDAL copies are unavoidable with manylinux wheels, which cannot share system libraries. `numpy`, `pandas`, `networkx`, `requests` and `jinja2` are already in the image and add nothing.

## Changes

- `build-packages.sh` and `docker/package-init.sh` — the two copies of the package list, kept in sync
- `test-sandbox.sh` — adds `test_geospatial`, which reprojects a point to EPSG:26918. This deliberately exercises pyproj's bundled PROJ data and GDAL loading under NsJail, which are the parts most likely to break in the sandbox rather than on a build host
- `api/README.md` — mentions the geospatial packages in the runtime list

## Testing

- `bash -n` clean on all three shell scripts
- The new test's JSON payload parses and its embedded Python compiles
- Wheel availability verified against the PyPI API for cp314 on x86_64 and aarch64; sizes measured by unpacking the resolved wheels
- The image build itself has **not** been run here — no Docker in this environment — so `test_geospatial` has not executed against a live sandbox. That is the one thing worth confirming in CI.