### PR TITLE
fix(upload): decode multipart filenames as UTF-8

### DIFF
--- a/service/src/service/router.ts
+++ b/service/src/service/router.ts
@@ -334,6 +334,7 @@ router.post('/upload', uploadLimiter, async (req: t.AuthenticatedRequest, res: R
     const bb = busboy({
       headers: req.headers,
       limits: { fileSize: planFileSize },
+      defParamCharset: 'utf8',
       preservePath: true,
     });
 
@@ -531,6 +532,7 @@ router.post('/upload/batch', uploadLimiter, async (req: t.AuthenticatedRequest, 
     const bb = busboy({
       headers: req.headers,
       limits: { fileSize: planFileSize, files: MAX_BATCH_FILES },
+      defParamCharset: 'utf8',
       preservePath: true,
     });
 


### PR DESCRIPTION
Fixes #35

## Problem

`POST /upload` and `POST /upload/batch` lose non-ASCII filenames. The name
reaches the sandbox `/mnt/data` as UTF-8-bytes-decoded-as-Latin-1 mojibake —
e.g. `Расчет_иска.docx` → `Ð Ð°ÑÑÐµÑ_Ð¸ÑÐºÐ°.docx`. As noted in #35 this
also affects Japanese filenames.

## Root cause

Both busboy instances in `service/src/service/router.ts` were constructed
without `defParamCharset`, so busboy 1.x fell back to its `latin1` default and
decoded the multipart `Content-Disposition` filename bytes as Latin-1. Clients
(e.g. LibreChat via `form-data`) send the filename as raw UTF-8 bytes, the
de-facto browser behavior.

The sibling handler `service/src/file-server.ts` (`POST /sessions/:id/objects`)
already sets `defParamCharset: 'utf8'` — this change brings the two upload
routes in line with it.

## Fix

Add `defParamCharset: 'utf8'` to the `/upload` and `/upload/batch` busboy
options.

## Verification

- Isolated repro (busboy@1.6.0, form-data@4.0.6): the latin1 default reproduces
  the exact mojibake; `defParamCharset: 'utf8'` yields the correct name.
- Rebuilt and deployed to a production stack — Cyrillic filenames now arrive
  intact in `/mnt/data`.
