### PR TITLE
fix(codeapi): add UTF-8 charset defaults to busboy in upload routes

### DIFF
--- a/service/src/service/router.ts
+++ b/service/src/service/router.ts
@@ -365,6 +365,8 @@ router.post('/upload', uploadLimiter, async (req: t.AuthenticatedRequest, res: R
     const bb = busboy({
       headers: req.headers,
       limits: { fileSize: planFileSize },
+      defCharset: 'utf8',
+      defParamCharset: 'utf8',
       preservePath: true,
     });
 
@@ -575,6 +577,8 @@ router.post('/upload/batch', uploadLimiter, async (req: t.AuthenticatedRequest, 
     const bb = busboy({
       headers: req.headers,
       limits: { fileSize: planFileSize, files: MAX_BATCH_FILES },
+      defCharset: 'utf8',
+      defParamCharset: 'utf8',
       preservePath: true,
     });
 


### PR DESCRIPTION
## Problem

Non-ASCII filenames (e.g. Japanese characters like `日本語テスト.md`) uploaded
through the `/upload` and `/upload/batch` endpoints are garbled because
`busboy` defaults to `Latin-1` (ISO-8859-1) for parameter charset decoding.

For example, `日本語` becomes `æ—¥æœ¬èªž`.

## Root Cause

The `file-server.ts` already sets `defCharset: 'utf8'` and
`defParamCharset: 'utf8'` when constructing busboy ([line 336-337](https://github.com/LibreChat-AI/code-interpreter/blob/main/service/src/file-server.ts#L336-L337)), but
the same options are missing from the two `busboy()` calls in `router.ts`:
- `/upload` endpoint ([line ~365](https://github.com/LibreChat-AI/code-interpreter/blob/main/service/src/service/router.ts#L365))
- `/upload/batch` endpoint ([line ~575](https://github.com/LibreChat-AI/code-interpreter/blob/main/service/src/service/router.ts#L575))

This asymmetry causes filenames to be correctly decoded in the file-server
path but garbled in the API gateway upload path.

## Fix

Add `defCharset: 'utf8'` and `defParamCharset: 'utf8'` to both `busboy()`
calls in `router.ts`, consistent with the existing `file-server.ts` configuration.

## Testing

Verified by uploading files with Japanese filenames (e.g. `Github_Code_Reviewer_日本語_-saved.md`)
through the `/upload` endpoint and confirming the filename is correctly preserved without garbling.

## Changes

- `service/src/service/router.ts`: Added `defCharset: 'utf8'` and `defParamCharset: 'utf8'` to 2 busboy constructor calls