### PR TITLE
🧃 feat: Add Opt-In RTK Shell Output Filtering

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,5 @@
 Code Interpreter
 Copyright 2026 ClickHouse, Inc.
+
+This product includes RTK v0.45.0 (https://github.com/rtk-ai/rtk),
+Copyright 2024 Patrick Szymkowiak, licensed under the Apache License 2.0.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ rewriting per request by setting `shell_output_filter` to `rtk`:
 ```json
 {
   "lang": "bash",
-  "code": "git status && git diff",
+  "code": "ls -la",
   "shell_output_filter": "rtk"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -146,6 +146,28 @@ descriptors in the launcher.
 Setting `KVM_ENABLED=false` still selects the directory-root target and the
 host package mount automatically for direct NsJail development.
 
+## Optional Bash output filtering
+
+Bash executions can opt into [RTK](https://github.com/rtk-ai/rtk) command
+rewriting per request by setting `shell_output_filter` to `rtk`:
+
+```json
+{
+  "lang": "bash",
+  "code": "git status && git diff",
+  "shell_output_filter": "rtk"
+}
+```
+
+Omitting the field (or setting it to `raw`) preserves the original execution
+path, which makes side-by-side evaluation straightforward. RTK `v0.45.0` is
+source-pinned to its immutable release commit and preinstalled in the sandbox
+image; it can also be invoked directly from Bash. Rewriting happens inside
+NsJail and fails open to the original script when RTK does not support a
+command or cannot run. Prometheus
+metrics expose Bash execution counts, outcomes, and stdout/stderr byte sizes by
+the `raw` or `rtk` filter without adding request-specific labels.
+
 Local Docker Compose files set `CODEAPI_INTERNAL_SERVICE_TOKEN` to a shared
 development value by default. Production deployments must override it with a
 strong secret; when it is unset, file object routes and Tool Call Server

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -62,8 +62,23 @@ RUN apt-install \
 RUN mkdir -p /pkgs
 
 COPY docker/package-init.sh /package-init.sh
+COPY docker/bash-run.sh /bash-run.sh
 COPY javascript-packages.txt /javascript-packages.txt
 RUN chmod +x /package-init.sh && FORCE_REBUILD=true /package-init.sh
+
+# ============================================================================
+# Stage 1c: Build the RTK binary against the sandbox's glibc baseline. The
+# upstream arm64 release requires a newer glibc than Debian bookworm provides.
+# ============================================================================
+FROM rust:1.91-bookworm AS rtk-builder
+
+ARG RTK_COMMIT=b34be37caf3796b69a50952a28e60e32b5daad43
+RUN git clone --depth 1 --branch v0.45.0 https://github.com/rtk-ai/rtk.git /rtk \
+    && cd /rtk \
+    && git checkout "$RTK_COMMIT" \
+    && test "$(git rev-parse HEAD)" = "$RTK_COMMIT" \
+    && cargo build --locked --release \
+    && ./target/release/rtk --version
 
 # ============================================================================
 # Stage 2: Build sandbox rootfs
@@ -110,6 +125,7 @@ RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
 
 COPY --from=nsjail-builder /nsjail/nsjail /usr/sbin/nsjail
 COPY --from=nsjail-builder /usr/local/bin/spec-guard /usr/local/bin/spec-guard
+COPY --from=rtk-builder /rtk/target/release/rtk /usr/local/bin/rtk
 RUN chmod +x /usr/sbin/nsjail
 
 # The tool-call socket proxy must run under Node, not Bun. Bun's node:http

--- a/api/README.md
+++ b/api/README.md
@@ -109,3 +109,7 @@ curl -s http://localhost:2000/api/v2/execute \
   -H 'Content-Type: application/json' \
   -d '{"language":"python","version":"3.14.4","files":[{"content":"print(42)"}]}' | jq
 ```
+
+For Bash, add `"shell_output_filter":"rtk"` to opt into compact RTK command
+rewrites for that request. Omit the field or use `"raw"` to preserve the
+unfiltered path. Other runtimes reject the field.

--- a/api/src/api/v2.ts
+++ b/api/src/api/v2.ts
@@ -14,7 +14,11 @@ import {
 import { EXECUTION_MANIFEST_HEADER, ExecutionManifestError, type ExecutionManifestClaims } from '../execution-manifest';
 import { verifyExecuteRequestManifest } from '../execution-manifest-request';
 import { EGRESS_GRANT_HEADER } from '../egress';
-import { activeSandboxExecutions, recordSandboxExecution } from '../metrics';
+import {
+  activeSandboxExecutions,
+  recordSandboxExecution,
+  recordSandboxOutputBytes,
+} from '../metrics';
 import { classifySandboxSafeError } from '../safe-error';
 import { withSpan } from '../telemetry';
 import { checkSandboxWorkspaceHealth } from '../workspace-isolation';
@@ -41,6 +45,10 @@ import {
   hasWorkspaceCommandToken,
   WorkspaceCommandRequestError,
 } from '../workspace-command';
+import {
+  resolveShellOutputFilter,
+  type ShellOutputFilter,
+} from '../../../shared/shell-output-filter';
 
 const router = express.Router();
 const SYNTHETIC_PRINCIPAL_SOURCE = 'synthetic_test';
@@ -142,6 +150,7 @@ export interface ExecuteRequestBody {
   output_session_id?: string;
   language: string;
   version: string;
+  shell_output_filter?: ShellOutputFilter;
   args?: string[];
   stdin?: string;
   files: TFile[];
@@ -276,6 +285,7 @@ function getJob(
   if (!rt) {
     throw { message: `${language}-${version} runtime is unknown` };
   }
+  const shellOutputFilter = resolveShellOutputFilter(body.shell_output_filter, rt.language);
 
   /* Reject a request with nothing runnable BEFORE anything is primed. This
    * gate used to count a lone `.dirkeep` as a utf8 source, so such a request
@@ -340,6 +350,7 @@ function getJob(
       compile: compile_memory_limit ?? rt.memory_limits.compile,
     },
     extra_env_vars: sanitizeEnvVars(env_vars),
+    shell_output_filter: shellOutputFilter,
     output_session_id: body.output_session_id,
     egress_grant: egressGrantToken,
     tool_call_socket_enabled: toolCallSocketEnabled,
@@ -435,6 +446,7 @@ router.post('/execute', express.json({ limit: config.execute_body_limit }), asyn
   let cleanedUp = false;
   let activeExecution = false;
   let metricsLanguage = 'unknown';
+  let metricsOutputFilter: ShellOutputFilter = 'raw';
   let metricsOutcome: Parameters<typeof recordSandboxExecution>[0]['outcome'] = 'execution_error';
   let primeCompleted = false;
 
@@ -503,6 +515,7 @@ router.post('/execute', express.json({ limit: config.execute_body_limit }), asyn
         req.headers[RUNTIME_SESSION_ID_HEADER],
       );
       metricsLanguage = job.runtime.language;
+      metricsOutputFilter = job.shellOutputFilter;
       markActiveExecution();
     } catch (error) {
       metricsOutcome = 'bad_request';
@@ -546,6 +559,13 @@ router.post('/execute', express.json({ limit: config.execute_body_limit }), asyn
       if (result.run === undefined) {
         result.run = result.compile;
       }
+
+      recordSandboxOutputBytes({
+        language: job.runtime.language,
+        outputFilter: job.shellOutputFilter,
+        stdout: result.run?.stdout ?? '',
+        stderr: result.run?.stderr ?? '',
+      });
 
       if (result.files && result.files.length > 0) {
         /* Upload returns the set of file IDs that were actually transferred to
@@ -627,6 +647,7 @@ router.post('/execute', express.json({ limit: config.execute_body_limit }), asyn
     }
     recordSandboxExecution({
       language: metricsLanguage,
+      outputFilter: metricsOutputFilter,
       outcome: metricsOutcome,
       durationSeconds: (performance.now() - started) / 1000,
     });

--- a/api/src/bash-run.test.ts
+++ b/api/src/bash-run.test.ts
@@ -55,6 +55,26 @@ exit "\${MOCK_RTK_STATUS:-0}"
     expect(run({ filter: 'rtk', args: ['argument'] })).toBe('filtered:argument\n');
   });
 
+  it('preserves the submitted path as $0 and BASH_ARGV0 for rewrites', () => {
+    fs.writeFileSync(path.join(mockBin, 'rtk'), `#!/bin/bash
+printf '%s\\n' 'printf "identity:%s:%s:%s\\n" "$0" "$BASH_ARGV0" "$1"'
+`);
+    fs.chmodSync(path.join(mockBin, 'rtk'), 0o755);
+
+    expect(run({ filter: 'rtk', args: ['argument'] })).toBe(
+      `identity:${sourcePath}:${sourcePath}:argument\n`,
+    );
+  });
+
+  it('preserves file execution for scripts that inspect BASH_SOURCE', () => {
+    fs.writeFileSync(
+      sourcePath,
+      'printf \'identity:%s:%s\\n\' "${BASH_SOURCE[0]}" "$0"\n',
+    );
+
+    expect(run({ filter: 'rtk' })).toBe(`identity:${sourcePath}:${sourcePath}\n`);
+  });
+
   it('accepts RTK ask rewrites because the API request already authorizes execution', () => {
     expect(run({ filter: 'rtk', status: 3 })).toBe('filtered:\n');
   });

--- a/api/src/bash-run.test.ts
+++ b/api/src/bash-run.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const wrapper = path.resolve(__dirname, '../../docker/bash-run.sh');
+
+describe('Bash RTK run wrapper', () => {
+  let tempDir: string;
+  let sourcePath: string;
+  let mockBin: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codeapi-rtk-test-'));
+    sourcePath = path.join(tempDir, 'script.sh');
+    mockBin = path.join(tempDir, 'bin');
+    fs.mkdirSync(mockBin);
+    fs.writeFileSync(sourcePath, "printf 'raw:%s\\n' \"${1:-none}\"\n");
+    fs.writeFileSync(path.join(mockBin, 'rtk'), `#!/bin/bash
+case "\${MOCK_RTK_STATUS:-0}" in
+  0|3) printf '%s\\n' 'printf '\"'\"'filtered:%s\\n'\"'\"' "$1"' ;;
+  *) printf '%s\\n' 'printf '\"'\"'must-not-run\\n'\"'\"'' ;;
+esac
+exit "\${MOCK_RTK_STATUS:-0}"
+`);
+    fs.chmodSync(path.join(mockBin, 'rtk'), 0o755);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function run(options: {
+    filter?: 'raw' | 'rtk';
+    status?: number;
+    args?: string[];
+  } = {}): string {
+    return execFileSync('bash', [wrapper, sourcePath, ...(options.args ?? [])], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${mockBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+        CODEAPI_SHELL_OUTPUT_FILTER: options.filter ?? 'raw',
+        MOCK_RTK_STATUS: String(options.status ?? 0),
+      },
+    });
+  }
+
+  it('preserves raw execution when the request does not opt in', () => {
+    expect(run()).toBe('raw:none\n');
+  });
+
+  it('executes RTK rewrites and preserves user script arguments', () => {
+    expect(run({ filter: 'rtk', args: ['argument'] })).toBe('filtered:argument\n');
+  });
+
+  it('accepts RTK ask rewrites because the API request already authorizes execution', () => {
+    expect(run({ filter: 'rtk', status: 3 })).toBe('filtered:\n');
+  });
+
+  it('fails open to the original script when RTK cannot rewrite the command', () => {
+    expect(run({ filter: 'rtk', status: 1, args: ['original'] })).toBe('raw:original\n');
+    expect(run({ filter: 'rtk', status: 2, args: ['original'] })).toBe('raw:original\n');
+  });
+});

--- a/api/src/bash-run.test.ts
+++ b/api/src/bash-run.test.ts
@@ -75,6 +75,15 @@ printf '%s\\n' 'printf "identity:%s:%s:%s\\n" "$0" "$BASH_ARGV0" "$1"'
     expect(run({ filter: 'rtk' })).toBe(`identity:${sourcePath}:${sourcePath}\n`);
   });
 
+  it('rewrites scripts that only mention BASH_SOURCE literally', () => {
+    fs.writeFileSync(
+      sourcePath,
+      "# BASH_SOURCE is only documented here\nprintf 'BASH_SOURCE is just text\\n'\n",
+    );
+
+    expect(run({ filter: 'rtk' })).toBe('filtered:\n');
+  });
+
   it('accepts RTK ask rewrites because the API request already authorizes execution', () => {
     expect(run({ filter: 'rtk', status: 3 })).toBe('filtered:\n');
   });

--- a/api/src/bash-run.test.ts
+++ b/api/src/bash-run.test.ts
@@ -75,6 +75,15 @@ printf '%s\\n' 'printf "identity:%s:%s:%s\\n" "$0" "$BASH_ARGV0" "$1"'
     expect(run({ filter: 'rtk' })).toBe(`identity:${sourcePath}:${sourcePath}\n`);
   });
 
+  it('preserves file execution for BASH_SOURCE transformations', () => {
+    fs.writeFileSync(
+      sourcePath,
+      ': "${BASH_SOURCE@Q}" "${BASH_SOURCE^^}" "${BASH_SOURCE,,}"\nprintf \'raw\\n\'\n',
+    );
+
+    expect(run({ filter: 'rtk' })).toBe('raw\n');
+  });
+
   it('rewrites scripts that only mention BASH_SOURCE literally', () => {
     fs.writeFileSync(
       sourcePath,

--- a/api/src/job-helpers.test.ts
+++ b/api/src/job-helpers.test.ts
@@ -12,6 +12,7 @@ import {
   inputsLiveUnder,
   mapWithConcurrency,
   mimeTypeFor,
+  filterExtraEnvVars,
 } from './job';
 import type { Runtime } from './runtime';
 import type { TFile } from './job';
@@ -40,6 +41,17 @@ function makeRuntime(overrides: Partial<Runtime> & { language: string; pkgdir: s
     ...overrides,
   };
 }
+
+describe('filterExtraEnvVars', () => {
+  it('prevents callers from overriding internal RTK controls', () => {
+    expect(filterExtraEnvVars({
+      CODEAPI_SHELL_OUTPUT_FILTER: 'rtk',
+      RTK_DB_PATH: '/mnt/data/history.db',
+      RTK_TEE: '1',
+      USER_VALUE: 'allowed',
+    })).toEqual({ USER_VALUE: 'allowed' });
+  });
+});
 
 describe('resolveOriginalName', () => {
   function responseWithHeader(value?: string): Response {

--- a/api/src/job.ts
+++ b/api/src/job.ts
@@ -42,6 +42,7 @@ import {
   isValidFilePath,
 } from './validation';
 import { cachedInputResponse, inputCacheKey, openCachedInput } from './session-inputs';
+import type { ShellOutputFilter } from '../../shared/shell-output-filter';
 
 export {
   DIRKEEP,
@@ -506,6 +507,9 @@ export const RESERVED_ENV_KEYS: ReadonlySet<string> = new Set([
   'HOME',
   'PATH',
   'TOOL_CALL_SOCKET',
+  'CODEAPI_SHELL_OUTPUT_FILTER',
+  'RTK_DB_PATH',
+  'RTK_TEE',
   'PYTHONPATH',
   'PYTHONSTARTUP',
   'PYTHONHOME',
@@ -705,6 +709,7 @@ export class Job {
   cpu_times: { run: number; compile: number };
   memory_limits: { run: number; compile: number };
   extra_env_vars?: Record<string, string>;
+  shellOutputFilter: ShellOutputFilter;
   egressGrantToken?: string;
   toolCallSocketEnabled: boolean;
   isSynthetic: boolean;
@@ -744,6 +749,7 @@ export class Job {
     cpu_times: { run: number; compile: number };
     memory_limits: { run: number; compile: number };
     extra_env_vars?: Record<string, string>;
+    shell_output_filter?: ShellOutputFilter;
     output_session_id?: string;
     egress_grant?: string;
     tool_call_socket_enabled?: boolean;
@@ -782,6 +788,7 @@ export class Job {
     this.cpu_times = opts.cpu_times;
     this.memory_limits = opts.memory_limits;
     this.extra_env_vars = opts.extra_env_vars;
+    this.shellOutputFilter = opts.shell_output_filter ?? 'raw';
     this.egressGrantToken = opts.egress_grant;
     this.toolCallSocketEnabled = opts.tool_call_socket_enabled === true;
     this.isSynthetic = opts.is_synthetic === true;
@@ -1546,6 +1553,18 @@ export class Job {
       SANDBOX_LANGUAGE: this.runtime.language,
       HOME: '/mnt/data',
     };
+
+    if (
+      script === 'run'
+      && this.runtime.language === 'bash'
+      && this.shellOutputFilter === 'rtk'
+    ) {
+      envVars.CODEAPI_SHELL_OUTPUT_FILTER = 'rtk';
+      /* Keep RTK bookkeeping ephemeral so a stateless run cannot create
+       * recoverable artifacts or pollute generated-file discovery. */
+      envVars.RTK_DB_PATH = '/tmp/rtk-history.db';
+      envVars.RTK_TEE = '0';
+    }
 
     let extraPkgdirs: string[] | undefined;
     if (this.runtime.language === 'bash') {

--- a/api/src/metrics.ts
+++ b/api/src/metrics.ts
@@ -1,5 +1,6 @@
 import client, { Counter, Gauge, Histogram, register } from 'prom-client';
 import type { NextFunction, Request, Response } from 'express';
+import type { ShellOutputFilter } from '../../shared/shell-output-filter';
 
 client.collectDefaultMetrics({ register });
 
@@ -27,6 +28,19 @@ export const sandboxExecutionDuration = new Histogram({
   help: 'Sandbox execution request duration in seconds',
   labelNames: ['language', 'outcome'] as const,
   buckets: [0.1, 0.5, 1, 2.5, 5, 10, 15, 30, 60, 120, 300],
+});
+
+export const sandboxShellOutputFilterExecutions = new Counter({
+  name: 'codeapi_sandbox_shell_output_filter_executions_total',
+  help: 'Total Bash sandbox executions by request-scoped output filter and outcome',
+  labelNames: ['shell_output_filter', 'outcome'] as const,
+});
+
+export const sandboxShellOutputBytes = new Histogram({
+  name: 'codeapi_sandbox_shell_output_bytes',
+  help: 'Bash sandbox output size by request-scoped output filter and stream',
+  labelNames: ['shell_output_filter', 'stream'] as const,
+  buckets: [0, 64, 256, 1024, 4096, 16_384, 65_536, 262_144, 1_048_576],
 });
 
 export const activeSandboxExecutions = new Gauge({
@@ -82,12 +96,36 @@ export function httpMetricsMiddleware(req: Request, res: Response, next: NextFun
 
 export function recordSandboxExecution(params: {
   language: string;
+  outputFilter?: ShellOutputFilter;
   outcome: 'success' | 'manifest_error' | 'bad_request' | 'validation_error' | 'execution_error';
   durationSeconds: number;
 }): void {
   const labels = { language: params.language || 'unknown', outcome: params.outcome };
   sandboxExecutions.inc(labels);
   sandboxExecutionDuration.observe(labels, params.durationSeconds);
+  if (params.language === 'bash') {
+    sandboxShellOutputFilterExecutions.inc({
+      shell_output_filter: params.outputFilter ?? 'raw',
+      outcome: params.outcome,
+    });
+  }
+}
+
+export function recordSandboxOutputBytes(params: {
+  language: string;
+  outputFilter: ShellOutputFilter;
+  stdout: string;
+  stderr: string;
+}): void {
+  if (params.language !== 'bash') return;
+  sandboxShellOutputBytes.observe(
+    { shell_output_filter: params.outputFilter, stream: 'stdout' },
+    Buffer.byteLength(params.stdout),
+  );
+  sandboxShellOutputBytes.observe(
+    { shell_output_filter: params.outputFilter, stream: 'stderr' },
+    Buffer.byteLength(params.stderr),
+  );
 }
 
 export async function metricsHandler(_req: Request, res: Response): Promise<void> {

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -470,11 +470,8 @@ install_bash() {
 }
 PKGEOF"
 
-    docker exec "$CONTAINER_NAME" bash -c "cat > ${pkg_dest}/run << 'RUNEOF'
-#!/bin/bash
-bash \"\$@\"
-RUNEOF
-chmod +x ${pkg_dest}/run"
+    docker cp "${SCRIPT_DIR}/docker/bash-run.sh" "${CONTAINER_NAME}:${pkg_dest}/run"
+    docker exec "$CONTAINER_NAME" chmod 0755 "${pkg_dest}/run"
 
     # Surface node + bun toolchains and their global trees on PATH so bash
     # tool invocations (which is how LLMs typically reach for `npm list -g`,

--- a/docker/Dockerfile.package-init
+++ b/docker/Dockerfile.package-init
@@ -24,6 +24,7 @@ RUN apt-install \
 RUN mkdir -p /pkgs
 
 COPY docker/package-init.sh /package-init.sh
+COPY docker/bash-run.sh /bash-run.sh
 COPY javascript-packages.txt /javascript-packages.txt
 RUN chmod +x /package-init.sh
 

--- a/docker/Dockerfile.worker-sandbox
+++ b/docker/Dockerfile.worker-sandbox
@@ -74,6 +74,7 @@ RUN apt-install \
 RUN mkdir -p /pkgs
 
 COPY docker/package-init.sh /package-init.sh
+COPY docker/bash-run.sh /bash-run.sh
 COPY javascript-packages.txt /javascript-packages.txt
 RUN chmod +x /package-init.sh && FORCE_REBUILD=true /package-init.sh
 
@@ -101,6 +102,20 @@ COPY api/src ./src
 COPY shared /shared
 COPY api/tsconfig.json ./
 RUN bun build ./src/index.ts --minify --outdir .build --target bun --external '@opentelemetry/*'
+
+# ============================================================================
+# Stage 3b: Build the RTK binary against the sandbox's glibc baseline. The
+# upstream arm64 release requires a newer glibc than Debian bookworm provides.
+# ============================================================================
+FROM rust:1.91-bookworm AS rtk-builder
+
+ARG RTK_COMMIT=b34be37caf3796b69a50952a28e60e32b5daad43
+RUN git clone --depth 1 --branch v0.45.0 https://github.com/rtk-ai/rtk.git /rtk \
+    && cd /rtk \
+    && git checkout "$RTK_COMMIT" \
+    && test "$(git rev-parse HEAD)" = "$RTK_COMMIT" \
+    && cargo build --locked --release \
+    && ./target/release/rtk --version
 
 # ============================================================================
 # Stage 4: Build sandbox rootfs (full OS layer for the microVM guest)
@@ -143,6 +158,7 @@ RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
 
 COPY --from=nsjail-builder /nsjail/nsjail /usr/sbin/nsjail
 COPY --from=nsjail-builder /usr/local/bin/spec-guard /usr/local/bin/spec-guard
+COPY --from=rtk-builder /rtk/target/release/rtk /usr/local/bin/rtk
 RUN chmod +x /usr/sbin/nsjail
 
 WORKDIR /sandbox_api

--- a/docker/bash-run.sh
+++ b/docker/bash-run.sh
@@ -4,19 +4,16 @@
 # never reaches a privileged service or worker process. Unsupported rewrites,
 # denied commands, and tool failures preserve the existing raw execution path.
 if [ "${CODEAPI_SHELL_OUTPUT_FILTER:-raw}" = "rtk" ] && [ "$#" -gt 0 ]; then
-    rewritten="$(rtk rewrite "$(cat -- "$1")" 2>/dev/null)"
-    rewrite_status=$?
+    # `bash -c` preserves the submitted path as $0/BASH_ARGV0, but Bash does
+    # not populate BASH_SOURCE for command strings. Keep the original file
+    # execution path for scripts that inspect BASH_SOURCE so filtering cannot
+    # change source-relative imports or helper lookups.
+    if ! grep -q 'BASH_SOURCE' -- "$1" 2>/dev/null; then
+        rewritten="$(rtk rewrite "$(cat -- "$1")" 2>/dev/null)"
+        rewrite_status=$?
 
-    if { [ "$rewrite_status" -eq 0 ] || [ "$rewrite_status" -eq 3 ]; } && [ -n "$rewritten" ]; then
-        rewritten_script="$(mktemp /tmp/codeapi-rtk.XXXXXX.sh 2>/dev/null)"
-        if [ -n "$rewritten_script" ]; then
-            cleanup_rewritten_script() {
-                rm -f -- "$rewritten_script"
-            }
-            trap cleanup_rewritten_script EXIT
-            printf '%s\n' "$rewritten" > "$rewritten_script"
-            bash "$rewritten_script" "${@:2}"
-            exit $?
+        if { [ "$rewrite_status" -eq 0 ] || [ "$rewrite_status" -eq 3 ]; } && [ -n "$rewritten" ]; then
+            exec bash -c "$rewritten" "$1" "${@:2}"
         fi
     fi
 fi

--- a/docker/bash-run.sh
+++ b/docker/bash-run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# RTK is deliberately invoked here, inside NsJail, so user-controlled source
+# never reaches a privileged service or worker process. Unsupported rewrites,
+# denied commands, and tool failures preserve the existing raw execution path.
+if [ "${CODEAPI_SHELL_OUTPUT_FILTER:-raw}" = "rtk" ] && [ "$#" -gt 0 ]; then
+    rewritten="$(rtk rewrite "$(cat -- "$1")" 2>/dev/null)"
+    rewrite_status=$?
+
+    if { [ "$rewrite_status" -eq 0 ] || [ "$rewrite_status" -eq 3 ]; } && [ -n "$rewritten" ]; then
+        rewritten_script="$(mktemp /tmp/codeapi-rtk.XXXXXX.sh 2>/dev/null)"
+        if [ -n "$rewritten_script" ]; then
+            cleanup_rewritten_script() {
+                rm -f -- "$rewritten_script"
+            }
+            trap cleanup_rewritten_script EXIT
+            printf '%s\n' "$rewritten" > "$rewritten_script"
+            bash "$rewritten_script" "${@:2}"
+            exit $?
+        fi
+    fi
+fi
+
+exec bash "$@"

--- a/docker/bash-run.sh
+++ b/docker/bash-run.sh
@@ -11,7 +11,7 @@ if [ "${CODEAPI_SHELL_OUTPUT_FILTER:-raw}" = "rtk" ] && [ "$#" -gt 0 ]; then
     # Match parameter or array expansion rather than a literal mention in a
     # comment or string. The wrapper only needs to preserve file execution
     # when the script actually depends on Bash's source-file metadata.
-    if ! grep -qE '\$\{BASH_SOURCE([[:space:]]|}|\[|[:?+#%/-])|\$BASH_SOURCE([^[:alnum:]_]|$)|(^|[^[:alnum:]_])BASH_SOURCE\[' -- "$1" 2>/dev/null; then
+    if ! grep -qE '\$\{BASH_SOURCE([^[:alnum:]_]|$)|\$BASH_SOURCE([^[:alnum:]_]|$)|(^|[^[:alnum:]_])BASH_SOURCE\[' -- "$1" 2>/dev/null; then
         rewritten="$(rtk rewrite "$(cat -- "$1")" 2>/dev/null)"
         rewrite_status=$?
 

--- a/docker/bash-run.sh
+++ b/docker/bash-run.sh
@@ -8,7 +8,10 @@ if [ "${CODEAPI_SHELL_OUTPUT_FILTER:-raw}" = "rtk" ] && [ "$#" -gt 0 ]; then
     # not populate BASH_SOURCE for command strings. Keep the original file
     # execution path for scripts that inspect BASH_SOURCE so filtering cannot
     # change source-relative imports or helper lookups.
-    if ! grep -q 'BASH_SOURCE' -- "$1" 2>/dev/null; then
+    # Match parameter or array expansion rather than a literal mention in a
+    # comment or string. The wrapper only needs to preserve file execution
+    # when the script actually depends on Bash's source-file metadata.
+    if ! grep -qE '\$\{BASH_SOURCE([[:space:]]|}|\[|[:?+#%/-])|\$BASH_SOURCE([^[:alnum:]_]|$)|(^|[^[:alnum:]_])BASH_SOURCE\[' -- "$1" 2>/dev/null; then
         rewritten="$(rtk rewrite "$(cat -- "$1")" 2>/dev/null)"
         rewrite_status=$?
 

--- a/docker/package-init.sh
+++ b/docker/package-init.sh
@@ -23,8 +23,10 @@ UV_VERSION="${UV_VERSION:-0.11.26}"
 NODE_VERSION="${NODE_VERSION:-24.15.0}"
 BUN_VERSION="${BUN_VERSION:-1.3.14}"
 BASH_PACKAGE_VERSION="${BASH_PACKAGE_VERSION:-5.2.0}"
+BASH_DEST="/pkgs/bash/${BASH_PACKAGE_VERSION}"
 INSTALL_FAILED=false
 JS_PACKAGE_MANIFEST="${JS_PACKAGE_MANIFEST:-${SCRIPT_DIR}/javascript-packages.txt}"
+BASH_RUN_SCRIPT="${BASH_RUN_SCRIPT:-${SCRIPT_DIR}/bash-run.sh}"
 
 load_js_packages() {
     if [ ! -f "$JS_PACKAGE_MANIFEST" ]; then
@@ -100,8 +102,23 @@ packages_ready() {
     [ -f "/pkgs/bash/${BASH_PACKAGE_VERSION}/.package-installed" ]
 }
 
+sync_bash_run_wrapper() {
+    if [ ! -f "$BASH_RUN_SCRIPT" ]; then
+        echo "ERROR: Missing Bash run wrapper: $BASH_RUN_SCRIPT" >&2
+        return 1
+    fi
+    if ! cmp -s "$BASH_RUN_SCRIPT" "$BASH_DEST/run"; then
+        echo "Updating Bash run wrapper"
+        if ! install -m 0755 "$BASH_RUN_SCRIPT" "$BASH_DEST/run"; then
+            return 1
+        fi
+    fi
+    return 0
+}
+
 if [ -f "$MARKER_FILE" ] && [ "$FORCE_REBUILD" != "true" ]; then
     if packages_ready; then
+        sync_bash_run_wrapper
         echo "Packages already initialized (marker file exists)"
         echo "Set FORCE_REBUILD=true to force reinstall"
         echo ""
@@ -498,7 +515,6 @@ echo "=============================================="
 echo ""
 
 SYSTEM_BASH_VERSION=$(bash --version | sed -nE '1s/.* ([0-9]+[.][0-9]+[.][0-9]+).*/\1/p')
-BASH_DEST="/pkgs/bash/${BASH_PACKAGE_VERSION}"
 mkdir -p "$BASH_DEST"
 
 cat > "$BASH_DEST/pkg-info.json" << EOF
@@ -511,11 +527,9 @@ cat > "$BASH_DEST/pkg-info.json" << EOF
 }
 EOF
 
-cat > "$BASH_DEST/run" << 'EOF'
-#!/bin/bash
-bash "$@"
-EOF
-chmod +x "$BASH_DEST/run"
+if ! sync_bash_run_wrapper; then
+    INSTALL_FAILED=true
+fi
 
 echo "PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:." > "$BASH_DEST/.env"
 echo "$(date +%s)000" > "$BASH_DEST/.package-installed"

--- a/launcher/Dockerfile
+++ b/launcher/Dockerfile
@@ -38,6 +38,17 @@ RUN gcc -O2 -static -o /usr/local/bin/spec-guard /tmp/spec-guard.c \
     && gcc -O2 -static -o /usr/local/bin/sandbox-rootfs-setup /tmp/rootfs-setup.c \
     && chmod 0111 /usr/local/bin/spec-guard /usr/local/bin/sandbox-rootfs-setup
 
+# Build RTK against the same Debian bookworm glibc baseline as the sandbox.
+FROM rust:1.91-bookworm AS rtk-builder
+
+ARG RTK_COMMIT=b34be37caf3796b69a50952a28e60e32b5daad43
+RUN git clone --depth 1 --branch v0.45.0 https://github.com/rtk-ai/rtk.git /rtk \
+    && cd /rtk \
+    && git checkout "$RTK_COMMIT" \
+    && test "$(git rev-parse HEAD)" = "$RTK_COMMIT" \
+    && cargo build --locked --release \
+    && ./target/release/rtk --version
+
 FROM oven/bun:1.3.14-debian AS sandbox-build
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -64,6 +75,7 @@ RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
 
 COPY --from=nsjail-builder /nsjail/nsjail /usr/sbin/nsjail
 COPY --from=nsjail-builder /usr/local/bin/spec-guard /usr/local/bin/spec-guard
+COPY --from=rtk-builder /rtk/target/release/rtk /usr/local/bin/rtk
 RUN chmod +x /usr/sbin/nsjail
 
 WORKDIR /sandbox_api

--- a/service/openapi.yml
+++ b/service/openapi.yml
@@ -146,6 +146,12 @@ components:
           type: array
           items:
             type: string
+        shell_output_filter:
+          type: string
+          enum: [raw, rtk]
+          description: >-
+            Optional Bash-only output filter. Omit or use raw for unchanged
+            execution; use rtk to rewrite supported commands for compact output.
         user_id:
           type: string
         entity_id:

--- a/service/rollup.config.js
+++ b/service/rollup.config.js
@@ -43,6 +43,7 @@ export default {
         '../shared/telemetry-core.ts',
         '../packages/code/src/protocol.ts',
         '../packages/code/src/identity.ts',
+        '../shared/shell-output-filter.ts',
       ],
       sourceMap: true,
       declaration: false,

--- a/service/src/config.spec.ts
+++ b/service/src/config.spec.ts
@@ -11,6 +11,10 @@ import {
 import { Languages } from './enum';
 import { createPayload } from './payload';
 import type { AuthenticatedRequest } from './types';
+import {
+  resolveShellOutputFilter,
+  ShellOutputFilterError,
+} from '../../shared/shell-output-filter';
 
 describe('node language configuration', () => {
   it('resolves Node.js aliases', () => {
@@ -55,6 +59,35 @@ describe('node language configuration', () => {
         },
       ],
     });
+  });
+});
+
+describe('request-scoped shell output filtering', () => {
+  it('propagates an opted-in RTK filter to the Bash sandbox payload', () => {
+    const req = {
+      body: {
+        lang: 'bash',
+        code: 'git status',
+        shell_output_filter: 'rtk',
+      },
+    } as unknown as AuthenticatedRequest;
+
+    expect(createPayload({ req, session_id: 'session-bash' })).toMatchObject({
+      language: 'bash',
+      version: '5.2.0',
+      shell_output_filter: 'rtk',
+    });
+  });
+
+  it('keeps omitted filters raw by leaving the wire field absent', () => {
+    expect(resolveShellOutputFilter(undefined, 'bash')).toBeUndefined();
+  });
+
+  it('rejects unknown filters and non-Bash runtimes', () => {
+    expect(() => resolveShellOutputFilter('compact', 'bash')).toThrow(ShellOutputFilterError);
+    expect(() => resolveShellOutputFilter('rtk', 'python')).toThrow(
+      'shell_output_filter is only supported for Bash executions',
+    );
   });
 });
 

--- a/service/src/payload.ts
+++ b/service/src/payload.ts
@@ -10,7 +10,13 @@ export function createPayload({
   isPyPlot,
   session_id,
 }: t.CreatePayload): t.PayloadBody {
-  const { lang: rawLang, code: userCode, args, files } = req.body as t.RequestBody;
+  const {
+    lang: rawLang,
+    code: userCode,
+    args,
+    files,
+    shell_output_filter,
+  } = req.body as t.RequestBody;
   const language = resolveLanguage(rawLang);
   if (language === undefined) {
     throw new Error(`Unsupported language: ${rawLang}`);
@@ -50,6 +56,10 @@ export function createPayload({
 
   if (args) {
     payload.args = args;
+  }
+
+  if (shell_output_filter) {
+    payload.shell_output_filter = shell_output_filter;
   }
 
   if (files && files.length > 0) {

--- a/service/src/service/router.ts
+++ b/service/src/service/router.ts
@@ -33,6 +33,10 @@ import {
 } from '../bridge/selection';
 import logger from '../logger';
 import { resolveQueuedSandboxBackend } from '../execution-profile';
+import {
+  resolveShellOutputFilter,
+  ShellOutputFilterError,
+} from '../../../shared/shell-output-filter';
 
 const { INSTANCE_ID } = env;
 const JOB_COMPLETION_WAIT_TIMEOUT_MS = jobCompletionWaitTimeoutMs(
@@ -145,6 +149,14 @@ router.post('/exec', executionLimiter, async (req: t.AuthenticatedRequest, res) 
   const language = resolveLanguage(rawLang);
   if (language == null) {
     return res.status(400).json({ error: `Unsupported language: ${rawLang}` });
+  }
+  try {
+    body.shell_output_filter = resolveShellOutputFilter(body.shell_output_filter, language);
+  } catch (error) {
+    if (error instanceof ShellOutputFilterError) {
+      return res.status(400).json({ error: error.message });
+    }
+    throw error;
   }
 
   let bridgeWorkerId: string | undefined;

--- a/service/src/types/service.ts
+++ b/service/src/types/service.ts
@@ -5,6 +5,7 @@ import type { ExecutionIdentity } from '../execution-identity';
 import type { CodeApiPrincipal } from '../auth/principal';
 import type { ExecutionProfile, SandboxBackendName } from '../execution-profile';
 import { Jobs } from '@/enum/service';
+import type { ShellOutputFilter } from '../../../shared/shell-output-filter';
 
 /**
  * Per-file vs. top-level session distinction
@@ -127,6 +128,8 @@ export interface RequestBody {
   code: string;
   lang: string;
   args?: string[];
+  /** Optional per-request Bash output filtering. Omitted requests stay raw. */
+  shell_output_filter?: ShellOutputFilter;
   user_id?: string;
   files?: RequestFile[];
   /**
@@ -173,6 +176,8 @@ export type PayloadFileRef = {
 export interface PayloadBody {
   language: string;
   version: string;
+  /** Intra-monorepo request-scoped Bash output filter. */
+  shell_output_filter?: ShellOutputFilter;
   run_memory_limit?: number;
   run_timeout?: number;
   run_cpu_time?: number;

--- a/service/tsconfig.esm.json
+++ b/service/tsconfig.esm.json
@@ -18,7 +18,7 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src/**/*.ts", "../shared/telemetry-core.ts"],
+  "include": ["src/**/*.ts", "../shared/telemetry-core.ts", "../shared/shell-output-filter.ts"],
   "exclude": [
     "node_modules",
     "**/*.spec.ts",

--- a/service/tsconfig.json
+++ b/service/tsconfig.json
@@ -17,7 +17,8 @@
     "src/**/*.ts",
     "../shared/telemetry-core.ts",
     "../packages/code/src/protocol.ts",
-    "../packages/code/src/identity.ts"
+    "../packages/code/src/identity.ts",
+    "../shared/shell-output-filter.ts"
   ],
   "exclude": [
     "node_modules",

--- a/shared/shell-output-filter.ts
+++ b/shared/shell-output-filter.ts
@@ -1,0 +1,32 @@
+export const SHELL_OUTPUT_FILTERS = ['raw', 'rtk'] as const;
+
+export type ShellOutputFilter = typeof SHELL_OUTPUT_FILTERS[number];
+
+export class ShellOutputFilterError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ShellOutputFilterError';
+  }
+}
+
+/**
+ * Validates the request-scoped shell output filter at each trust boundary.
+ * RTK rewrites shell commands, so exposing it for non-Bash runtimes would be
+ * misleading and would make future runtime behavior ambiguous.
+ */
+export function resolveShellOutputFilter(
+  value: unknown,
+  language: string,
+): ShellOutputFilter | undefined {
+  if (value === undefined) return undefined;
+  if (
+    typeof value !== 'string'
+    || !SHELL_OUTPUT_FILTERS.includes(value as ShellOutputFilter)
+  ) {
+    throw new ShellOutputFilterError('shell_output_filter must be one of: raw, rtk');
+  }
+  if (language !== 'bash') {
+    throw new ShellOutputFilterError('shell_output_filter is only supported for Bash executions');
+  }
+  return value as ShellOutputFilter;
+}


### PR DESCRIPTION
## Summary

I added request-scoped RTK output filtering for Bash executions while preserving raw execution as the default and keeping all command rewriting inside the sandbox boundary.

- Add `shell_output_filter: "raw" | "rtk"` to the public and internal execution contracts with Bash-only validation at both trust boundaries.
- Build RTK v0.45.0 from its immutable release commit with Rust 1.91 so amd64 and arm64 binaries match the Debian bookworm sandbox glibc baseline.
- Execute RTK rewrites from the Bash runtime wrapper inside NsJail, preserve script arguments, and fail open to the original script when rewriting is unsupported or unavailable.
- Keep RTK history and tee artifacts ephemeral for opted-in runs and reserve the internal environment controls against caller override.
- Record low-cardinality Prometheus execution outcomes and stdout/stderr byte sizes for raw-versus-RTK comparisons.
- Document the opt-in request field, direct binary availability, image behavior, metrics, and Apache-2.0 attribution.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- Ran `cd api && bun run build`.
- Ran `cd service && bun run build`; the existing Rollup export/circular-dependency warnings remain unchanged.
- Ran `cd api && bun test src/bash-run.test.ts src/job-helpers.test.ts` (69 passed).
- Ran `cd service && bun test src/config.spec.ts` (17 passed).
- Ran `bash -n docker/bash-run.sh docker/package-init.sh`.
- Built the `rtk-builder` target from both Dockerfiles on linux/arm64 and verified `rtk 0.45.0`.
- Verified the real binary rewrites `git status && git diff` to `rtk git status && rtk git diff`, honors the ephemeral RTK environment, and creates no files under sandbox HOME.
- Attempted the complete API and service suites; this managed environment blocks their existing ephemeral socket listeners and external Redis/k6 dependencies, and inherited `AWS_CA_BUNDLE` trips existing hardened-startup fixtures. No focused RTK test failed.

### **Test Configuration**:

- macOS arm64 host
- Docker Desktop linux/arm64 builder
- Bun 1.3.13
- RTK 0.45.0
- Rust 1.91 bookworm builder

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
