### PR TITLE
fix(runner): reject NUL bytes in file paths

### DIFF
--- a/api/src/validation.test.ts
+++ b/api/src/validation.test.ts
@@ -126,6 +126,10 @@ describe('validateFilePath', () => {
     expect(() => validateFilePath('.', submissionDir)).toThrow(ValidationError);
   });
 
+  it('rejects NUL bytes in file names', () => {
+    expect(() => validateFilePath('file\0.txt', submissionDir)).toThrow(/NUL/);
+  });
+
   it('rejects path traversal with .. segments', () => {
     expect(() => validateFilePath('../etc/passwd', submissionDir)).toThrow(ValidationError);
     expect(() => validateFilePath('a/../../escape', submissionDir)).toThrow(ValidationError);
@@ -187,5 +191,9 @@ describe('isValidFilePath', () => {
   it('returns false for empty or shape-violating paths', () => {
     expect(isValidFilePath('', submissionDir)).toBe(false);
     expect(isValidFilePath('a'.repeat(MAX_LEN + 10), submissionDir)).toBe(false);
+  });
+
+  it('returns false for paths containing NUL bytes', () => {
+    expect(isValidFilePath('file\0.txt', submissionDir)).toBe(false);
   });
 });

--- a/api/src/validation.ts
+++ b/api/src/validation.ts
@@ -48,6 +48,9 @@ export function validateFilePath(name: string, submissionDir: string): void {
   if (!name || name === '.') {
     throw new ValidationError('File path must not be empty');
   }
+  if (name.includes('\0')) {
+    throw new ValidationError('File path must not contain NUL bytes');
+  }
   /* Reject absolute paths up front. `path.resolve(submissionDir, name)`
    * ignores `submissionDir` when `name` is absolute, so an absolute path
    * that happens to point inside `submissionDir` (e.g. the exact on-disk


### PR DESCRIPTION
## Summary

Reject file names containing NUL bytes in `validateFilePath()`.

## Why

A request can currently include a name such as `result\0.csv`. It passes the existing relative path, canonical path, and shape checks, but Node rejects it later when the runner calls the filesystem. That turns invalid user input into a late filesystem error. Returning `ValidationError` at the validation boundary keeps the failure predictable and avoids sending malformed paths deeper into the runner.

This is a validation and error-handling fix. It does not change normal file names or the existing path traversal rules.

## Tests

- `bun test api/src/validation.test.ts`
