### PR TITLE
fix(runner): fail safe on invalid output size config

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -53,7 +53,7 @@ export const config = {
   disable_networking: (process.env.SANDBOX_DISABLE_NETWORKING ?? 'true') === 'true',
   use_cgroupv2: (process.env.SANDBOX_USE_CGROUPV2 ?? 'true') === 'true',
   allowed_local_network_port: Number(process.env.SANDBOX_ALLOWED_LOCAL_NETWORK_PORT ?? 0),
-  output_max_size: Number(process.env.SANDBOX_OUTPUT_MAX_SIZE ?? 1024),
+  output_max_size: safeInt(process.env.SANDBOX_OUTPUT_MAX_SIZE, 1024),
   max_process_count: Number(process.env.SANDBOX_MAX_PROCESS_COUNT ?? 64),
   max_open_files: Number(process.env.SANDBOX_MAX_OPEN_FILES ?? 2048),
   max_file_size: Number(process.env.SANDBOX_MAX_FILE_SIZE ?? 10000000),


### PR DESCRIPTION
## Summary

Parse `SANDBOX_OUTPUT_MAX_SIZE` with `safeInt`, using 1024 when the value is invalid.

## Why

The current `Number(...)` conversion turns a typo such as `SANDBOX_OUTPUT_MAX_SIZE=banana` into `NaN`. The runner uses this value in comparisons while streaming stdout and stderr. Every comparison with `NaN` is false, so the configured output cap is effectively disabled and output can keep accumulating in memory.

The existing `safeInt` helper already handles invalid, non-positive, and fractional values. This change uses that helper for the output limit only. Valid integer settings continue to work as before.

## Tests

- `bun test api/src/config.test.ts api/src/validation.test.ts`
- Checked `banana`, `-5`, `3.7`, and `2048` through the config module.
