### PR TITLE
🏡 feat: Add Hosted App Runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,12 +158,17 @@ jobs:
           shellcheck scripts/build-lambda-microvm-artifact.sh
 
       - name: Validate runner Dockerfile
-        run: >-
-          docker buildx build --check
-          --platform linux/arm64
-          --target lambda-microvm-runner
-          -f api/Dockerfile
-          .
+        run: |
+          docker buildx build --check \
+            --platform linux/arm64 \
+            --target lambda-microvm-runner \
+            -f api/Dockerfile \
+            .
+          docker buildx build --check \
+            --platform linux/arm64 \
+            --target lambda-microvm-app-host \
+            -f api/Dockerfile \
+            .
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -148,7 +148,8 @@ RUN rm -f /usr/bin/nsenter /usr/bin/unshare /usr/bin/chroot /usr/sbin/chroot \
     2>/dev/null || true
 
 COPY api/src/entrypoint.sh ./entrypoint.sh
-RUN chmod +x ./entrypoint.sh
+COPY api/src/hosted-app-launcher.sh /usr/local/bin/codeapi-hosted-app-launcher
+RUN chmod +x ./entrypoint.sh /usr/local/bin/codeapi-hosted-app-launcher
 
 # ============================================================================
 # Stage 2b: AWS Lambda MicroVM container base image
@@ -187,6 +188,17 @@ ENV PORT=2000 \
 
 EXPOSE 2000/tcp
 ENTRYPOINT ["/sandbox_api/entrypoint.sh"]
+
+# Dedicated resident-process host. This image deliberately keeps the runner
+# control listener on 8080 and exposes one fixed user-app port separately.
+# `/execute` is disabled when hosted-app mode is enabled; the control plane
+# restores a checkpoint and starts the app through `/api/v2/hosted-app/start`.
+FROM lambda-microvm-runner AS lambda-microvm-app-host
+
+ENV SANDBOX_HOSTED_APPS_ENABLED=true \
+    SANDBOX_HOSTED_APP_PORT=3000
+
+EXPOSE 3000/tcp
 
 # ============================================================================
 # Stage 3: Build the Rust launcher binary (Fedora for libkrun ABI)

--- a/api/src/api/hosted-app.routes.test.ts
+++ b/api/src/api/hosted-app.routes.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
+import express from 'express';
+import type { Server } from 'node:http';
+import { config } from '../config';
+import { resetSessionWorkspaceStateForTests } from '../session-workspace';
+import v2Router from './v2';
+
+let server: Server;
+let baseUrl: string;
+const savedHostedAppsEnabled = config.hosted_apps_enabled;
+const savedSessionWorkspaceEnabled = config.session_workspace_enabled;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.urlencoded({ extended: true }));
+  app.use('/api/v2', v2Router);
+  await new Promise<void>(resolve => {
+    server = app.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${typeof address === 'object' && address ? address.port : 0}`;
+});
+
+afterEach(() => {
+  config.hosted_apps_enabled = false;
+  config.session_workspace_enabled = false;
+  resetSessionWorkspaceStateForTests();
+});
+
+afterAll(async () => {
+  await new Promise<void>(resolve => server.close(() => resolve()));
+  config.hosted_apps_enabled = savedHostedAppsEnabled;
+  config.session_workspace_enabled = savedSessionWorkspaceEnabled;
+  resetSessionWorkspaceStateForTests();
+});
+
+const post = (path: string, body: unknown = {}) => fetch(`${baseUrl}/api/v2${path}`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+describe('hosted-app route isolation', () => {
+  test('ordinary runner images do not expose hosted-app controls', async () => {
+    config.hosted_apps_enabled = false;
+    config.session_workspace_enabled = true;
+
+    const response = await post('/hosted-app/start');
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ message: 'Not Found' });
+  });
+
+  test('dedicated app hosts require the authenticated runtime-session binding', async () => {
+    config.hosted_apps_enabled = true;
+    config.session_workspace_enabled = true;
+
+    const response = await post('/hosted-app/start');
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ message: 'Missing runtime session header' });
+  });
+
+  test('dedicated app hosts refuse ordinary execution requests', async () => {
+    config.hosted_apps_enabled = true;
+    config.session_workspace_enabled = true;
+
+    const response = await post('/execute', {});
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ message: 'Not Found' });
+  });
+
+  test('status is session-bound and reports absence without starting a process', async () => {
+    config.hosted_apps_enabled = true;
+    config.session_workspace_enabled = true;
+
+    const response = await fetch(`${baseUrl}/api/v2/hosted-app/status`, {
+      headers: { 'X-Runtime-Session-Id': 'rt_hosted_demo' },
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: 'hosted_app_not_running',
+      message: 'No hosted app has been started',
+    });
+  });
+});

--- a/api/src/api/hosted-app.routes.test.ts
+++ b/api/src/api/hosted-app.routes.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test
 import express from 'express';
 import type { Server } from 'node:http';
 import { config } from '../config';
+import { HostedAppError, hostedAppSupervisor } from '../hosted-app';
 import { resetSessionWorkspaceStateForTests } from '../session-workspace';
 import v2Router from './v2';
 
@@ -84,5 +85,31 @@ describe('hosted-app route isolation', () => {
       error: 'hosted_app_not_running',
       message: 'No hosted app has been started',
     });
+  });
+
+  test('checkpoint creation uses the hosted-app workspace gate', async () => {
+    config.hosted_apps_enabled = true;
+    config.session_workspace_enabled = true;
+    const original = hostedAppSupervisor.withQuiescedWorkspace;
+    hostedAppSupervisor.withQuiescedWorkspace = async () => {
+      throw new HostedAppError(
+        'hosted_app_workspace_busy',
+        'the hosted app must be stopped before accessing its workspace',
+        409,
+      );
+    };
+
+    try {
+      const response = await fetch(`${baseUrl}/api/v2/session/checkpoint`, {
+        headers: { 'X-Runtime-Session-Id': 'rt_hosted_checkpoint' },
+      });
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual({
+        error: 'hosted_app_workspace_busy',
+        message: 'the hosted app must be stopped before accessing its workspace',
+      });
+    } finally {
+      hostedAppSupervisor.withQuiescedWorkspace = original;
+    }
   });
 });

--- a/api/src/api/lifecycle.ts
+++ b/api/src/api/lifecycle.ts
@@ -1,6 +1,7 @@
 import express, { Router, type Request, type Response } from 'express';
 import { logger } from '../logger';
 import { bindSessionWorkspace, parseSessionBinding, unbindSessionWorkspace } from '../session-workspace';
+import { hostedAppSupervisor } from '../hosted-app';
 
 /**
  * AWS Lambda MicroVM hook endpoints. The platform POSTs to
@@ -97,7 +98,12 @@ lifecycleRouter.post('/suspend', ackHook('suspend'));
 
 lifecycleRouter.post('/terminate', (_req: Request, res: Response) => {
   logger.info({ hook: 'terminate' }, 'MicroVM lifecycle hook invoked');
-  void unbindSessionWorkspace().catch((err) => logger.error({ err }, 'Failed to unbind session workspace on terminate'));
+  /* Stop before resetting the workspace so a resident process cannot race the
+   * recursive session cleanup. The platform does not need to wait for this
+   * best-effort cleanup before destroying the whole MicroVM. */
+  void hostedAppSupervisor.shutdown()
+    .then(() => unbindSessionWorkspace())
+    .catch((err) => logger.error({ err }, 'Failed to stop hosted app on terminate'));
   return res.status(200).json({ hook: 'terminate', status: 'ok' });
 });
 

--- a/api/src/api/v2.ts
+++ b/api/src/api/v2.ts
@@ -691,7 +691,11 @@ router.get('/session/checkpoint', (req: Request, res: Response, next: NextFuncti
   if (failure) {
     return res.status(failure.status).json(failure.body);
   }
-  return streamSessionCheckpoint(res).catch(next);
+  const checkpoint = (): Promise<void> => streamSessionCheckpoint(res);
+  return (config.hosted_apps_enabled
+    ? hostedAppSupervisor.withQuiescedWorkspace(checkpoint)
+    : checkpoint()
+  ).catch(error => hostedAppFailure(error, res, next));
 });
 router.post('/session/restore', (req: Request, res: Response, next: NextFunction) => {
   const failure = bindSessionFromHeader(req);
@@ -700,7 +704,7 @@ router.post('/session/restore', (req: Request, res: Response, next: NextFunction
   }
   const restore = (): Promise<void> => restoreSessionCheckpoint(req, res);
   return (config.hosted_apps_enabled
-    ? hostedAppSupervisor.withWorkspaceMutation(restore)
+    ? hostedAppSupervisor.withQuiescedWorkspace(restore)
     : restore()
   ).catch(error => hostedAppFailure(error, res, next));
 });
@@ -770,7 +774,7 @@ router.post(
     if (failure) return res.status(failure.status).json(failure.body);
     return hostedAppSupervisor.stop()
       .then(status => status ? res.status(200).json(status) : res.status(204).send())
-      .catch(next);
+      .catch(error => hostedAppFailure(error, res, next));
   },
 );
 /**

--- a/api/src/api/v2.ts
+++ b/api/src/api/v2.ts
@@ -32,6 +32,10 @@ import {
   pruneInputCache,
   storeCachedInputs,
 } from '../session-inputs';
+import {
+  HostedAppError,
+  hostedAppSupervisor,
+} from '../hosted-app';
 
 const router = express.Router();
 const SYNTHETIC_PRINCIPAL_SOURCE = 'synthetic_test';
@@ -388,6 +392,16 @@ router.use((req: Request, res: Response, next: NextFunction) => {
   next();
 });
 
+/* A hosted-app image is a dedicated process host, not an execution runner.
+ * Keeping `/execute` structurally unavailable prevents a resident app and an
+ * NsJail job from sharing the pinned session UID/workspace concurrently. */
+router.use('/execute', (_req: Request, res: Response, next: NextFunction) => {
+  if (config.hosted_apps_enabled) {
+    return res.status(404).json({ message: 'Not Found' });
+  }
+  next();
+});
+
 /** Replay PTC payloads (user code + tool definitions + inlined
  * `_ptc_history.json` + pyplot assets) can far exceed Express's default
  * ~100kb body limit. The parser is installed *here* rather than globally
@@ -686,6 +700,75 @@ router.post('/session/restore', (req: Request, res: Response, next: NextFunction
   }
   return restoreSessionCheckpoint(req, res).catch(next);
 });
+
+function requireHostedAppTarget(
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): Response | void {
+  if (!config.hosted_apps_enabled) {
+    return res.status(404).json({ message: 'Not Found' });
+  }
+  next();
+}
+
+function hostedAppFailure(
+  error: unknown,
+  res: Response,
+  next: NextFunction,
+): Response | void {
+  if (error instanceof HostedAppError) {
+    return res.status(error.status).json({ error: error.code, message: error.message });
+  }
+  next(error);
+}
+
+/* Dedicated Lambda MicroVM resident-server adapter. The control plane first
+ * restores an immutable session checkpoint into this VM, then starts exactly
+ * one foreground process. Preview traffic uses a separate AWS token restricted
+ * to `hosted_app_port`; these control routes stay on the runner port. */
+router.post(
+  '/hosted-app/start',
+  requireHostedAppTarget,
+  express.json({ limit: '64kb' }),
+  (req: Request, res: Response, next: NextFunction) => {
+    const failure = bindSessionFromHeader(req);
+    if (failure) return res.status(failure.status).json(failure.body);
+    return hostedAppSupervisor.start(req.body)
+      .then(status => res.status(200).json(status))
+      .catch(error => hostedAppFailure(error, res, next));
+  },
+);
+
+router.get(
+  '/hosted-app/status',
+  requireHostedAppTarget,
+  (req: Request, res: Response) => {
+    const failure = bindSessionFromHeader(req);
+    if (failure) return res.status(failure.status).json(failure.body);
+    const status = hostedAppSupervisor.status();
+    if (!status) {
+      return res.status(404).json({
+        error: 'hosted_app_not_running',
+        message: 'No hosted app has been started',
+      });
+    }
+    return res.status(200).json(status);
+  },
+);
+
+router.post(
+  '/hosted-app/stop',
+  requireHostedAppTarget,
+  express.json({ limit: '1kb' }),
+  (req: Request, res: Response, next: NextFunction) => {
+    const failure = bindSessionFromHeader(req);
+    if (failure) return res.status(failure.status).json(failure.body);
+    return hostedAppSupervisor.stop()
+      .then(status => status ? res.status(200).json(status) : res.status(204).send())
+      .catch(next);
+  },
+);
 /**
  * Input delivery for backends whose sandbox cannot reach the file server.
  *

--- a/api/src/api/v2.ts
+++ b/api/src/api/v2.ts
@@ -698,7 +698,11 @@ router.post('/session/restore', (req: Request, res: Response, next: NextFunction
   if (failure) {
     return res.status(failure.status).json(failure.body);
   }
-  return restoreSessionCheckpoint(req, res).catch(next);
+  const restore = (): Promise<void> => restoreSessionCheckpoint(req, res);
+  return (config.hosted_apps_enabled
+    ? hostedAppSupervisor.withWorkspaceMutation(restore)
+    : restore()
+  ).catch(error => hostedAppFailure(error, res, next));
 });
 
 function requireHostedAppTarget(

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -71,6 +71,31 @@ export const config = {
    * session mode. An enabled runner additionally binds each request to a
    * workspace through the authenticated X-Runtime-Session-Id header. */
   session_workspace_enabled: (process.env.SANDBOX_SESSION_WORKSPACE_ENABLED ?? 'false') === 'true',
+  /**
+   * Enables the Lambda-only hosted-app runner surface. This must only be set
+   * on a dedicated app-host MicroVM image: user application processes share
+   * that VM's network namespace and are therefore intentionally never started
+   * by the ordinary stateless/session execution runner.
+   */
+  hosted_apps_enabled: (process.env.SANDBOX_HOSTED_APPS_ENABLED ?? 'false') === 'true',
+  hosted_app_port: safeInt(process.env.SANDBOX_HOSTED_APP_PORT, 3000),
+  hosted_app_start_timeout_ms: safeInt(
+    process.env.SANDBOX_HOSTED_APP_START_TIMEOUT_MS,
+    30_000,
+  ),
+  hosted_app_stop_timeout_ms: safeInt(
+    process.env.SANDBOX_HOSTED_APP_STOP_TIMEOUT_MS,
+    5_000,
+  ),
+  hosted_app_log_max_bytes: safeInt(
+    process.env.SANDBOX_HOSTED_APP_LOG_MAX_BYTES,
+    64 * 1024,
+  ),
+  hosted_app_memory_max_bytes: safeInt(
+    process.env.SANDBOX_HOSTED_APP_MEMORY_MAX_BYTES,
+    2 * 1024 * 1024 * 1024,
+  ),
+  hosted_app_pids_max: safeInt(process.env.SANDBOX_HOSTED_APP_PIDS_MAX, 128),
   job_uid_base: safeInt(process.env.SANDBOX_JOB_UID_BASE, 200000),
   job_gid_base: safeInt(process.env.SANDBOX_JOB_GID_BASE, 200000),
   job_uid_count: safeInt(

--- a/api/src/hosted-app-launcher.sh
+++ b/api/src/hosted-app-launcher.sh
@@ -16,6 +16,7 @@ shift 3
 # inherit the cgroup even if they daemonize or create a new process group.
 printf '%s' "$$" > "${CGROUP_PATH}/cgroup.procs"
 exec /usr/bin/setpriv \
+  --no-new-privs \
   --reuid "$APP_UID" \
   --regid "$APP_GID" \
   --clear-groups \

--- a/api/src/hosted-app-launcher.sh
+++ b/api/src/hosted-app-launcher.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -lt 5 ]; then
+  echo "usage: hosted-app-launcher <cgroup> <uid> <gid> <command> [args...]" >&2
+  exit 64
+fi
+
+CGROUP_PATH="$1"
+APP_UID="$2"
+APP_GID="$3"
+shift 3
+
+# This wrapper starts as root, joins the root-owned cgroup before any user code
+# can fork, then irreversibly drops identity and capabilities. App descendants
+# inherit the cgroup even if they daemonize or create a new process group.
+printf '%s' "$$" > "${CGROUP_PATH}/cgroup.procs"
+exec /usr/bin/setpriv \
+  --reuid "$APP_UID" \
+  --regid "$APP_GID" \
+  --clear-groups \
+  --inh-caps=-all \
+  --ambient-caps=-all \
+  --bounding-set=-all \
+  -- "$@"

--- a/api/src/hosted-app.test.ts
+++ b/api/src/hosted-app.test.ts
@@ -102,6 +102,7 @@ function dependencies(
     guardError?: Error;
     killCgroup?: () => Promise<void>;
     runtime?: Runtime;
+    runtimes?: Runtime[];
   } = {},
 ): {
   deps: HostedAppDependencies;
@@ -110,19 +111,24 @@ function dependencies(
   cgroupKills: string[];
   kills: Array<{ pid: number; signal: NodeJS.Signals }>;
   children: FakeChild[];
+  preparations: Array<{ runtime: Runtime; nodeModulesPath?: string }>;
 } {
   const spawns: Array<{ command: string; args: readonly string[]; options: SpawnOptions }> = [];
   const guards: number[] = [];
   const cgroupKills: string[] = [];
   const kills: Array<{ pid: number; signal: NodeJS.Signals }> = [];
   const children: FakeChild[] = [];
+  const preparations: Array<{ runtime: Runtime; nodeModulesPath?: string }> = [];
   const getSession = () => ({
     ownership: async () => ({ dir: root, uid: 200123, gid: 200123 }),
   } as SessionWorkspace);
   const deps: HostedAppDependencies = {
     getSession,
     resolveRuntime: () => options.runtime === undefined ? fakeRuntime() : options.runtime,
-    prepareRuntimeWorkspace: async () => {},
+    listRuntimes: () => options.runtimes ?? [options.runtime ?? fakeRuntime()],
+    prepareRuntimeWorkspace: async (_workspaceDir, runtime, nodeModulesPath) => {
+      preparations.push({ runtime, nodeModulesPath });
+    },
     spawnApp: ((command: string, args: readonly string[], spawnOptions: SpawnOptions) => {
       spawns.push({ command, args, options: spawnOptions });
       const child = fakeChild(4242 + children.length);
@@ -146,7 +152,7 @@ function dependencies(
     },
     now: () => new Date('2026-08-21T12:00:00.000Z'),
   };
-  return { deps, spawns, guards, cgroupKills, kills, children };
+  return { deps, spawns, guards, cgroupKills, kills, children, preparations };
 }
 
 describe('HostedAppSupervisor', () => {
@@ -200,6 +206,37 @@ describe('HostedAppSupervisor', () => {
     });
     expect(launch.options.env).not.toHaveProperty('port');
     expect(launch.options.env).not.toHaveProperty('LD_PRELOAD');
+    await supervisor.shutdown();
+  });
+
+  test('gives Bash hosted apps access to curated packaged runtimes', async () => {
+    const root = await workspace();
+    const bash = {
+      ...fakeRuntime(),
+      language: 'bash',
+      pkgdir: '/pkgs/bash/5',
+      env_vars: { PATH: '/pkgs/bash/5/bin:/usr/bin' },
+    };
+    const node = {
+      ...fakeRuntime(),
+      env_vars: {
+        PATH: '/pkgs/node/22/bin:/usr/bin',
+        NODE_PATH: '/pkgs/node/22/node_modules',
+      },
+    };
+    const fixture = dependencies(root, { runtime: bash, runtimes: [bash, node] });
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+
+    await supervisor.start(request({ language: 'bash', version: '>=5' }));
+
+    expect(fixture.spawns[0].options.env).toMatchObject({
+      PATH: '/pkgs/node/22/bin:/pkgs/bash/5/bin:/usr/bin',
+      NODE_PATH: '/pkgs/node/22/node_modules',
+    });
+    expect(fixture.preparations).toEqual([{
+      runtime: bash,
+      nodeModulesPath: '/pkgs/node/22/node_modules',
+    }]);
     await supervisor.shutdown();
   });
 
@@ -303,14 +340,14 @@ describe('HostedAppSupervisor', () => {
     expect(supervisor.status()?.state).toBe('failed');
   });
 
-  test('serializes workspace mutation and rejects it while an app is running', async () => {
+  test('serializes quiesced workspace access and rejects it while an app is running', async () => {
     const root = await workspace();
     const fixture = dependencies(root);
     const supervisor = new HostedAppSupervisor(fixture.deps);
     await supervisor.start(request());
     let mutated = false;
 
-    const error = await supervisor.withWorkspaceMutation(async () => {
+    const error = await supervisor.withQuiescedWorkspace(async () => {
       mutated = true;
     }).catch(value => value);
 
@@ -372,6 +409,26 @@ describe('HostedAppSupervisor', () => {
     expect(stopped).toBe(true);
   });
 
+  test('classifies a stop cleanup failure as a retryable server error', async () => {
+    const root = await workspace();
+    let permitCleanup = false;
+    const fixture = dependencies(root, {
+      killCgroup: async () => {
+        if (!permitCleanup) throw new Error('cgroup remains populated');
+      },
+    });
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+
+    const error = await supervisor.stop().catch(value => value);
+    expect(error).toBeInstanceOf(HostedAppError);
+    expect(error.code).toBe('hosted_app_cleanup_failed');
+    expect(error.status).toBe(503);
+
+    permitCleanup = true;
+    await supervisor.shutdown();
+  });
+
   test('fails workspace mutation closed until a failed app cgroup is drained', async () => {
     const root = await workspace();
     let permitCleanup = false;
@@ -386,7 +443,7 @@ describe('HostedAppSupervisor', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
     let mutated = false;
 
-    const error = await supervisor.withWorkspaceMutation(async () => {
+    const error = await supervisor.withQuiescedWorkspace(async () => {
       mutated = true;
     }).catch(value => value);
     expect(error).toBeInstanceOf(HostedAppError);
@@ -394,7 +451,7 @@ describe('HostedAppSupervisor', () => {
     expect(mutated).toBe(false);
 
     permitCleanup = true;
-    await supervisor.withWorkspaceMutation(async () => { mutated = true; });
+    await supervisor.withQuiescedWorkspace(async () => { mutated = true; });
     expect(mutated).toBe(true);
   });
 

--- a/api/src/hosted-app.test.ts
+++ b/api/src/hosted-app.test.ts
@@ -27,6 +27,7 @@ const savedConfig = {
   start: config.hosted_app_start_timeout_ms,
   stop: config.hosted_app_stop_timeout_ms,
   logs: config.hosted_app_log_max_bytes,
+  packages: config.packages_directory,
 };
 
 let roots: string[] = [];
@@ -43,6 +44,7 @@ afterEach(async () => {
   config.hosted_app_start_timeout_ms = savedConfig.start;
   config.hosted_app_stop_timeout_ms = savedConfig.stop;
   config.hosted_app_log_max_bytes = savedConfig.logs;
+  config.packages_directory = savedConfig.packages;
   await Promise.all(roots.map(root => fsp.rm(root, { recursive: true, force: true })));
   roots = [];
 });
@@ -298,9 +300,11 @@ describe('HostedAppSupervisor', () => {
 
   test('links bundled JavaScript packages into the hosted workspace', async () => {
     const root = await workspace();
-    const packageRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'hosted-app-packages-'));
-    roots.push(packageRoot);
-    await fsp.mkdir(path.join(packageRoot, 'node_modules'));
+    const packages = await fsp.mkdtemp(path.join(os.tmpdir(), 'hosted-app-packages-'));
+    roots.push(packages);
+    config.packages_directory = packages;
+    const packageRoot = path.join(packages, 'node', '22');
+    await fsp.mkdir(path.join(packageRoot, 'node_modules'), { recursive: true });
     const runtime = { ...fakeRuntime(), pkgdir: packageRoot };
 
     await prepareHostedAppRuntimeWorkspace(root, runtime);
@@ -308,6 +312,67 @@ describe('HostedAppSupervisor', () => {
     expect(await fsp.realpath(path.join(root, 'node_modules'))).toBe(
       await fsp.realpath(path.join(packageRoot, 'node_modules')),
     );
+  });
+
+  test('refreshes a supervisor-managed package link for a new runtime', async () => {
+    const root = await workspace();
+    const packages = await fsp.mkdtemp(path.join(os.tmpdir(), 'hosted-app-packages-'));
+    roots.push(packages);
+    config.packages_directory = packages;
+    const firstRoot = path.join(packages, 'node', '22');
+    const secondRoot = path.join(packages, 'bun', '1');
+    await fsp.mkdir(path.join(firstRoot, 'node_modules'), { recursive: true });
+    await fsp.mkdir(path.join(secondRoot, 'node_modules'), { recursive: true });
+
+    await prepareHostedAppRuntimeWorkspace(root, { ...fakeRuntime(), pkgdir: firstRoot });
+    await prepareHostedAppRuntimeWorkspace(root, { ...fakeRuntime(), pkgdir: secondRoot });
+
+    expect(await fsp.realpath(path.join(root, 'node_modules'))).toBe(
+      await fsp.realpath(path.join(secondRoot, 'node_modules')),
+    );
+  });
+
+  test('waits for confirmed cgroup cleanup before completing stop', async () => {
+    const root = await workspace();
+    let releaseCleanup!: () => void;
+    const cleanupBlocked = new Promise<void>(resolve => { releaseCleanup = resolve; });
+    const fixture = dependencies(root, { killCgroup: () => cleanupBlocked });
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+
+    let stopped = false;
+    const stopping = supervisor.stop().then(() => { stopped = true; });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(stopped).toBe(false);
+
+    releaseCleanup();
+    await stopping;
+    expect(stopped).toBe(true);
+  });
+
+  test('skips queued exit cleanup after a replacement becomes active', async () => {
+    const root = await workspace();
+    const fixture = dependencies(root);
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+    let releaseOwnership!: (value: { dir: string; uid: number; gid: number }) => void;
+    const ownershipBlocked = new Promise<{ dir: string; uid: number; gid: number }>(
+      resolve => { releaseOwnership = resolve; },
+    );
+    fixture.deps.getSession = () => ({
+      ownership: () => ownershipBlocked,
+    } as SessionWorkspace);
+
+    const replacement = supervisor.start(request({ revision: 'rev-2' }));
+    await new Promise(resolve => setTimeout(resolve, 0));
+    fixture.children[0].emit('exit', 1, null);
+    releaseOwnership({ dir: root, uid: 200123, gid: 200123 });
+
+    expect((await replacement).revision).toBe('rev-2');
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(supervisor.status()?.state).toBe('running');
+    expect(fixture.cgroupKills).toHaveLength(1);
+    await supervisor.shutdown();
   });
 
   test('fails closed before spawning when the network guard cannot be installed', async () => {

--- a/api/src/hosted-app.test.ts
+++ b/api/src/hosted-app.test.ts
@@ -10,6 +10,7 @@ import type { SessionWorkspace } from './session-workspace';
 import {
   HostedAppError,
   HostedAppSupervisor,
+  prepareHostedAppRuntimeWorkspace,
   type HostedAppDependencies,
   type HostedAppStartRequest,
 } from './hosted-app';
@@ -95,8 +96,10 @@ function dependencies(
   root: string,
   options: {
     probe?: boolean;
+    probePort?: () => Promise<boolean>;
     guardError?: Error;
     killCgroup?: () => Promise<void>;
+    runtime?: Runtime;
   } = {},
 ): {
   deps: HostedAppDependencies;
@@ -116,7 +119,8 @@ function dependencies(
   } as SessionWorkspace);
   const deps: HostedAppDependencies = {
     getSession,
-    resolveRuntime: () => fakeRuntime(),
+    resolveRuntime: () => options.runtime === undefined ? fakeRuntime() : options.runtime,
+    prepareRuntimeWorkspace: async () => {},
     spawnApp: ((command: string, args: readonly string[], spawnOptions: SpawnOptions) => {
       spawns.push({ command, args, options: spawnOptions });
       const child = fakeChild(4242 + children.length);
@@ -132,7 +136,7 @@ function dependencies(
       guards.push(uid);
       if (options.guardError) throw options.guardError;
     },
-    probePort: async () => options.probe ?? true,
+    probePort: options.probePort ?? (async () => options.probe ?? true),
     killProcessGroup: (pid, signal) => {
       kills.push({ pid, signal });
       const child = children.find(candidate => candidate.pid === pid);
@@ -237,6 +241,73 @@ describe('HostedAppSupervisor', () => {
     expect(fixture.cgroupKills.length).toBeGreaterThan(0);
     expect(fixture.spawns).toHaveLength(2);
     await supervisor.shutdown();
+  });
+
+  test('validates a replacement before stopping the running revision', async () => {
+    const root = await workspace();
+    const fixture = dependencies(root);
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+    fixture.deps.resolveRuntime = () => undefined;
+
+    const error = await supervisor.start(request({ revision: 'rev-2' })).catch(value => value);
+
+    expect(error).toBeInstanceOf(HostedAppError);
+    expect(error.code).toBe('hosted_app_runtime_not_found');
+    expect(supervisor.status()?.state).toBe('running');
+    expect(fixture.kills).toEqual([]);
+    await supervisor.shutdown();
+  });
+
+  test('does not report running when the child exits during its readiness probe', async () => {
+    const root = await workspace();
+    let finishProbe!: (ready: boolean) => void;
+    const probe = new Promise<boolean>(resolve => { finishProbe = resolve; });
+    const fixture = dependencies(root, { probePort: () => probe });
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    const started = supervisor.start(request());
+    while (fixture.children.length === 0) {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+
+    fixture.children[0].emit('exit', 1, null);
+    finishProbe(true);
+    const error = await started.catch(value => value);
+
+    expect(error).toBeInstanceOf(HostedAppError);
+    expect(error.code).toBe('hosted_app_start_failed');
+    expect(supervisor.status()?.state).toBe('failed');
+  });
+
+  test('serializes workspace mutation and rejects it while an app is running', async () => {
+    const root = await workspace();
+    const fixture = dependencies(root);
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+    let mutated = false;
+
+    const error = await supervisor.withWorkspaceMutation(async () => {
+      mutated = true;
+    }).catch(value => value);
+
+    expect(error).toBeInstanceOf(HostedAppError);
+    expect(error.code).toBe('hosted_app_workspace_busy');
+    expect(mutated).toBe(false);
+    await supervisor.shutdown();
+  });
+
+  test('links bundled JavaScript packages into the hosted workspace', async () => {
+    const root = await workspace();
+    const packageRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'hosted-app-packages-'));
+    roots.push(packageRoot);
+    await fsp.mkdir(path.join(packageRoot, 'node_modules'));
+    const runtime = { ...fakeRuntime(), pkgdir: packageRoot };
+
+    await prepareHostedAppRuntimeWorkspace(root, runtime);
+
+    expect(await fsp.realpath(path.join(root, 'node_modules'))).toBe(
+      await fsp.realpath(path.join(packageRoot, 'node_modules')),
+    );
   });
 
   test('fails closed before spawning when the network guard cannot be installed', async () => {

--- a/api/src/hosted-app.test.ts
+++ b/api/src/hosted-app.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PassThrough } from 'node:stream';
+import type { SpawnOptions } from 'node:child_process';
+import type { Runtime } from './runtime';
+import type { SessionWorkspace } from './session-workspace';
+import {
+  HostedAppError,
+  HostedAppSupervisor,
+  type HostedAppDependencies,
+  type HostedAppStartRequest,
+} from './hosted-app';
+import { config } from './config';
+
+interface FakeChild extends EventEmitter {
+  pid: number;
+  stdout: PassThrough;
+  stderr: PassThrough;
+}
+
+const savedConfig = {
+  port: config.hosted_app_port,
+  start: config.hosted_app_start_timeout_ms,
+  stop: config.hosted_app_stop_timeout_ms,
+  logs: config.hosted_app_log_max_bytes,
+};
+
+let roots: string[] = [];
+
+beforeEach(() => {
+  config.hosted_app_port = 3123;
+  config.hosted_app_start_timeout_ms = 25;
+  config.hosted_app_stop_timeout_ms = 25;
+  config.hosted_app_log_max_bytes = 64;
+});
+
+afterEach(async () => {
+  config.hosted_app_port = savedConfig.port;
+  config.hosted_app_start_timeout_ms = savedConfig.start;
+  config.hosted_app_stop_timeout_ms = savedConfig.stop;
+  config.hosted_app_log_max_bytes = savedConfig.logs;
+  await Promise.all(roots.map(root => fsp.rm(root, { recursive: true, force: true })));
+  roots = [];
+});
+
+async function workspace(): Promise<string> {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'hosted-app-'));
+  roots.push(root);
+  await fsp.writeFile(path.join(root, 'server.js'), 'serve();');
+  await fsp.mkdir(path.join(root, 'app'));
+  return root;
+}
+
+function fakeRuntime(): Runtime {
+  return {
+    language: 'node',
+    version: { raw: '22.0.0' } as Runtime['version'],
+    aliases: [],
+    pkgdir: '/pkgs/node/22',
+    compiled: false,
+    env_vars: { PATH: '/pkgs/node/22/bin:/usr/bin' },
+    timeouts: { compile: 0, run: 0 },
+    cpu_times: { compile: 0, run: 0 },
+    memory_limits: { compile: 0, run: 0 },
+    max_process_count: 64,
+    max_open_files: 2048,
+    max_file_size: 10_000_000,
+    output_max_size: 1024,
+  };
+}
+
+function fakeChild(pid = 4242): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.pid = pid;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  return child;
+}
+
+function request(overrides: Partial<HostedAppStartRequest> = {}): HostedAppStartRequest {
+  return {
+    app_id: 'demo',
+    revision: 'rev-1',
+    language: 'node',
+    version: '>=22',
+    entrypoint: 'server.js',
+    ...overrides,
+  };
+}
+
+function dependencies(
+  root: string,
+  options: {
+    probe?: boolean;
+    guardError?: Error;
+  } = {},
+): {
+  deps: HostedAppDependencies;
+  spawns: Array<{ command: string; args: readonly string[]; options: SpawnOptions }>;
+  guards: number[];
+  cgroupKills: string[];
+  kills: Array<{ pid: number; signal: NodeJS.Signals }>;
+  children: FakeChild[];
+} {
+  const spawns: Array<{ command: string; args: readonly string[]; options: SpawnOptions }> = [];
+  const guards: number[] = [];
+  const cgroupKills: string[] = [];
+  const kills: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+  const children: FakeChild[] = [];
+  const getSession = () => ({
+    ownership: async () => ({ dir: root, uid: 200123, gid: 200123 }),
+  } as SessionWorkspace);
+  const deps: HostedAppDependencies = {
+    getSession,
+    resolveRuntime: () => fakeRuntime(),
+    spawnApp: ((command: string, args: readonly string[], spawnOptions: SpawnOptions) => {
+      spawns.push({ command, args, options: spawnOptions });
+      const child = fakeChild(4242 + children.length);
+      children.push(child);
+      return child as unknown as ReturnType<HostedAppDependencies['spawnApp']>;
+    }) as HostedAppDependencies['spawnApp'],
+    prepareCgroup: async () => {},
+    killCgroup: async () => { cgroupKills.push('kill'); },
+    installNetworkGuard: async uid => {
+      guards.push(uid);
+      if (options.guardError) throw options.guardError;
+    },
+    probePort: async () => options.probe ?? true,
+    killProcessGroup: (pid, signal) => {
+      kills.push({ pid, signal });
+      const child = children.find(candidate => candidate.pid === pid);
+      queueMicrotask(() => child?.emit('exit', null, signal));
+    },
+    now: () => new Date('2026-08-21T12:00:00.000Z'),
+  };
+  return { deps, spawns, guards, cgroupKills, kills, children };
+}
+
+describe('HostedAppSupervisor', () => {
+  test('starts a runtime as the session UID with a curated fixed-port environment', async () => {
+    const root = await workspace();
+    const fixture = dependencies(root);
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+
+    const status = await supervisor.start(request({
+      args: ['--production'],
+      env: {
+        APP_NAME: 'demo',
+        HOME: '/attacker',
+        port: '9999',
+        HOST: 'attacker.invalid',
+        LD_PRELOAD: '/tmp/evil.so',
+      },
+    }));
+
+    expect(status).toMatchObject({
+      app_id: 'demo',
+      revision: 'rev-1',
+      state: 'running',
+      port: 3123,
+      pid: 4242,
+    });
+    expect(fixture.guards).toEqual([200123]);
+    expect(fixture.spawns).toHaveLength(1);
+    const launch = fixture.spawns[0];
+    expect(launch.command).toBe('/usr/local/bin/codeapi-hosted-app-launcher');
+    const realRoot = await fsp.realpath(root);
+    expect(launch.args).toEqual([
+      '/sys/fs/cgroup/codeapi_hosted_app',
+      '200123',
+      '200123',
+      '/bin/bash',
+      '/pkgs/node/22/run',
+      path.join(realRoot, 'server.js'),
+      '--production',
+    ]);
+    expect(launch.options).toMatchObject({
+      cwd: realRoot,
+      detached: true,
+    });
+    expect(launch.options.env).toMatchObject({
+      APP_NAME: 'demo',
+      HOME: root,
+      HOST: '0.0.0.0',
+      PORT: '3123',
+      PATH: '/pkgs/node/22/bin:/usr/bin',
+    });
+    expect(launch.options.env).not.toHaveProperty('port');
+    expect(launch.options.env).not.toHaveProperty('LD_PRELOAD');
+    await supervisor.shutdown();
+  });
+
+  test('is idempotent for the exact same immutable revision', async () => {
+    const root = await workspace();
+    const fixture = dependencies(root);
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    const spec = request({ env: { B: '2', A: '1' } });
+
+    const first = await supervisor.start(spec);
+    const second = await supervisor.start(request({ env: { A: '1', B: '2' } }));
+
+    expect(second).toEqual(first);
+    expect(fixture.spawns).toHaveLength(1);
+    await supervisor.shutdown();
+  });
+
+  test('rejects changed launch settings under an existing revision', async () => {
+    const root = await workspace();
+    const fixture = dependencies(root);
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+
+    const error = await supervisor.start(request({ args: ['changed'] })).catch(value => value);
+    expect(error).toBeInstanceOf(HostedAppError);
+    expect(error.code).toBe('hosted_app_revision_conflict');
+    expect(fixture.spawns).toHaveLength(1);
+    await supervisor.shutdown();
+  });
+
+  test('stops the old process group before launching a new revision', async () => {
+    const root = await workspace();
+    const fixture = dependencies(root);
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+
+    const status = await supervisor.start(request({ revision: 'rev-2' }));
+
+    expect(status.revision).toBe('rev-2');
+    expect(fixture.kills).toEqual([{ pid: 4242, signal: 'SIGTERM' }]);
+    expect(fixture.cgroupKills.length).toBeGreaterThan(0);
+    expect(fixture.spawns).toHaveLength(2);
+    await supervisor.shutdown();
+  });
+
+  test('fails closed before spawning when the network guard cannot be installed', async () => {
+    const root = await workspace();
+    const fixture = dependencies(root, { guardError: new Error('iptables unavailable') });
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+
+    const error = await supervisor.start(request()).catch(value => value);
+
+    expect(error).toBeInstanceOf(HostedAppError);
+    expect(error.code).toBe('hosted_app_isolation_failed');
+    expect(fixture.spawns).toHaveLength(0);
+  });
+
+  test('rejects symlink entrypoints even when the target is a regular file', async () => {
+    const root = await workspace();
+    const outside = await fsp.mkdtemp(path.join(os.tmpdir(), 'hosted-app-outside-'));
+    roots.push(outside);
+    await fsp.writeFile(path.join(outside, 'outside.js'), 'steal();');
+    await fsp.symlink(path.join(outside, 'outside.js'), path.join(root, 'linked.js'));
+    const fixture = dependencies(root);
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+
+    const error = await supervisor.start(request({ entrypoint: 'linked.js' })).catch(value => value);
+
+    expect(error).toBeInstanceOf(HostedAppError);
+    expect(error.code).toBe('hosted_app_path_escape');
+    expect(fixture.guards).toHaveLength(0);
+    expect(fixture.spawns).toHaveLength(0);
+  });
+
+  test('retains only the bounded tail of process logs', async () => {
+    const root = await workspace();
+    config.hosted_app_log_max_bytes = 8;
+    const fixture = dependencies(root);
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+
+    fixture.children[0].stdout.write('0123456789');
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(supervisor.status()?.stdout).toBe('23456789');
+    await supervisor.shutdown();
+  });
+
+  test('reaps the cgroup when the tracked parent exits unexpectedly', async () => {
+    const root = await workspace();
+    const fixture = dependencies(root);
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+
+    fixture.children[0].emit('exit', 1, null);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(supervisor.status()?.state).toBe('failed');
+    expect(fixture.cgroupKills.length).toBeGreaterThan(0);
+    await supervisor.shutdown();
+  });
+});

--- a/api/src/hosted-app.test.ts
+++ b/api/src/hosted-app.test.ts
@@ -96,6 +96,7 @@ function dependencies(
   options: {
     probe?: boolean;
     guardError?: Error;
+    killCgroup?: () => Promise<void>;
   } = {},
 ): {
   deps: HostedAppDependencies;
@@ -123,7 +124,10 @@ function dependencies(
       return child as unknown as ReturnType<HostedAppDependencies['spawnApp']>;
     }) as HostedAppDependencies['spawnApp'],
     prepareCgroup: async () => {},
-    killCgroup: async () => { cgroupKills.push('kill'); },
+    killCgroup: async () => {
+      cgroupKills.push('kill');
+      await options.killCgroup?.();
+    },
     installNetworkGuard: async uid => {
       guards.push(uid);
       if (options.guardError) throw options.guardError;
@@ -289,6 +293,32 @@ describe('HostedAppSupervisor', () => {
 
     expect(supervisor.status()?.state).toBe('failed');
     expect(fixture.cgroupKills.length).toBeGreaterThan(0);
+    await supervisor.shutdown();
+  });
+
+  test('waits for unexpected-exit cleanup before launching a replacement revision', async () => {
+    const root = await workspace();
+    let releaseCleanup!: () => void;
+    const cleanupBlocked = new Promise<void>(resolve => { releaseCleanup = resolve; });
+    let cleanupCalls = 0;
+    const fixture = dependencies(root, {
+      killCgroup: async () => {
+        cleanupCalls += 1;
+        if (cleanupCalls === 1) await cleanupBlocked;
+      },
+    });
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+
+    fixture.children[0].emit('exit', 1, null);
+    await Promise.resolve();
+    const replacement = supervisor.start(request({ revision: 'rev-2' }));
+    await Promise.resolve();
+    expect(fixture.spawns).toHaveLength(1);
+
+    releaseCleanup();
+    expect((await replacement).revision).toBe('rev-2');
+    expect(fixture.spawns).toHaveLength(2);
     await supervisor.shutdown();
   });
 });

--- a/api/src/hosted-app.test.ts
+++ b/api/src/hosted-app.test.ts
@@ -230,6 +230,28 @@ describe('HostedAppSupervisor', () => {
     await supervisor.shutdown();
   });
 
+  test('preserves revision immutability after stop and replacement', async () => {
+    const root = await workspace();
+    const fixture = dependencies(root);
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+    await supervisor.stop();
+
+    const afterStop = await supervisor.start(request({ args: ['changed'] })).catch(value => value);
+    expect(afterStop).toBeInstanceOf(HostedAppError);
+    expect(afterStop.code).toBe('hosted_app_revision_conflict');
+
+    await supervisor.start(request());
+    await supervisor.start(request({ revision: 'rev-2' }));
+    const afterReplacement = await supervisor.start(
+      request({ args: ['changed'] }),
+    ).catch(value => value);
+    expect(afterReplacement).toBeInstanceOf(HostedAppError);
+    expect(afterReplacement.code).toBe('hosted_app_revision_conflict');
+    expect(fixture.spawns).toHaveLength(3);
+    await supervisor.shutdown();
+  });
+
   test('stops the old process group before launching a new revision', async () => {
     const root = await workspace();
     const fixture = dependencies(root);
@@ -348,6 +370,32 @@ describe('HostedAppSupervisor', () => {
     releaseCleanup();
     await stopping;
     expect(stopped).toBe(true);
+  });
+
+  test('fails workspace mutation closed until a failed app cgroup is drained', async () => {
+    const root = await workspace();
+    let permitCleanup = false;
+    const fixture = dependencies(root, {
+      killCgroup: async () => {
+        if (!permitCleanup) throw new Error('cgroup remains populated');
+      },
+    });
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+    fixture.children[0].emit('exit', 1, null);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    let mutated = false;
+
+    const error = await supervisor.withWorkspaceMutation(async () => {
+      mutated = true;
+    }).catch(value => value);
+    expect(error).toBeInstanceOf(HostedAppError);
+    expect(error.code).toBe('hosted_app_cleanup_failed');
+    expect(mutated).toBe(false);
+
+    permitCleanup = true;
+    await supervisor.withWorkspaceMutation(async () => { mutated = true; });
+    expect(mutated).toBe(true);
   });
 
   test('skips queued exit cleanup after a replacement becomes active', async () => {

--- a/api/src/hosted-app.ts
+++ b/api/src/hosted-app.ts
@@ -1,0 +1,660 @@
+import { execFile, spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import * as fsp from 'node:fs/promises';
+import * as net from 'node:net';
+import * as path from 'node:path';
+import type { Readable } from 'node:stream';
+import { promisify } from 'node:util';
+import { config } from './config';
+import { filterExtraEnvVars } from './job';
+import { logger } from './logger';
+import { getLatestRuntimeMatchingLanguageVersion } from './runtime';
+import { getBoundSessionWorkspace, type SessionWorkspace } from './session-workspace';
+import { ValidationError, validateFilePath } from './validation';
+
+const execFileAsync = promisify(execFile);
+const APP_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const REVISION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const HOSTED_APP_EGRESS_CHAIN = 'CODEAPI_HOSTED_APP_EGRESS';
+/* Sibling of sandbox_api, not its child: the API process lives in sandbox_api
+ * and cgroup v2 forbids enabling domain controllers below a populated parent. */
+const HOSTED_APP_CGROUP = '/sys/fs/cgroup/codeapi_hosted_app';
+const HOSTED_APP_LAUNCHER = '/usr/local/bin/codeapi-hosted-app-launcher';
+const MAX_ARGS = 64;
+const MAX_ARG_BYTES = 4096;
+const MAX_ENV_VARS = 64;
+const MAX_ENV_VALUE_BYTES = 4096;
+const MAX_ENV_BYTES = 32 * 1024;
+const PROBE_INTERVAL_MS = 100;
+
+export interface HostedAppStartRequest {
+  app_id: string;
+  revision: string;
+  language: string;
+  version: string;
+  entrypoint: string;
+  cwd?: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+interface NormalizedHostedAppRequest extends HostedAppStartRequest {
+  cwd: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+export type HostedAppState = 'starting' | 'running' | 'stopping' | 'stopped' | 'failed';
+
+export interface HostedAppStatus {
+  app_id: string;
+  revision: string;
+  state: HostedAppState;
+  port: number;
+  pid?: number;
+  started_at: string;
+  exited_at?: string;
+  exit_code?: number;
+  signal?: NodeJS.Signals;
+  message?: string;
+  stdout: string;
+  stderr: string;
+}
+
+export class HostedAppError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'HostedAppError';
+  }
+}
+
+interface ActiveHostedApp {
+  request: NormalizedHostedAppRequest;
+  specKey: string;
+  process?: HostedAppChild;
+  status: HostedAppStatus;
+}
+
+interface HostedAppChild extends ChildProcess {
+  readonly pid: number;
+  readonly stdout: Readable;
+  readonly stderr: Readable;
+}
+
+type SpawnApp = (command: string, args: readonly string[], options: SpawnOptions) => HostedAppChild;
+type ResolveRuntime = typeof getLatestRuntimeMatchingLanguageVersion;
+
+export interface HostedAppDependencies {
+  getSession: () => SessionWorkspace | undefined;
+  resolveRuntime: ResolveRuntime;
+  spawnApp: SpawnApp;
+  prepareCgroup: () => Promise<void>;
+  killCgroup: () => Promise<void>;
+  installNetworkGuard: (uid: number) => Promise<void>;
+  probePort: (port: number) => Promise<boolean>;
+  killProcessGroup: (pid: number, signal: NodeJS.Signals) => void;
+  now: () => Date;
+}
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function normalizeHostedAppRequest(value: unknown): NormalizedHostedAppRequest {
+  if (!isPlainObject(value)) {
+    throw new HostedAppError('invalid_hosted_app_request', 'request body must be an object', 400);
+  }
+
+  const stringField = (name: string): string => {
+    const field = value[name];
+    if (typeof field !== 'string' || field.length === 0) {
+      throw new HostedAppError(
+        'invalid_hosted_app_request',
+        `${name} must be a non-empty string`,
+        400,
+      );
+    }
+    if (field.includes('\0')) {
+      throw new HostedAppError('invalid_hosted_app_request', `${name} must not contain NUL`, 400);
+    }
+    return field;
+  };
+
+  const appId = stringField('app_id');
+  const revision = stringField('revision');
+  const language = stringField('language');
+  const version = stringField('version');
+  const entrypoint = stringField('entrypoint');
+  if (!APP_ID_PATTERN.test(appId)) {
+    throw new HostedAppError('invalid_hosted_app_request', 'app_id is malformed', 400);
+  }
+  if (!REVISION_PATTERN.test(revision)) {
+    throw new HostedAppError('invalid_hosted_app_request', 'revision is malformed', 400);
+  }
+  try {
+    validateFilePath(entrypoint, '/tmp/codeapi-hosted-app-validation');
+  } catch (error) {
+    throw new HostedAppError(
+      'invalid_hosted_app_request',
+      `entrypoint is invalid: ${error instanceof Error ? error.message : 'invalid path'}`,
+      400,
+    );
+  }
+
+  const cwdValue = value.cwd ?? '.';
+  if (typeof cwdValue !== 'string' || cwdValue.includes('\0')) {
+    throw new HostedAppError('invalid_hosted_app_request', 'cwd must be a string', 400);
+  }
+  if (cwdValue !== '.') {
+    try {
+      /* validateFilePath is also the canonical relative-path validator. A cwd
+       * is allowed to name a directory; append a sentinel so trailing-slash
+       * and directory-root cases retain the same traversal checks. */
+      validateFilePath(path.posix.join(cwdValue, '.codeapi-cwd'), '/tmp/codeapi-hosted-app-validation');
+      if (path.posix.normalize(cwdValue) !== cwdValue || cwdValue.endsWith('/')) {
+        throw new ValidationError('cwd must be a canonical relative path');
+      }
+    } catch (error) {
+      throw new HostedAppError(
+        'invalid_hosted_app_request',
+        `cwd is invalid: ${error instanceof Error ? error.message : 'invalid path'}`,
+        400,
+      );
+    }
+  }
+
+  const argsValue = value.args ?? [];
+  if (
+    !Array.isArray(argsValue)
+    || argsValue.length > MAX_ARGS
+    || argsValue.some(arg => (
+      typeof arg !== 'string'
+      || arg.includes('\0')
+      || byteLength(arg) > MAX_ARG_BYTES
+    ))
+  ) {
+    throw new HostedAppError(
+      'invalid_hosted_app_request',
+      `args must contain at most ${MAX_ARGS} bounded strings`,
+      400,
+    );
+  }
+
+  const envValue = value.env ?? {};
+  if (!isPlainObject(envValue) || Object.keys(envValue).length > MAX_ENV_VARS) {
+    throw new HostedAppError(
+      'invalid_hosted_app_request',
+      `env must be an object with at most ${MAX_ENV_VARS} entries`,
+      400,
+    );
+  }
+  const env: Record<string, string> = {};
+  let envBytes = 0;
+  for (const [key, raw] of Object.entries(envValue)) {
+    if (
+      !ENV_NAME_PATTERN.test(key)
+      || typeof raw !== 'string'
+      || raw.includes('\0')
+      || byteLength(raw) > MAX_ENV_VALUE_BYTES
+    ) {
+      throw new HostedAppError('invalid_hosted_app_request', `env.${key} is invalid`, 400);
+    }
+    envBytes += byteLength(key) + byteLength(raw);
+    if (envBytes > MAX_ENV_BYTES) {
+      throw new HostedAppError('invalid_hosted_app_request', 'env is too large', 400);
+    }
+    env[key] = raw;
+  }
+
+  return {
+    app_id: appId,
+    revision,
+    language,
+    version,
+    entrypoint,
+    cwd: cwdValue,
+    args: [...argsValue] as string[],
+    env,
+  };
+}
+
+function canonicalSpecKey(request: NormalizedHostedAppRequest): string {
+  return JSON.stringify({
+    ...request,
+    env: Object.fromEntries(Object.entries(request.env).sort(([a], [b]) => a.localeCompare(b))),
+  });
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (relative !== '..' && !relative.startsWith(`..${path.sep}`));
+}
+
+async function resolveWorkspacePaths(
+  workspaceDir: string,
+  request: NormalizedHostedAppRequest,
+): Promise<{ cwd: string; entrypoint: string }> {
+  const realRoot = await fsp.realpath(workspaceDir);
+  const cwd = await fsp.realpath(path.resolve(realRoot, request.cwd)).catch(() => {
+    throw new HostedAppError('hosted_app_cwd_missing', 'cwd does not exist', 400);
+  });
+  if (!isInside(realRoot, cwd)) {
+    throw new HostedAppError('hosted_app_path_escape', 'cwd escapes the session workspace', 400);
+  }
+  const cwdStat = await fsp.stat(cwd);
+  if (!cwdStat.isDirectory()) {
+    throw new HostedAppError('hosted_app_cwd_missing', 'cwd is not a directory', 400);
+  }
+
+  const requestedEntrypoint = path.resolve(realRoot, request.entrypoint);
+  const entrypointLstat = await fsp.lstat(requestedEntrypoint).catch(() => {
+    throw new HostedAppError('hosted_app_entrypoint_missing', 'entrypoint does not exist', 400);
+  });
+  if (entrypointLstat.isSymbolicLink()) {
+    throw new HostedAppError('hosted_app_path_escape', 'entrypoint must not be a symbolic link', 400);
+  }
+  const entrypoint = await fsp.realpath(requestedEntrypoint);
+  if (!isInside(realRoot, entrypoint)) {
+    throw new HostedAppError('hosted_app_path_escape', 'entrypoint escapes the session workspace', 400);
+  }
+  const entrypointStat = await fsp.stat(entrypoint);
+  if (!entrypointStat.isFile()) {
+    throw new HostedAppError('hosted_app_entrypoint_missing', 'entrypoint is not a file', 400);
+  }
+  return { cwd, entrypoint };
+}
+
+function appendBounded(current: string, chunk: Buffer | string): string {
+  const next = current + chunk.toString();
+  const bytes = Buffer.byteLength(next);
+  if (bytes <= config.hosted_app_log_max_bytes) return next;
+  return Buffer.from(next).subarray(bytes - config.hosted_app_log_max_bytes).toString();
+}
+
+async function commandSucceeds(binary: string, args: string[]): Promise<boolean> {
+  try {
+    await execFileAsync(binary, args);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Hosted apps receive inbound preview traffic, but may not initiate network
+ * connections. Besides blocking internet egress, this prevents the untrusted
+ * app UID from calling the root-owned control listener on localhost. Reply
+ * packets for accepted inbound connections remain allowed by conntrack.
+ */
+export async function installHostedAppNetworkGuard(uid: number): Promise<void> {
+  for (const binary of ['/usr/sbin/iptables', '/usr/sbin/ip6tables']) {
+    if (!(await commandSucceeds(binary, ['-w', '5', '-L', HOSTED_APP_EGRESS_CHAIN]))) {
+      await execFileAsync(binary, ['-w', '5', '-N', HOSTED_APP_EGRESS_CHAIN]);
+    }
+    await execFileAsync(binary, ['-w', '5', '-F', HOSTED_APP_EGRESS_CHAIN]);
+    await execFileAsync(binary, [
+      '-w', '5', '-A', HOSTED_APP_EGRESS_CHAIN,
+      '-m', 'conntrack', '--ctstate', 'ESTABLISHED,RELATED', '-j', 'ACCEPT',
+    ]);
+    await execFileAsync(binary, ['-w', '5', '-A', HOSTED_APP_EGRESS_CHAIN, '-j', 'REJECT']);
+    const jump = [
+      '-m', 'owner', '--uid-owner', String(uid), '-j', HOSTED_APP_EGRESS_CHAIN,
+    ];
+    if (!(await commandSucceeds(binary, ['-w', '5', '-C', 'OUTPUT', ...jump]))) {
+      await execFileAsync(binary, ['-w', '5', '-I', 'OUTPUT', '1', ...jump]);
+    }
+  }
+}
+
+/** Create a process-tree boundary owned only by the root runner. The launcher
+ * moves itself here before dropping to the session UID, so every descendant
+ * inherits the cgroup and cannot escape it by daemonizing or calling setsid. */
+export async function prepareHostedAppCgroup(): Promise<void> {
+  await fsp.mkdir(HOSTED_APP_CGROUP, { recursive: true });
+  /* cgroup.kill (Linux 5.14+) is required, not an optional optimization: it is
+   * the primitive that prevents a setsid()/double-fork descendant escaping
+   * revision replacement. Fail closed on kernels that do not expose it. */
+  await fsp.access(path.join(HOSTED_APP_CGROUP, 'cgroup.kill'));
+  await killHostedAppCgroup();
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const events = await fsp.readFile(path.join(HOSTED_APP_CGROUP, 'cgroup.events'), 'utf8');
+    if (/^populated 0$/m.test(events)) break;
+    if (attempt === 19) throw new Error('hosted-app cgroup did not become empty');
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+  await fsp.writeFile(path.join(HOSTED_APP_CGROUP, 'memory.max'), String(
+    config.hosted_app_memory_max_bytes,
+  ));
+  await fsp.writeFile(path.join(HOSTED_APP_CGROUP, 'pids.max'), String(
+    config.hosted_app_pids_max,
+  ));
+}
+
+/** `cgroup.kill` reaches descendants that changed session/process group. */
+export async function killHostedAppCgroup(): Promise<void> {
+  try {
+    await fsp.writeFile(path.join(HOSTED_APP_CGROUP, 'cgroup.kill'), '1');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}
+
+export function probeHostedAppPort(port: number): Promise<boolean> {
+  return new Promise(resolve => {
+    const socket = net.createConnection({ host: '127.0.0.1', port });
+    socket.setTimeout(500);
+    socket.once('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    const fail = (): void => {
+      socket.destroy();
+      resolve(false);
+    };
+    socket.once('error', fail);
+    socket.once('timeout', fail);
+  });
+}
+
+function killHostedAppProcessGroup(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(-pid, signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+  }
+}
+
+function publicStatus(active: ActiveHostedApp): HostedAppStatus {
+  return { ...active.status };
+}
+
+export class HostedAppSupervisor {
+  private active: ActiveHostedApp | undefined;
+  private transition: Promise<void> = Promise.resolve();
+
+  constructor(private readonly deps: HostedAppDependencies = {
+    getSession: getBoundSessionWorkspace,
+    resolveRuntime: getLatestRuntimeMatchingLanguageVersion,
+    spawnApp: (command, args, options) => spawn(command, args, options) as unknown as HostedAppChild,
+    prepareCgroup: prepareHostedAppCgroup,
+    killCgroup: killHostedAppCgroup,
+    installNetworkGuard: installHostedAppNetworkGuard,
+    probePort: probeHostedAppPort,
+    killProcessGroup: killHostedAppProcessGroup,
+    now: () => new Date(),
+  }) {}
+
+  status(): HostedAppStatus | undefined {
+    return this.active ? publicStatus(this.active) : undefined;
+  }
+
+  async start(rawRequest: unknown): Promise<HostedAppStatus> {
+    return this.serialize(() => this.startImpl(rawRequest));
+  }
+
+  async stop(): Promise<HostedAppStatus | undefined> {
+    return this.serialize(() => this.stopImpl());
+  }
+
+  async shutdown(): Promise<void> {
+    await this.stop();
+  }
+
+  private async serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.transition;
+    let release!: () => void;
+    this.transition = new Promise<void>(resolve => { release = resolve; });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private async startImpl(rawRequest: unknown): Promise<HostedAppStatus> {
+    const request = normalizeHostedAppRequest(rawRequest);
+    const specKey = canonicalSpecKey(request);
+    if (this.active?.status.state === 'running' && this.active.specKey === specKey) {
+      return publicStatus(this.active);
+    }
+    if (
+      this.active
+      && this.active.request.app_id === request.app_id
+      && this.active.request.revision === request.revision
+      && this.active.specKey !== specKey
+    ) {
+      throw new HostedAppError(
+        'hosted_app_revision_conflict',
+        'an app revision is immutable; use a new revision for changed launch settings',
+        409,
+      );
+    }
+    await this.stopImpl();
+
+    const session = this.deps.getSession();
+    if (!session) {
+      throw new HostedAppError(
+        'hosted_app_session_required',
+        'a bound stateful runtime session is required',
+        409,
+      );
+    }
+    const runtime = this.deps.resolveRuntime(request.language, request.version);
+    if (!runtime) {
+      throw new HostedAppError(
+        'hosted_app_runtime_not_found',
+        `runtime ${request.language}@${request.version} is not installed`,
+        400,
+      );
+    }
+    if (runtime.compiled) {
+      throw new HostedAppError(
+        'hosted_app_runtime_unsupported',
+        'compiled runtimes are not supported by the resident-server adapter',
+        400,
+      );
+    }
+
+    const ownership = await session.ownership();
+    const workspace = await resolveWorkspacePaths(ownership.dir, request);
+    try {
+      await this.deps.prepareCgroup();
+      await this.deps.installNetworkGuard(ownership.uid);
+    } catch (error) {
+      logger.error({ err: error, uid: ownership.uid }, 'Hosted-app isolation setup failed');
+      throw new HostedAppError(
+        'hosted_app_isolation_failed',
+        'hosted app could not be started safely',
+        503,
+      );
+    }
+
+    const status: HostedAppStatus = {
+      app_id: request.app_id,
+      revision: request.revision,
+      state: 'starting',
+      port: config.hosted_app_port,
+      started_at: this.deps.now().toISOString(),
+      stdout: '',
+      stderr: '',
+    };
+    const active: ActiveHostedApp = { request, specKey, status };
+    this.active = active;
+
+    const callerEnv = filterExtraEnvVars(request.env);
+    for (const key of Object.keys(callerEnv)) {
+      if (key.toUpperCase() === 'PORT' || key.toUpperCase() === 'HOST') {
+        delete callerEnv[key];
+      }
+    }
+    const env: NodeJS.ProcessEnv = {
+      ...callerEnv,
+      ...runtime.env_vars,
+      HOME: ownership.dir,
+      HOST: '0.0.0.0',
+      PORT: String(config.hosted_app_port),
+      SANDBOX_LANGUAGE: runtime.language,
+    };
+    const command = HOSTED_APP_LAUNCHER;
+    const args = [
+      HOSTED_APP_CGROUP,
+      String(ownership.uid),
+      String(ownership.gid),
+      '/bin/bash',
+      path.join(runtime.pkgdir, 'run'),
+      workspace.entrypoint,
+      ...request.args,
+    ];
+
+    let child: HostedAppChild;
+    try {
+      child = this.deps.spawnApp(command, args, {
+        cwd: workspace.cwd,
+        env,
+        detached: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (error) {
+      active.status.state = 'failed';
+      active.status.exited_at = this.deps.now().toISOString();
+      active.status.message = 'hosted app process could not be spawned';
+      throw new HostedAppError('hosted_app_spawn_failed', active.status.message, 500);
+    }
+    active.process = child;
+    active.status.pid = child.pid;
+    child.stdout.on('data', chunk => {
+      active.status.stdout = appendBounded(active.status.stdout, chunk);
+    });
+    child.stderr.on('data', chunk => {
+      active.status.stderr = appendBounded(active.status.stderr, chunk);
+    });
+    child.once('error', error => {
+      active.status.state = 'failed';
+      active.status.exited_at = this.deps.now().toISOString();
+      active.status.message = error.message;
+    });
+    child.once('exit', (code, signal) => {
+      active.process = undefined;
+      active.status.exited_at = this.deps.now().toISOString();
+      if (code !== null) active.status.exit_code = code;
+      if (signal !== null) active.status.signal = signal;
+      if (active.status.state === 'stopping') {
+        active.status.state = 'stopped';
+      } else if (active.status.state !== 'stopped') {
+        active.status.state = 'failed';
+        active.status.message ??= 'hosted app exited';
+      }
+      /* A daemonized descendant can outlive the tracked launcher process and
+       * process group. An explicit stop owns and awaits its cgroup sweep; an
+       * unexpected exit must initiate one here. Keeping those paths exclusive
+       * prevents a late old-app cleanup racing a newly launched revision. */
+      if (active.status.state !== 'stopped') {
+        void this.deps.killCgroup().catch(error => {
+          logger.error({ err: error, appId: active.request.app_id }, 'Hosted-app cgroup cleanup failed');
+        });
+      }
+    });
+
+    const deadline = Date.now() + config.hosted_app_start_timeout_ms;
+    while (Date.now() < deadline) {
+      if (active.status.state === 'failed') {
+        await this.stopImpl(true);
+        active.status.state = 'failed';
+        throw new HostedAppError(
+          'hosted_app_start_failed',
+          active.status.message ?? 'hosted app exited before becoming ready',
+          502,
+        );
+      }
+      if (await this.deps.probePort(config.hosted_app_port)) {
+        active.status.state = 'running';
+        logger.info(
+          { appId: request.app_id, revision: request.revision, pid: child.pid },
+          'Hosted app started',
+        );
+        return publicStatus(active);
+      }
+      await new Promise(resolve => setTimeout(resolve, PROBE_INTERVAL_MS));
+    }
+
+    active.status.message = `hosted app did not listen on port ${config.hosted_app_port}`;
+    await this.stopImpl(true);
+    active.status.state = 'failed';
+    throw new HostedAppError('hosted_app_start_timeout', active.status.message, 504);
+  }
+
+  private async stopImpl(preserveActive = false): Promise<HostedAppStatus | undefined> {
+    const active = this.active;
+    if (!active) return undefined;
+    const child = active.process;
+    if (!child?.pid) {
+      await this.deps.killCgroup();
+      if (!preserveActive) this.active = undefined;
+      return publicStatus(active);
+    }
+
+    active.status.state = 'stopping';
+    this.deps.killProcessGroup(child.pid, 'SIGTERM');
+    const exited = new Promise<boolean>(resolve => child.once('exit', () => resolve(true)));
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timedOut = new Promise<boolean>(resolve => {
+      timer = setTimeout(() => resolve(false), config.hosted_app_stop_timeout_ms);
+      timer.unref?.();
+    });
+    const stopped = await Promise.race([exited, timedOut]);
+    if (timer) clearTimeout(timer);
+    if (!stopped && active.process?.pid) {
+      await this.deps.killCgroup();
+      await Promise.race([
+        new Promise<void>(resolve => child.once('exit', () => resolve())),
+        new Promise<void>(resolve => setTimeout(resolve, config.hosted_app_stop_timeout_ms)),
+      ]);
+    }
+    /* Always sweep the cgroup: the tracked parent may have exited cleanly
+     * while a daemonized descendant stayed alive in a different process group. */
+    await this.deps.killCgroup();
+    active.status.state = 'stopped';
+    active.status.exited_at ??= this.deps.now().toISOString();
+    const status = publicStatus(active);
+    if (!preserveActive) this.active = undefined;
+    return status;
+  }
+}
+
+export function validateHostedAppStartup(): void {
+  if (!config.hosted_apps_enabled) return;
+  const bindParts = config.bind_address.split(':');
+  const runnerPort = Number(bindParts[bindParts.length - 1]);
+  const failures: string[] = [];
+  if (!config.session_workspace_enabled) {
+    failures.push('SANDBOX_SESSION_WORKSPACE_ENABLED must be true');
+  }
+  if (config.hosted_app_port < 1024 || config.hosted_app_port > 65535) {
+    failures.push('SANDBOX_HOSTED_APP_PORT must be between 1024 and 65535');
+  }
+  if (config.hosted_app_port === runnerPort) {
+    failures.push('SANDBOX_HOSTED_APP_PORT must differ from PORT');
+  }
+  if (!config.use_cgroupv2) {
+    failures.push('SANDBOX_USE_CGROUPV2 must be true');
+  }
+  if (process.getuid?.() !== 0) {
+    failures.push('the dedicated hosted-app runner must start as root');
+  }
+  if (failures.length > 0) {
+    throw new Error(`Invalid hosted-app runner configuration: ${failures.join('; ')}`);
+  }
+}
+
+export const hostedAppSupervisor = new HostedAppSupervisor();

--- a/api/src/hosted-app.ts
+++ b/api/src/hosted-app.ts
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 import { config } from './config';
 import { filterExtraEnvVars } from './job';
 import { logger } from './logger';
-import { getLatestRuntimeMatchingLanguageVersion } from './runtime';
+import { getLatestRuntimeMatchingLanguageVersion, type Runtime } from './runtime';
 import { getBoundSessionWorkspace, type SessionWorkspace } from './session-workspace';
 import { ValidationError, validateFilePath } from './validation';
 
@@ -91,6 +91,7 @@ type ResolveRuntime = typeof getLatestRuntimeMatchingLanguageVersion;
 export interface HostedAppDependencies {
   getSession: () => SessionWorkspace | undefined;
   resolveRuntime: ResolveRuntime;
+  prepareRuntimeWorkspace: (workspaceDir: string, runtime: Runtime) => Promise<void>;
   spawnApp: SpawnApp;
   prepareCgroup: () => Promise<void>;
   killCgroup: () => Promise<void>;
@@ -98,6 +99,31 @@ export interface HostedAppDependencies {
   probePort: (port: number) => Promise<boolean>;
   killProcessGroup: (pid: number, signal: NodeJS.Signals) => void;
   now: () => Date;
+}
+
+export async function prepareHostedAppRuntimeWorkspace(
+  workspaceDir: string,
+  runtime: Runtime,
+): Promise<void> {
+  const packageModules = path.join(runtime.pkgdir, 'node_modules');
+  const packageStat = await fsp.stat(packageModules).catch(error => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  });
+  if (!packageStat?.isDirectory()) return;
+
+  const workspaceModules = path.join(workspaceDir, 'node_modules');
+  try {
+    await fsp.lstat(workspaceModules);
+    return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  try {
+    await fsp.symlink(packageModules, workspaceModules, 'dir');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+  }
 }
 
 function byteLength(value: string): number {
@@ -385,6 +411,7 @@ export class HostedAppSupervisor {
   constructor(private readonly deps: HostedAppDependencies = {
     getSession: getBoundSessionWorkspace,
     resolveRuntime: getLatestRuntimeMatchingLanguageVersion,
+    prepareRuntimeWorkspace: prepareHostedAppRuntimeWorkspace,
     spawnApp: (command, args, options) => spawn(command, args, options) as unknown as HostedAppChild,
     prepareCgroup: prepareHostedAppCgroup,
     killCgroup: killHostedAppCgroup,
@@ -408,6 +435,20 @@ export class HostedAppSupervisor {
 
   async shutdown(): Promise<void> {
     await this.stop();
+  }
+
+  async withWorkspaceMutation<T>(operation: () => Promise<T>): Promise<T> {
+    return this.serialize(async () => {
+      const state = this.active?.status.state;
+      if (state === 'starting' || state === 'running' || state === 'stopping') {
+        throw new HostedAppError(
+          'hosted_app_workspace_busy',
+          'the hosted app must be stopped before replacing its workspace',
+          409,
+        );
+      }
+      return operation();
+    });
   }
 
   private async serialize<T>(operation: () => Promise<T>): Promise<T> {
@@ -440,8 +481,6 @@ export class HostedAppSupervisor {
         409,
       );
     }
-    await this.stopImpl();
-
     const session = this.deps.getSession();
     if (!session) {
       throw new HostedAppError(
@@ -467,6 +506,13 @@ export class HostedAppSupervisor {
     }
 
     const ownership = await session.ownership();
+    await resolveWorkspacePaths(ownership.dir, request);
+    await this.deps.prepareRuntimeWorkspace(ownership.dir, runtime);
+    await this.stopImpl();
+    /* The previous process shared this workspace UID and could have changed a
+     * validated path before it exited. Re-resolve after the process/cgroup are
+     * gone; the preflight above exists to avoid stopping it for ordinary
+     * configuration errors, while this check is authoritative for launch. */
     const workspace = await resolveWorkspacePaths(ownership.dir, request);
     try {
       await this.deps.prepareCgroup();
@@ -583,7 +629,17 @@ export class HostedAppSupervisor {
           502,
         );
       }
-      if (await this.deps.probePort(config.hosted_app_port)) {
+      const ready = await this.deps.probePort(config.hosted_app_port);
+      if (active.process !== child || active.status.state === 'failed') {
+        await this.stopImpl(true);
+        active.status.state = 'failed';
+        throw new HostedAppError(
+          'hosted_app_start_failed',
+          active.status.message ?? 'hosted app exited before becoming ready',
+          502,
+        );
+      }
+      if (ready) {
         active.status.state = 'running';
         logger.info(
           { appId: request.app_id, revision: request.revision, pid: child.pid },

--- a/api/src/hosted-app.ts
+++ b/api/src/hosted-app.ts
@@ -1,4 +1,5 @@
 import { execFile, spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import * as fsp from 'node:fs/promises';
 import * as net from 'node:net';
 import * as path from 'node:path';
@@ -25,6 +26,7 @@ const MAX_ARG_BYTES = 4096;
 const MAX_ENV_VARS = 64;
 const MAX_ENV_VALUE_BYTES = 4096;
 const MAX_ENV_BYTES = 32 * 1024;
+const MAX_TRACKED_APP_REVISIONS = 1024;
 const PROBE_INTERVAL_MS = 100;
 
 export interface HostedAppStartRequest {
@@ -75,6 +77,7 @@ export class HostedAppError extends Error {
 interface ActiveHostedApp {
   request: NormalizedHostedAppRequest;
   specKey: string;
+  cgroupDrained: boolean;
   process?: HostedAppChild;
   status: HostedAppStatus;
 }
@@ -264,10 +267,11 @@ function normalizeHostedAppRequest(value: unknown): NormalizedHostedAppRequest {
 }
 
 function canonicalSpecKey(request: NormalizedHostedAppRequest): string {
-  return JSON.stringify({
+  const canonical = JSON.stringify({
     ...request,
     env: Object.fromEntries(Object.entries(request.env).sort(([a], [b]) => a.localeCompare(b))),
   });
+  return createHash('sha256').update(canonical).digest('hex');
 }
 
 function isInside(root: string, candidate: string): boolean {
@@ -422,6 +426,7 @@ function publicStatus(active: ActiveHostedApp): HostedAppStatus {
 
 export class HostedAppSupervisor {
   private active: ActiveHostedApp | undefined;
+  private readonly revisionSpecs = new Map<string, string>();
   private transition: Promise<void> = Promise.resolve();
 
   constructor(private readonly deps: HostedAppDependencies = {
@@ -463,6 +468,22 @@ export class HostedAppSupervisor {
           409,
         );
       }
+      if (this.active && !this.active.cgroupDrained) {
+        try {
+          await this.deps.killCgroup();
+          this.active.cgroupDrained = true;
+        } catch (error) {
+          logger.error(
+            { err: error, appId: this.active.request.app_id },
+            'Hosted-app cgroup cleanup failed before workspace mutation',
+          );
+          throw new HostedAppError(
+            'hosted_app_cleanup_failed',
+            'the hosted app workspace is not safe to replace',
+            503,
+          );
+        }
+      }
       return operation();
     });
   }
@@ -482,20 +503,17 @@ export class HostedAppSupervisor {
   private async startImpl(rawRequest: unknown): Promise<HostedAppStatus> {
     const request = normalizeHostedAppRequest(rawRequest);
     const specKey = canonicalSpecKey(request);
-    if (this.active?.status.state === 'running' && this.active.specKey === specKey) {
-      return publicStatus(this.active);
-    }
-    if (
-      this.active
-      && this.active.request.app_id === request.app_id
-      && this.active.request.revision === request.revision
-      && this.active.specKey !== specKey
-    ) {
+    const revisionKey = `${request.app_id}\0${request.revision}`;
+    const rememberedSpec = this.revisionSpecs.get(revisionKey);
+    if (rememberedSpec !== undefined && rememberedSpec !== specKey) {
       throw new HostedAppError(
         'hosted_app_revision_conflict',
         'an app revision is immutable; use a new revision for changed launch settings',
         409,
       );
+    }
+    if (this.active?.status.state === 'running' && this.active.specKey === specKey) {
+      return publicStatus(this.active);
     }
     const session = this.deps.getSession();
     if (!session) {
@@ -523,6 +541,16 @@ export class HostedAppSupervisor {
 
     const ownership = await session.ownership();
     await resolveWorkspacePaths(ownership.dir, request);
+    if (rememberedSpec === undefined) {
+      if (this.revisionSpecs.size >= MAX_TRACKED_APP_REVISIONS) {
+        throw new HostedAppError(
+          'hosted_app_revision_limit',
+          'the hosted app revision limit for this runtime session was reached',
+          409,
+        );
+      }
+      this.revisionSpecs.set(revisionKey, specKey);
+    }
     await this.stopImpl();
     await this.deps.prepareRuntimeWorkspace(ownership.dir, runtime);
     /* The previous process shared this workspace UID and could have changed a
@@ -551,7 +579,7 @@ export class HostedAppSupervisor {
       stdout: '',
       stderr: '',
     };
-    const active: ActiveHostedApp = { request, specKey, status };
+    const active: ActiveHostedApp = { request, specKey, cgroupDrained: false, status };
     this.active = active;
 
     const callerEnv = filterExtraEnvVars(request.env);
@@ -625,6 +653,7 @@ export class HostedAppSupervisor {
         void this.serialize(async () => {
           if (this.active !== active || active.status.state === 'stopped') return;
           await this.deps.killCgroup();
+          active.cgroupDrained = true;
         }).catch(error => {
           logger.error(
             { err: error, appId: active.request.app_id },
@@ -678,6 +707,7 @@ export class HostedAppSupervisor {
     const child = active.process;
     if (!child?.pid) {
       await this.deps.killCgroup();
+      active.cgroupDrained = true;
       active.status.state = 'stopped';
       active.status.exited_at ??= this.deps.now().toISOString();
       if (!preserveActive) this.active = undefined;
@@ -704,6 +734,7 @@ export class HostedAppSupervisor {
     /* Always sweep the cgroup: the tracked parent may have exited cleanly
      * while a daemonized descendant stayed alive in a different process group. */
     await this.deps.killCgroup();
+    active.cgroupDrained = true;
     active.status.state = 'stopped';
     active.status.exited_at ??= this.deps.now().toISOString();
     const status = publicStatus(active);

--- a/api/src/hosted-app.ts
+++ b/api/src/hosted-app.ts
@@ -6,9 +6,9 @@ import * as path from 'node:path';
 import type { Readable } from 'node:stream';
 import { promisify } from 'node:util';
 import { config } from './config';
-import { filterExtraEnvVars } from './job';
+import { aggregateBashExtras, filterExtraEnvVars } from './job';
 import { logger } from './logger';
-import { getLatestRuntimeMatchingLanguageVersion, type Runtime } from './runtime';
+import { getLatestRuntimeMatchingLanguageVersion, getRuntimes, type Runtime } from './runtime';
 import { getBoundSessionWorkspace, type SessionWorkspace } from './session-workspace';
 import { ValidationError, validateFilePath } from './validation';
 
@@ -94,7 +94,12 @@ type ResolveRuntime = typeof getLatestRuntimeMatchingLanguageVersion;
 export interface HostedAppDependencies {
   getSession: () => SessionWorkspace | undefined;
   resolveRuntime: ResolveRuntime;
-  prepareRuntimeWorkspace: (workspaceDir: string, runtime: Runtime) => Promise<void>;
+  listRuntimes: () => Runtime[];
+  prepareRuntimeWorkspace: (
+    workspaceDir: string,
+    runtime: Runtime,
+    nodeModulesPath?: string,
+  ) => Promise<void>;
   spawnApp: SpawnApp;
   prepareCgroup: () => Promise<void>;
   killCgroup: () => Promise<void>;
@@ -107,8 +112,9 @@ export interface HostedAppDependencies {
 export async function prepareHostedAppRuntimeWorkspace(
   workspaceDir: string,
   runtime: Runtime,
+  nodeModulesPath?: string,
 ): Promise<void> {
-  const packageModules = path.join(runtime.pkgdir, 'node_modules');
+  const packageModules = nodeModulesPath ?? path.join(runtime.pkgdir, 'node_modules');
   const packageStat = await fsp.stat(packageModules).catch(error => {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
     throw error;
@@ -432,6 +438,7 @@ export class HostedAppSupervisor {
   constructor(private readonly deps: HostedAppDependencies = {
     getSession: getBoundSessionWorkspace,
     resolveRuntime: getLatestRuntimeMatchingLanguageVersion,
+    listRuntimes: getRuntimes,
     prepareRuntimeWorkspace: prepareHostedAppRuntimeWorkspace,
     spawnApp: (command, args, options) => spawn(command, args, options) as unknown as HostedAppChild,
     prepareCgroup: prepareHostedAppCgroup,
@@ -451,20 +458,31 @@ export class HostedAppSupervisor {
   }
 
   async stop(): Promise<HostedAppStatus | undefined> {
-    return this.serialize(() => this.stopImpl());
+    return this.serialize(async () => {
+      try {
+        return await this.stopImpl();
+      } catch (error) {
+        logger.error({ err: error }, 'Hosted-app stop cleanup failed');
+        throw new HostedAppError(
+          'hosted_app_cleanup_failed',
+          'the hosted app could not be stopped safely',
+          503,
+        );
+      }
+    });
   }
 
   async shutdown(): Promise<void> {
     await this.stop();
   }
 
-  async withWorkspaceMutation<T>(operation: () => Promise<T>): Promise<T> {
+  async withQuiescedWorkspace<T>(operation: () => Promise<T>): Promise<T> {
     return this.serialize(async () => {
       const state = this.active?.status.state;
       if (state === 'starting' || state === 'running' || state === 'stopping') {
         throw new HostedAppError(
           'hosted_app_workspace_busy',
-          'the hosted app must be stopped before replacing its workspace',
+          'the hosted app must be stopped before accessing its workspace',
           409,
         );
       }
@@ -552,7 +570,14 @@ export class HostedAppSupervisor {
       this.revisionSpecs.set(revisionKey, specKey);
     }
     await this.stopImpl();
-    await this.deps.prepareRuntimeWorkspace(ownership.dir, runtime);
+    const runtimeEnv = { ...runtime.env_vars };
+    let nodeModulesPath: string | undefined;
+    if (runtime.language === 'bash') {
+      const linkTarget: { nodeModulesPath?: string } = {};
+      aggregateBashExtras(runtime.pkgdir, runtimeEnv, this.deps.listRuntimes(), linkTarget);
+      nodeModulesPath = linkTarget.nodeModulesPath;
+    }
+    await this.deps.prepareRuntimeWorkspace(ownership.dir, runtime, nodeModulesPath);
     /* The previous process shared this workspace UID and could have changed a
      * validated path before it exited. Re-resolve after the process/cgroup are
      * gone; the preflight above exists to avoid stopping it for ordinary
@@ -590,7 +615,7 @@ export class HostedAppSupervisor {
     }
     const env: NodeJS.ProcessEnv = {
       ...callerEnv,
-      ...runtime.env_vars,
+      ...runtimeEnv,
       HOME: ownership.dir,
       HOST: '0.0.0.0',
       PORT: String(config.hosted_app_port),

--- a/api/src/hosted-app.ts
+++ b/api/src/hosted-app.ts
@@ -556,12 +556,18 @@ export class HostedAppSupervisor {
         active.status.message ??= 'hosted app exited';
       }
       /* A daemonized descendant can outlive the tracked launcher process and
-       * process group. An explicit stop owns and awaits its cgroup sweep; an
-       * unexpected exit must initiate one here. Keeping those paths exclusive
-       * prevents a late old-app cleanup racing a newly launched revision. */
+       * process group. Queue unexpected cleanup in the same transition chain
+       * as start/stop: a detached sweep must never land after a new revision
+       * has entered this shared cgroup. */
       if (active.status.state !== 'stopped') {
-        void this.deps.killCgroup().catch(error => {
-          logger.error({ err: error, appId: active.request.app_id }, 'Hosted-app cgroup cleanup failed');
+        void this.serialize(async () => {
+          if (active.status.state === 'stopped') return;
+          await this.deps.killCgroup();
+        }).catch(error => {
+          logger.error(
+            { err: error, appId: active.request.app_id },
+            'Hosted-app cgroup cleanup failed',
+          );
         });
       }
     });

--- a/api/src/hosted-app.ts
+++ b/api/src/hosted-app.ts
@@ -113,11 +113,20 @@ export async function prepareHostedAppRuntimeWorkspace(
   if (!packageStat?.isDirectory()) return;
 
   const workspaceModules = path.join(workspaceDir, 'node_modules');
+  let workspaceModulesStat: Awaited<ReturnType<typeof fsp.lstat>> | undefined;
   try {
-    await fsp.lstat(workspaceModules);
-    return;
+    workspaceModulesStat = await fsp.lstat(workspaceModules);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  if (workspaceModulesStat && !workspaceModulesStat.isSymbolicLink()) return;
+  if (workspaceModulesStat?.isSymbolicLink()) {
+    const linkTarget = await fsp.readlink(workspaceModules);
+    const resolvedTarget = path.resolve(workspaceDir, linkTarget);
+    const packageRoot = path.resolve(config.packages_directory);
+    if (!isInside(packageRoot, resolvedTarget)) return;
+    if (resolvedTarget === packageModules) return;
+    await fsp.unlink(workspaceModules);
   }
   try {
     await fsp.symlink(packageModules, workspaceModules, 'dir');
@@ -352,12 +361,6 @@ export async function prepareHostedAppCgroup(): Promise<void> {
    * revision replacement. Fail closed on kernels that do not expose it. */
   await fsp.access(path.join(HOSTED_APP_CGROUP, 'cgroup.kill'));
   await killHostedAppCgroup();
-  for (let attempt = 0; attempt < 20; attempt += 1) {
-    const events = await fsp.readFile(path.join(HOSTED_APP_CGROUP, 'cgroup.events'), 'utf8');
-    if (/^populated 0$/m.test(events)) break;
-    if (attempt === 19) throw new Error('hosted-app cgroup did not become empty');
-    await new Promise(resolve => setTimeout(resolve, 25));
-  }
   await fsp.writeFile(path.join(HOSTED_APP_CGROUP, 'memory.max'), String(
     config.hosted_app_memory_max_bytes,
   ));
@@ -371,7 +374,20 @@ export async function killHostedAppCgroup(): Promise<void> {
   try {
     await fsp.writeFile(path.join(HOSTED_APP_CGROUP, 'cgroup.kill'), '1');
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+  const deadline = Date.now() + config.hosted_app_stop_timeout_ms;
+  while (true) {
+    const events = await fsp.readFile(
+      path.join(HOSTED_APP_CGROUP, 'cgroup.events'),
+      'utf8',
+    );
+    if (/^populated 0$/m.test(events)) return;
+    if (Date.now() >= deadline) {
+      throw new Error('hosted-app cgroup did not become empty');
+    }
+    await new Promise(resolve => setTimeout(resolve, 25));
   }
 }
 
@@ -507,8 +523,8 @@ export class HostedAppSupervisor {
 
     const ownership = await session.ownership();
     await resolveWorkspacePaths(ownership.dir, request);
-    await this.deps.prepareRuntimeWorkspace(ownership.dir, runtime);
     await this.stopImpl();
+    await this.deps.prepareRuntimeWorkspace(ownership.dir, runtime);
     /* The previous process shared this workspace UID and could have changed a
      * validated path before it exited. Re-resolve after the process/cgroup are
      * gone; the preflight above exists to avoid stopping it for ordinary
@@ -607,7 +623,7 @@ export class HostedAppSupervisor {
        * has entered this shared cgroup. */
       if (active.status.state !== 'stopped') {
         void this.serialize(async () => {
-          if (active.status.state === 'stopped') return;
+          if (this.active !== active || active.status.state === 'stopped') return;
           await this.deps.killCgroup();
         }).catch(error => {
           logger.error(
@@ -662,6 +678,8 @@ export class HostedAppSupervisor {
     const child = active.process;
     if (!child?.pid) {
       await this.deps.killCgroup();
+      active.status.state = 'stopped';
+      active.status.exited_at ??= this.deps.now().toISOString();
       if (!preserveActive) this.active = undefined;
       return publicStatus(active);
     }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -8,6 +8,7 @@ import { httpMetricsMiddleware, metricsHandler } from './metrics';
 import { positiveInt, shutdownTelemetry, traceHttpRequest } from './telemetry';
 import { startWarmupCommand } from './warmup';
 import { stopToolCallSocketProxy } from './tool-call-socket-process';
+import { hostedAppSupervisor, validateHostedAppStartup } from './hosted-app';
 import v2Router from './api/v2';
 import lifecycleRouter, { LIFECYCLE_HOOK_BASE_PATH } from './api/lifecycle';
 
@@ -66,6 +67,7 @@ app.use((err: HttpError, _req: express.Request, res: express.Response, _next: ex
 });
 
 async function main(): Promise<void> {
+  validateHostedAppStartup();
   validateHardenedSandboxStartup();
   await initializeSandboxWorkspaceIsolation();
   await startWarmupCommand();
@@ -111,6 +113,9 @@ async function main(): Promise<void> {
     shuttingDown = true;
     stopWorkspaceReaper();
     await closeHttpServerWithTimeout();
+    await hostedAppSupervisor.shutdown().catch((err) => {
+      logger.warn({ err }, 'Hosted-app process shutdown failed');
+    });
     await stopToolCallSocketProxy().catch((err) => {
       logger.warn({ err }, 'Tool-call socket proxy shutdown failed');
     });

--- a/docs/lambda-microvm/README.md
+++ b/docs/lambda-microvm/README.md
@@ -142,6 +142,64 @@ IMAGE_DIGEST=sha256:<64-hex-digest> \
   scripts/build-lambda-microvm-artifact.sh zip upload
 ```
 
+### Dedicated hosted-app image (experimental)
+
+Resident web servers use a separate `lambda-microvm-app-host` image. They do
+not run as background children of `/execute`: an execution's PID/network
+namespaces end with that execution, while the app host intentionally keeps one
+supervised foreground process alive for the MicroVM lease. Build its immutable
+artifact through the same provenance-checked pipeline:
+
+```bash
+MICROVM_IMAGE_TARGET=lambda-microvm-app-host \
+  ECR_URI="$ECR_URI" S3_URI="$S3_URI" IMAGE_TAG="$IMAGE_TAG" \
+  scripts/build-lambda-microvm-artifact.sh build push zip upload
+# → app-host tags/artifacts are distinct from the normal runner
+```
+
+The app-host contract is deliberately narrow:
+
+1. Launch a MicroVM from the dedicated app-host image and wait for port 8080.
+2. Mint a control token restricted to port 8080.
+3. Restore an immutable stateful-session checkpoint with
+   `X-Runtime-Session-Id`, exactly as for a replacement session runner.
+4. `POST /api/v2/hosted-app/start` on port 8080 with the same session header:
+
+   ```json
+   {
+     "app_id": "my-app",
+     "revision": "rev-1",
+     "language": "node",
+     "version": ">=22",
+     "entrypoint": "server.js",
+     "cwd": ".",
+     "args": [],
+     "env": {}
+   }
+   ```
+
+   The process must listen on `HOST=0.0.0.0` and the injected `PORT` (3000 by
+   default). Start is idempotent for an identical revision; changed launch
+   settings require a new revision.
+5. Mint a separate preview token restricted to port 3000. Keep the endpoint and
+   both AWS credentials behind a CodeAPI preview gateway; never put a raw AWS
+   proxy token in browser-visible HTML or JavaScript.
+
+Hosted mode disables ordinary `/api/v2/execute`. The app runs as the
+session-workspace UID with a curated environment, and the runner installs
+fail-closed IPv4 and IPv6 OUTPUT rules before spawn: responses to inbound
+preview traffic are allowed, but new outbound connections (including calls to
+the root-owned control listener on localhost) are rejected. One app runs per
+MicroVM. A restored checkpoint is a revision copy, not a live shared filesystem
+with the coding VM.
+
+Lambda suspend/resume preserves the resident process, but the eight-hour hard
+lifetime does not. The higher-level hosted-app control plane must therefore
+retain the immutable revision/checkpoint identity, relaunch, restore, and start
+again after expiry. Static assets and request-shaped handlers should remain on
+cheaper stateless delivery paths; this target is only the resident-server
+adapter.
+
 ### 3. Generate the split execution-manifest keys
 
 The worker signs each execution manifest; the runner only receives the public

--- a/scripts/build-lambda-microvm-artifact.sh
+++ b/scripts/build-lambda-microvm-artifact.sh
@@ -7,7 +7,7 @@
 # in a same-account ECR repo (Lambda's build infra can pull it there).
 #
 # Stages (each optional, in order):
-#   build   docker buildx the arm64 lambda-microvm-runner target (no AWS)
+#   build   docker buildx the selected arm64 MicroVM target (no AWS)
 #   push    push to ECR (needs AWS_PROFILE + repo)
 #   zip     render the code-artifact Dockerfile and zip it (no AWS)
 #   upload  upload the zip to S3 (needs AWS_PROFILE + bucket)
@@ -24,6 +24,8 @@
 #   S3_URI         e.g. s3://codeapi-microvm-artifacts/runner
 #   AWS_PROFILE    e.g. librechat-dev
 #   AWS_REGION     required for push/upload
+#   MICROVM_IMAGE_TARGET  lambda-microvm-runner (default) or
+#                         lambda-microvm-app-host
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -37,8 +39,25 @@ if [ -z "${IMAGE_TAG:-}" ]; then
 fi
 ECR_URI="${ECR_URI:-}"
 S3_URI="${S3_URI:-}"
-OUT_DIR="${OUT_DIR:-.build-lambda-microvm}"
-LOCAL_TAG="codeapi-lambda-microvm-runner:${IMAGE_TAG}"
+MICROVM_IMAGE_TARGET="${MICROVM_IMAGE_TARGET:-lambda-microvm-runner}"
+case "$MICROVM_IMAGE_TARGET" in
+  lambda-microvm-runner)
+    ARTIFACT_KIND="runner"
+    PUBLISHED_TAG="$IMAGE_TAG"
+    DEFAULT_OUT_DIR=".build-lambda-microvm"
+    ;;
+  lambda-microvm-app-host)
+    ARTIFACT_KIND="app-host"
+    PUBLISHED_TAG="app-host-${IMAGE_TAG}"
+    DEFAULT_OUT_DIR=".build-lambda-microvm-app-host"
+    ;;
+  *)
+    echo "MICROVM_IMAGE_TARGET must be lambda-microvm-runner or lambda-microvm-app-host" >&2
+    exit 1
+    ;;
+esac
+OUT_DIR="${OUT_DIR:-$DEFAULT_OUT_DIR}"
+LOCAL_TAG="codeapi-${MICROVM_IMAGE_TARGET}:${IMAGE_TAG}"
 IMAGE_DIGEST="${IMAGE_DIGEST:-}"
 
 require_ecr() {
@@ -58,8 +77,8 @@ resolve_image_digest() {
     local cached_repository cached_tag
     cached_repository="$(sed -n '1p' "$OUT_DIR/image-repository" 2>/dev/null || true)"
     cached_tag="$(sed -n '1p' "$OUT_DIR/image-tag" 2>/dev/null || true)"
-    if [ "$cached_repository" != "$ECR_URI" ] || [ "$cached_tag" != "$IMAGE_TAG" ]; then
-      echo "Cached image digest does not belong to ECR_URI=$ECR_URI IMAGE_TAG=$IMAGE_TAG; run push first or set IMAGE_DIGEST explicitly." >&2
+    if [ "$cached_repository" != "$ECR_URI" ] || [ "$cached_tag" != "$PUBLISHED_TAG" ]; then
+      echo "Cached image digest does not belong to ECR_URI=$ECR_URI PUBLISHED_TAG=$PUBLISHED_TAG; run push first or set IMAGE_DIGEST explicitly." >&2
       exit 1
     fi
     IMAGE_DIGEST="$(sed -n '1p' "$OUT_DIR/image-digest")"
@@ -76,12 +95,12 @@ resolve_image_digest() {
 do_build() {
   local tags=(-t "$LOCAL_TAG")
   if [ -n "$ECR_URI" ]; then
-    tags+=(-t "$ECR_URI:$IMAGE_TAG")
+    tags+=(-t "$ECR_URI:$PUBLISHED_TAG")
   fi
-  echo ">> buildx arm64 lambda-microvm-runner (${LOCAL_TAG})"
+  echo ">> buildx arm64 ${MICROVM_IMAGE_TARGET} (${LOCAL_TAG})"
   docker buildx build \
     --platform linux/arm64 \
-    --target lambda-microvm-runner \
+    --target "$MICROVM_IMAGE_TARGET" \
     -f api/Dockerfile \
     "${tags[@]}" \
     --load \
@@ -91,13 +110,13 @@ do_build() {
 do_push() {
   require_ecr
   mkdir -p "$OUT_DIR"
-  echo ">> pushing $ECR_URI:$IMAGE_TAG"
+  echo ">> pushing $ECR_URI:$PUBLISHED_TAG"
   aws ecr get-login-password --region "${AWS_REGION:?AWS_REGION required}" \
     | docker login --username AWS --password-stdin "${ECR_URI%%/*}"
   # `build` is intentionally usable without AWS/ECR configuration. Tag here as
   # well so a later, separately invoked `push` stage still has the remote tag.
-  docker image tag "$LOCAL_TAG" "$ECR_URI:$IMAGE_TAG"
-  docker push "$ECR_URI:$IMAGE_TAG" | tee "$OUT_DIR/push.log"
+  docker image tag "$LOCAL_TAG" "$ECR_URI:$PUBLISHED_TAG"
+  docker push "$ECR_URI:$PUBLISHED_TAG" | tee "$OUT_DIR/push.log"
   IMAGE_DIGEST="$(sed -n 's/^.*digest: \(sha256:[0-9a-f]\{64\}\).*$/\1/p' "$OUT_DIR/push.log" | tail -n 1)"
   [ -n "$IMAGE_DIGEST" ] || {
     echo "Could not determine the pushed ECR digest; refusing to render a mutable artifact." >&2
@@ -105,8 +124,8 @@ do_push() {
   }
   printf '%s\n' "$IMAGE_DIGEST" > "$OUT_DIR/image-digest"
   printf '%s\n' "$ECR_URI" > "$OUT_DIR/image-repository"
-  printf '%s\n' "$IMAGE_TAG" > "$OUT_DIR/image-tag"
-  echo ">> immutable runner ref: $ECR_URI@$IMAGE_DIGEST"
+  printf '%s\n' "$PUBLISHED_TAG" > "$OUT_DIR/image-tag"
+  echo ">> immutable ${ARTIFACT_KIND} ref: $ECR_URI@$IMAGE_DIGEST"
 }
 
 do_zip() {
@@ -118,7 +137,7 @@ FROM ${ECR_URI}@${IMAGE_DIGEST}
 EOF
   (cd "$OUT_DIR" && rm -f artifact.zip && zip -q artifact.zip Dockerfile)
   printf '%s\n' "$ECR_URI" > "$OUT_DIR/artifact-image-repository"
-  printf '%s\n' "$IMAGE_TAG" > "$OUT_DIR/artifact-image-tag"
+  printf '%s\n' "$PUBLISHED_TAG" > "$OUT_DIR/artifact-image-tag"
   printf '%s\n' "$IMAGE_DIGEST" > "$OUT_DIR/artifact-image-digest"
   file_sha256 "$OUT_DIR/artifact.zip" > "$OUT_DIR/artifact-sha256"
   echo ">> wrote $OUT_DIR/artifact.zip (FROM ${ECR_URI}@${IMAGE_DIGEST})"
@@ -145,13 +164,13 @@ do_upload() {
   artifact_hash="$(sed -n '1p' "$OUT_DIR/artifact-sha256")"
   actual_hash="$(file_sha256 "$OUT_DIR/artifact.zip")"
   if [ "$artifact_repository" != "$ECR_URI" ] \
-    || [ "$artifact_tag" != "$IMAGE_TAG" ] \
+    || [ "$artifact_tag" != "$PUBLISHED_TAG" ] \
     || [ "$artifact_digest" != "$IMAGE_DIGEST" ] \
     || [ "$artifact_hash" != "$actual_hash" ]; then
       echo "artifact.zip provenance does not match the current repository, tag, digest, or bytes; run zip again before upload." >&2
       exit 1
   fi
-  local key="$S3_URI/runner-${IMAGE_TAG}.zip"
+  local key="$S3_URI/${ARTIFACT_KIND}-${IMAGE_TAG}.zip"
   aws s3 cp "$OUT_DIR/artifact.zip" "$key" --region "${AWS_REGION:?AWS_REGION required}"
   echo ">> uploaded $key"
   cat <<EOF
@@ -159,7 +178,7 @@ do_upload() {
 Next:
   cd service
   AWS_PROFILE=... bun scripts/create-microvm-image.ts \\
-    --name codeapi-session \\
+    --name codeapi-${ARTIFACT_KIND} \\
     --artifact "$key" \\
     --build-role <build-role-with-s3+ecr-read> \\
     --region \${AWS_REGION} \\


### PR DESCRIPTION
## Summary

- add a dedicated `lambda-microvm-app-host` image and feature-gated resident-server control API
- restore a stateful workspace revision, then supervise one immutable app revision on a fixed preview port
- isolate the app with a dedicated cgroup, PID/memory limits, a no-new-privileges UID/GID/capability drop, and fail-closed IPv4/IPv6 outbound rules
- serialize unexpected-exit cgroup cleanup with start/stop so an old sweep cannot kill a replacement revision
- disable ordinary `/execute` work on app-host images and bind every control operation to the authenticated runtime session
- extend the provenance-checked Lambda artifact builder and runbook for the separate app-host image

## Boundary

This is the Lambda resident-server adapter and image/runtime contract. The fleet-level app lease registry and owner-authenticated preview gateway are delivered by stacked PR #58; raw AWS endpoints/tokens are explicitly not exposed by this PR.

## Verification

- `env -u AWS_CA_BUNDLE bun test` in `api` — 366 pass, 16 skipped, 0 failed
- focused hosted-app supervisor + route tests — 13 pass
- `bash -n` for both Lambda artifact builder and hosted-app launcher
- exact-head CI — 5/5 green at `7aaab6c`

`bun test` without unsetting the workstation-provided `AWS_CA_BUNDLE` makes three pre-existing hardened-startup tests intentionally reject that inherited secret-like AWS environment variable; the clean-env run above passes the full suite.