### PR TITLE
🧰 feat: Add Stateful Runtime Supervisor

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -3,11 +3,11 @@
 Provider-neutral protocol and worker CLI for attaching a stateful, sandboxed
 code environment to LibreChat Code API.
 
-The CLI is a transport bridge, not a sandbox. Run it beside a Code Interpreter
-sandbox (NsJail for trusted local development, or the hardened microVM stack for
-untrusted internet traffic). It connects outbound to Code API, long-polls for
-assignments, forwards them to the local sandbox, and returns fenced results.
-The VM does not need an inbound public port.
+The CLI owns the runtime-supervisor seam. The bundled endpoint adapter connects
+to an already-running loopback Code Interpreter sandbox; future adapters create
+and isolate the runtime themselves. It connects outbound to Code API,
+long-polls for assignments, sends them to the local runtime, and returns fenced
+results. The VM does not need an inbound public port.
 
 ## Pair
 
@@ -58,8 +58,9 @@ Optional environment variables:
 - `LIBRECHAT_CODE_POLICY`: local policy description hashed into the worker's
   registration; defaults to `default-deny`.
 - `LIBRECHAT_CODE_STATEFUL_WORKSPACE`: defaults to `false`. Set it to `true`
-  only when the local sandbox supervisor provides a distinct persistent runner
-  for every runtime session. In that mode the endpoint must contain a
+  only when the local runtime supervisor provides a distinct persistent runner
+  for every runtime session. The bundled endpoint adapter requires the endpoint
+  to contain a
   `{runtimeSessionId}` placeholder, for example
   `http://127.0.0.1:2000/sessions/{runtimeSessionId}/api/v2`. The worker URL-
   encodes and substitutes the assigned session ID before execution. Hintless
@@ -68,7 +69,9 @@ Optional environment variables:
 
 A single built-in sandbox runner binds itself to one runtime session and must
 not be advertised as stateful. Use the default stateless capability until a
-session-routing supervisor is configured.
+session-routing supervisor is configured. The endpoint adapter is a
+compatibility adapter: it validates and routes a session but cannot create,
+discard, or attest the underlying sandbox on its own.
 
 Static worker authentication is rejected when Code API hardened mode is
 enabled. Expose only the sandbox loopback endpoint to the CLI, and enforce

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -18,6 +18,10 @@
     "./worker": {
       "types": "./dist/worker.d.ts",
       "import": "./dist/worker.js"
+    },
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "import": "./dist/runtime.js"
     }
   },
   "bin": {

--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -8,6 +8,7 @@ import {
   saveBridgeIdentity,
 } from './storage.js';
 import { BridgeWorker } from './worker.js';
+import { EndpointRuntimeSupervisor } from './runtime.js';
 import {
   isValidBridgeWorkerCapabilities,
   isValidBridgeWorkerId,
@@ -119,7 +120,10 @@ async function run(runtimeSessionId?: string): Promise<void> {
     token: configuredToken,
     identity: workerIdentity,
     workerId,
-    sandboxEndpoint,
+    runtimeSupervisor: new EndpointRuntimeSupervisor({
+      endpoint: sandboxEndpoint,
+      statefulWorkspace,
+    }),
     capabilities,
     onIdentityChange:
       pairedIdentity && identityPath

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -2,4 +2,5 @@ export * from './protocol.js';
 export * from './identity.js';
 export * from './pairing.js';
 export * from './storage.js';
+export * from './runtime.js';
 export * from './worker.js';

--- a/packages/code/src/runtime.test.ts
+++ b/packages/code/src/runtime.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { EndpointRuntimeSupervisor } from './runtime.js';
+
+test('endpoint runtime supervisor resolves an isolated endpoint for stateful work', async () => {
+  const supervisor = new EndpointRuntimeSupervisor({
+    endpoint: 'http://127.0.0.1:2000/sessions/{runtimeSessionId}/api/v2/',
+    statefulWorkspace: true,
+  });
+
+  const lease = await supervisor.acquire({
+    protocolVersion: 1,
+    assignmentId: 'assignment-1',
+    workerId: 'worker-1',
+    incarnationId: 'incarnation-1',
+    generation: 1,
+    leaseToken: 'lease-token',
+    expiresAt: new Date().toISOString(),
+    runtimeSessionId: 'rt/user 1',
+    request: { body: {}, headers: {} },
+  });
+
+  assert.equal(lease.sessionId, 'rt/user 1');
+  assert.equal(
+    lease.endpoint,
+    'http://127.0.0.1:2000/sessions/rt%2Fuser%201/api/v2',
+  );
+});
+
+test('endpoint runtime supervisor refuses stateful work without an isolated route', async () => {
+  const supervisor = new EndpointRuntimeSupervisor({
+    endpoint: 'http://127.0.0.1:2000/api/v2',
+    statefulWorkspace: true,
+  });
+
+  await assert.rejects(
+    supervisor.acquire({
+      protocolVersion: 1,
+      assignmentId: 'assignment-1',
+      workerId: 'worker-1',
+      incarnationId: 'incarnation-1',
+      generation: 1,
+      leaseToken: 'lease-token',
+      expiresAt: new Date().toISOString(),
+      runtimeSessionId: 'rt-1',
+      request: { body: {}, headers: {} },
+    }),
+    /runtime supervisor endpoint containing/,
+  );
+});
+
+test('endpoint runtime supervisor gives stateless work an ephemeral session route', async () => {
+  const supervisor = new EndpointRuntimeSupervisor({
+    endpoint: 'http://127.0.0.1:2000/sessions/{runtimeSessionId}/api/v2',
+    statefulWorkspace: false,
+  });
+
+  const lease = await supervisor.acquire({
+    protocolVersion: 1,
+    assignmentId: 'assignment-1',
+    workerId: 'worker-1',
+    incarnationId: 'incarnation-1',
+    generation: 1,
+    leaseToken: 'lease-token',
+    expiresAt: new Date().toISOString(),
+    request: { body: {}, headers: {} },
+  });
+
+  assert.equal(lease.sessionId, 'assignment-assignment-1');
+  assert.equal(
+    lease.endpoint,
+    'http://127.0.0.1:2000/sessions/assignment-assignment-1/api/v2',
+  );
+});

--- a/packages/code/src/runtime.ts
+++ b/packages/code/src/runtime.ts
@@ -11,7 +11,7 @@ export interface RuntimeLease {
 export interface RuntimeSupervisor {
   acquire(assignment: BridgeAssignment, signal?: AbortSignal): Promise<RuntimeLease>;
   reset(runtimeSessionId: string, signal?: AbortSignal): Promise<void>;
-  quarantine?(runtimeSessionId: string, reason: string, cause?: unknown): Promise<void>;
+  quarantine(runtimeSessionId: string, reason: string, cause?: unknown): Promise<void>;
 }
 
 export interface EndpointRuntimeSupervisorOptions {
@@ -68,4 +68,8 @@ export class EndpointRuntimeSupervisor implements RuntimeSupervisor {
   }
 
   async reset(_runtimeSessionId: string): Promise<void> {}
+
+  async quarantine(runtimeSessionId: string, _reason: string, _cause?: unknown): Promise<void> {
+    await this.reset(runtimeSessionId);
+  }
 }

--- a/packages/code/src/runtime.ts
+++ b/packages/code/src/runtime.ts
@@ -1,0 +1,71 @@
+import type { BridgeAssignment } from './protocol.js';
+
+export const RUNTIME_SESSION_PLACEHOLDER = '{runtimeSessionId}';
+
+export interface RuntimeLease {
+  endpoint: string;
+  sessionId?: string;
+  release?(): Promise<void>;
+}
+
+export interface RuntimeSupervisor {
+  acquire(assignment: BridgeAssignment, signal?: AbortSignal): Promise<RuntimeLease>;
+  reset(runtimeSessionId: string, signal?: AbortSignal): Promise<void>;
+  quarantine?(runtimeSessionId: string, reason: string, cause?: unknown): Promise<void>;
+}
+
+export interface EndpointRuntimeSupervisorOptions {
+  endpoint: string;
+  statefulWorkspace: boolean;
+}
+
+function normalizedEndpoint(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function assignmentSessionId(assignment: BridgeAssignment): string | undefined {
+  if (assignment.runtimeSessionId != null) return assignment.runtimeSessionId;
+  if (assignment.assignmentId.length === 0) return undefined;
+  return `assignment-${assignment.assignmentId}`;
+}
+
+/**
+ * Compatibility adapter for an already-running loopback sandbox supervisor.
+ * New runtime adapters own provisioning and return the same lease shape.
+ */
+export class EndpointRuntimeSupervisor implements RuntimeSupervisor {
+  private readonly endpoint: string;
+
+  constructor(private readonly options: EndpointRuntimeSupervisorOptions) {
+    this.endpoint = normalizedEndpoint(options.endpoint);
+    if (this.endpoint.length === 0) {
+      throw new Error('Runtime supervisor endpoint is required');
+    }
+  }
+
+  async acquire(assignment: BridgeAssignment): Promise<RuntimeLease> {
+    const sessionId = assignmentSessionId(assignment);
+    if (assignment.runtimeSessionId != null) {
+      if (!this.options.statefulWorkspace) {
+        throw new Error('Stateful assignments require a stateful runtime supervisor');
+      }
+      if (!this.endpoint.includes(RUNTIME_SESSION_PLACEHOLDER)) {
+        throw new Error(
+          'Stateful assignments require a runtime supervisor endpoint containing {runtimeSessionId}',
+        );
+      }
+    }
+    if (sessionId == null || !this.endpoint.includes(RUNTIME_SESSION_PLACEHOLDER)) {
+      return { endpoint: this.endpoint };
+    }
+    return {
+      endpoint: this.endpoint.replace(
+        RUNTIME_SESSION_PLACEHOLDER,
+        encodeURIComponent(sessionId),
+      ),
+      sessionId,
+    };
+  }
+
+  async reset(_runtimeSessionId: string): Promise<void> {}
+}

--- a/packages/code/src/worker.test.ts
+++ b/packages/code/src/worker.test.ts
@@ -8,6 +8,7 @@ import {
 } from './worker.js';
 
 import type { BridgeAssignment } from './protocol.js';
+import type { RuntimeSupervisor } from './runtime.js';
 
 const incarnationId = 'incarnation-00000001';
 
@@ -81,6 +82,115 @@ test('worker forwards a fenced assignment to the sandbox and settles the result'
     status: 'fulfilled',
     result: { session_id: 'run-1', files: [] },
   });
+});
+
+test('worker delegates runtime acquisition, release, and reset to its supervisor', async () => {
+  const calls: string[] = [];
+  const supervisor: RuntimeSupervisor = {
+    async acquire(assignment) {
+      calls.push(`acquire:${assignment.runtimeSessionId}`);
+      return {
+        endpoint: 'http://127.0.0.1:3000/runtime',
+        sessionId: assignment.runtimeSessionId,
+        async release() {
+          calls.push(`release:${assignment.runtimeSessionId}`);
+        },
+      };
+    },
+    async reset(runtimeSessionId) {
+      calls.push(`reset:${runtimeSessionId}`);
+    },
+  };
+  const worker = new BridgeWorker({
+    codeApiUrl: 'https://code.example/v1',
+    token: 'worker-secret',
+    workerId: 'vm-1',
+    incarnationId,
+    runtimeSupervisor: supervisor,
+    capabilities: {
+      statefulWorkspace: true,
+      sandboxProfile: 'oci',
+      runtimes: ['bash'],
+    },
+    fetchImpl: async (input) => {
+      const url = String(input);
+      if (url.endsWith('/execute')) {
+        assert.equal(url, 'http://127.0.0.1:3000/runtime/execute');
+        return Response.json({ session_id: 'run-1', files: [] });
+      }
+      return Response.json({ protocolVersion: 1, accepted: true });
+    },
+  });
+  const assignment: BridgeAssignment = {
+    protocolVersion: 1,
+    assignmentId: 'assignment-1',
+    workerId: 'vm-1',
+    incarnationId,
+    generation: 1,
+    leaseToken: 'lease-token-that-is-long-enough-for-testing',
+    expiresAt: new Date(Date.now() + 5_000).toISOString(),
+    runtimeSessionId: 'rt-user-1',
+    request: { body: { language: 'bash' }, headers: {} },
+  };
+
+  await worker.executeAndSettle(assignment);
+  await worker.resetWorkspace('rt-user-1');
+
+  assert.deepEqual(calls, [
+    'acquire:rt-user-1',
+    'release:rt-user-1',
+    'reset:rt-user-1',
+  ]);
+});
+
+test('worker asks its supervisor to quarantine an ambiguous stateful runtime', async () => {
+  const quarantined: Array<{ sessionId: string; reason: string }> = [];
+  const supervisor: RuntimeSupervisor = {
+    async acquire() {
+      return { endpoint: 'http://127.0.0.1:3000/runtime', sessionId: 'rt-user-1' };
+    },
+    async reset() {},
+    async quarantine(sessionId, reason) {
+      quarantined.push({ sessionId, reason });
+    },
+  };
+  const worker = new BridgeWorker({
+    codeApiUrl: 'https://code.example/v1',
+    token: 'worker-secret',
+    workerId: 'vm-1',
+    incarnationId,
+    runtimeSupervisor: supervisor,
+    capabilities: {
+      statefulWorkspace: true,
+      sandboxProfile: 'oci',
+      runtimes: ['bash'],
+    },
+    fetchImpl: async (input) => {
+      if (String(input).endsWith('/execute')) {
+        throw new TypeError('connection reset');
+      }
+      return Response.json({ protocolVersion: 1, accepted: true });
+    },
+  });
+
+  await assert.rejects(
+    worker.executeAndSettle({
+      protocolVersion: 1,
+      assignmentId: 'assignment-1',
+      workerId: 'vm-1',
+      incarnationId,
+      generation: 1,
+      leaseToken: 'lease-token-that-is-long-enough-for-testing',
+      expiresAt: new Date(Date.now() + 5_000).toISOString(),
+      runtimeSessionId: 'rt-user-1',
+      request: { body: { language: 'bash' }, headers: {} },
+    }),
+    BridgeWorkspaceQuarantinedError,
+  );
+
+  assert.equal(quarantined.length, 1);
+  assert.equal(quarantined[0]?.sessionId, 'rt-user-1');
+  assert.match(quarantined[0]?.reason ?? '', /ambiguous sandbox execution/);
 });
 
 test('worker acknowledges a discarded workspace through the reset endpoint', async () => {

--- a/packages/code/src/worker.test.ts
+++ b/packages/code/src/worker.test.ts
@@ -100,6 +100,7 @@ test('worker delegates runtime acquisition, release, and reset to its supervisor
     async reset(runtimeSessionId) {
       calls.push(`reset:${runtimeSessionId}`);
     },
+    async quarantine() {},
   };
   const worker = new BridgeWorker({
     codeApiUrl: 'https://code.example/v1',

--- a/packages/code/src/worker.ts
+++ b/packages/code/src/worker.ts
@@ -590,7 +590,10 @@ export class BridgeWorker {
         assignment,
         executionController.signal,
       );
-      const sandboxExecuteUrl = `${runtimeLease.endpoint}/execute`;
+      if (executionController.signal.aborted) {
+        throw executionController.signal.reason ?? new DOMException('aborted', 'AbortError');
+      }
+      const sandboxExecuteUrl = `${runtimeLease.endpoint.replace(/\/+$/, '')}/execute`;
       const headers = {
         ...assignment.request.headers,
         ...(runtimeLease.sessionId
@@ -717,10 +720,13 @@ export class BridgeWorker {
         );
       }
     } finally {
-      await this.releaseRuntimeLease(runtimeLease, assignment);
       heartbeatController.abort();
-      await heartbeat;
-      signal?.removeEventListener('abort', abortExecution);
+      try {
+        await this.releaseRuntimeLease(runtimeLease, assignment);
+      } finally {
+        await heartbeat;
+        signal?.removeEventListener('abort', abortExecution);
+      }
     }
   }
 
@@ -760,7 +766,7 @@ export class BridgeWorker {
       return new BridgeWorkspaceQuarantinedError(message, cause);
     }
     try {
-      await this.runtimeSupervisor.quarantine?.(runtimeSessionId, message, cause);
+      await this.runtimeSupervisor.quarantine(runtimeSessionId, message, cause);
       return new BridgeWorkspaceQuarantinedError(message, cause);
     } catch (error) {
       return new BridgeWorkspaceQuarantinedError(

--- a/packages/code/src/worker.ts
+++ b/packages/code/src/worker.ts
@@ -5,6 +5,7 @@ import {
   BridgeProtocolError,
   bridgeWorkerPath,
 } from './protocol.js';
+import { EndpointRuntimeSupervisor } from './runtime.js';
 import { signBridgeRequest } from './identity.js';
 
 import type {
@@ -16,13 +17,16 @@ import type {
   BridgeWorkerCredentialResponse,
   BridgeWorkerRegistrationResponse,
 } from './protocol.js';
+import type { RuntimeLease, RuntimeSupervisor } from './runtime.js';
 
 export interface BridgeWorkerOptions {
   codeApiUrl: string;
   token?: string;
   identity?: BridgeWorkerIdentity;
   workerId: string;
-  sandboxEndpoint: string;
+  /** @deprecated Use runtimeSupervisor for new runtime adapters. */
+  sandboxEndpoint?: string;
+  runtimeSupervisor?: RuntimeSupervisor;
   capabilities: BridgeWorkerCapabilities;
   leaseWaitMs?: number;
   leaseTransportGraceMs?: number;
@@ -67,7 +71,6 @@ const CREDENTIAL_REFRESH_RETRY_DELAY_MS = 100;
 const SETTLEMENT_RETRY_DELAY_MS = 100;
 const REJECTION_ACK_GRACE_MS = 30_000;
 const MAX_SETTLEMENT_ERROR_LENGTH = 4_096;
-const RUNTIME_SESSION_PLACEHOLDER = '{runtimeSessionId}';
 
 export function reconnectDelayMs(
   attempt: number,
@@ -121,7 +124,7 @@ export class BridgeWorkspaceQuarantinedError extends Error {
 export class BridgeWorker {
   private readonly fetchImpl: typeof fetch;
   private readonly codeApiUrl: string;
-  private readonly sandboxEndpoint: string;
+  private readonly runtimeSupervisor: RuntimeSupervisor;
   private readonly incarnationId: string;
   private registrationTtlMs = DEFAULT_REGISTRATION_TTL_MS;
   private lastRegisteredAtMs = 0;
@@ -133,9 +136,22 @@ export class BridgeWorker {
         'Bridge worker requires a static token or paired identity',
       );
     }
+    if (options.runtimeSupervisor != null && options.sandboxEndpoint != null) {
+      throw new BridgeProtocolError(
+        'Bridge worker accepts either a runtime supervisor or sandbox endpoint, not both',
+      );
+    }
+    if (options.runtimeSupervisor == null && !options.sandboxEndpoint?.trim()) {
+      throw new BridgeProtocolError('Bridge worker requires a runtime supervisor');
+    }
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.codeApiUrl = normalizedBaseUrl(options.codeApiUrl);
-    this.sandboxEndpoint = normalizedBaseUrl(options.sandboxEndpoint);
+    this.runtimeSupervisor =
+      options.runtimeSupervisor ??
+      new EndpointRuntimeSupervisor({
+        endpoint: options.sandboxEndpoint ?? '',
+        statefulWorkspace: options.capabilities.statefulWorkspace,
+      });
     this.incarnationId =
       options.incarnationId ?? randomBytes(18).toString('base64url');
   }
@@ -197,6 +213,7 @@ export class BridgeWorker {
     if (runtimeSessionId.trim().length === 0) {
       throw new BridgeProtocolError('Runtime session ID is required');
     }
+    await this.runtimeSupervisor.reset(runtimeSessionId, signal);
     await this.timedRequest(
       `${this.codeApiUrl}${bridgeWorkerPath(this.options.workerId)}/workspaces/reset`,
       {
@@ -558,6 +575,7 @@ export class BridgeWorker {
     let ambiguousSandboxError: unknown;
     let sandboxRejectedExecution = false;
     let sandboxStarted = false;
+    let runtimeLease: RuntimeLease | undefined;
     try {
       credentialMaintenance = this.maintainCredential(
         assignment,
@@ -568,13 +586,15 @@ export class BridgeWorker {
         credentialMaintenanceError = error;
         executionController.abort();
       });
-      const sandboxExecuteUrl =
-        `${this.sandboxEndpointFor(assignment)}/execute`;
-      const sandboxSessionId = this.sandboxSessionIdFor(assignment);
+      runtimeLease = await this.runtimeSupervisor.acquire(
+        assignment,
+        executionController.signal,
+      );
+      const sandboxExecuteUrl = `${runtimeLease.endpoint}/execute`;
       const headers = {
         ...assignment.request.headers,
-        ...(sandboxSessionId
-          ? { 'X-Runtime-Session-Id': sandboxSessionId }
+        ...(runtimeLease.sessionId
+          ? { 'X-Runtime-Session-Id': runtimeLease.sessionId }
           : {}),
       };
       const sandboxRequestBody = JSON.stringify(assignment.request.body);
@@ -656,7 +676,8 @@ export class BridgeWorker {
     await credentialMaintenance;
     try {
       if (ambiguousSandboxError != null) {
-        throw new BridgeWorkspaceQuarantinedError(
+        throw await this.quarantineWorkspace(
+          assignment.runtimeSessionId,
           `Stateful workspace ${assignment.runtimeSessionId} was quarantined after an ambiguous sandbox execution`,
           ambiguousSandboxError,
         );
@@ -696,22 +717,11 @@ export class BridgeWorker {
         );
       }
     } finally {
+      await this.releaseRuntimeLease(runtimeLease, assignment);
       heartbeatController.abort();
       await heartbeat;
       signal?.removeEventListener('abort', abortExecution);
     }
-  }
-
-  private sandboxSessionIdFor(
-    assignment: BridgeAssignment,
-  ): string | undefined {
-    if (assignment.runtimeSessionId != null) {
-      return assignment.runtimeSessionId;
-    }
-    if (this.sandboxEndpoint.includes(RUNTIME_SESSION_PLACEHOLDER)) {
-      return `assignment-${assignment.assignmentId}`;
-    }
-    return undefined;
   }
 
   private assignmentRemainingMs(assignment: BridgeAssignment): number {
@@ -724,28 +734,40 @@ export class BridgeWorker {
     return Math.max(0, Date.parse(assignment.expiresAt) - Date.now());
   }
 
-  private sandboxEndpointFor(assignment: BridgeAssignment): string {
-    if (assignment.runtimeSessionId == null) {
-      if (!this.sandboxEndpoint.includes(RUNTIME_SESSION_PLACEHOLDER)) {
-        return this.sandboxEndpoint;
-      }
-      return this.sandboxEndpoint.replace(
-        RUNTIME_SESSION_PLACEHOLDER,
-        encodeURIComponent(`assignment-${assignment.assignmentId}`),
+  private async releaseRuntimeLease(
+    lease: RuntimeLease | undefined,
+    assignment: BridgeAssignment,
+  ): Promise<void> {
+    if (lease?.release == null) return;
+    try {
+      await lease.release();
+    } catch (error) {
+      if (assignment.runtimeSessionId == null) throw error;
+      throw await this.quarantineWorkspace(
+        assignment.runtimeSessionId,
+        `Stateful workspace ${assignment.runtimeSessionId} could not release its runtime lease`,
+        error,
       );
     }
-    if (
-      this.options.capabilities.statefulWorkspace !== true ||
-      !this.sandboxEndpoint.includes(RUNTIME_SESSION_PLACEHOLDER)
-    ) {
-      throw new BridgeProtocolError(
-        'Stateful assignments require a sandbox endpoint template containing {runtimeSessionId}',
+  }
+
+  private async quarantineWorkspace(
+    runtimeSessionId: string | undefined,
+    message: string,
+    cause?: unknown,
+  ): Promise<BridgeWorkspaceQuarantinedError> {
+    if (runtimeSessionId == null) {
+      return new BridgeWorkspaceQuarantinedError(message, cause);
+    }
+    try {
+      await this.runtimeSupervisor.quarantine?.(runtimeSessionId, message, cause);
+      return new BridgeWorkspaceQuarantinedError(message, cause);
+    } catch (error) {
+      return new BridgeWorkspaceQuarantinedError(
+        `${message}; local runtime quarantine could not be confirmed`,
+        error,
       );
     }
-    return this.sandboxEndpoint.replace(
-      RUNTIME_SESSION_PLACEHOLDER,
-      encodeURIComponent(assignment.runtimeSessionId),
-    );
   }
 
   private async delay(ms: number, signal: AbortSignal): Promise<void> {
@@ -831,7 +853,8 @@ export class BridgeWorker {
   ): Promise<void> {
     if (signal?.aborted === true) {
       if (assignment.runtimeSessionId != null) {
-        throw new BridgeWorkspaceQuarantinedError(
+        throw await this.quarantineWorkspace(
+          assignment.runtimeSessionId,
           `Stateful workspace ${assignment.runtimeSessionId} was quarantined before settlement during shutdown`,
           signal.reason,
         );
@@ -871,7 +894,8 @@ export class BridgeWorker {
               assignment.runtimeSessionId != null &&
               settlement.status === 'fulfilled'
             ) {
-              throw new BridgeWorkspaceQuarantinedError(
+              throw await this.quarantineWorkspace(
+                assignment.runtimeSessionId,
                 `Stateful workspace ${assignment.runtimeSessionId} was quarantined after Code API rejected its fulfilled settlement`,
                 error,
               );
@@ -894,7 +918,8 @@ export class BridgeWorker {
       assignment.runtimeSessionId != null &&
       settlement.status === 'fulfilled'
     ) {
-      throw new BridgeWorkspaceQuarantinedError(
+      throw await this.quarantineWorkspace(
+        assignment.runtimeSessionId,
         `Stateful workspace ${assignment.runtimeSessionId} was quarantined after ambiguous settlement delivery`,
         lastError,
       );


### PR DESCRIPTION
## Summary

I introduced a runtime-supervisor seam for `@librechat/code`, so the bridge worker no longer owns session URL routing or leaves runtime reset/quarantine outside its lifecycle.

- Add a provider-neutral runtime supervisor module with acquisition, release, reset, and quarantine lifecycle hooks.
- Preserve current loopback deployments through an endpoint compatibility adapter.
- Route CLI configuration through the runtime supervisor instead of passing the sandbox endpoint directly to the worker.
- Delegate stateful runtime cleanup and reset before Code API reset acknowledgement.
- Export the runtime module and document the compatibility adapter’s limits.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran `npm test` in `packages/code`.
- Verified 63 focused tests, including runtime acquisition, stateless routing, stateful endpoint validation, release, reset, and quarantine delegation.

### **Test Configuration**:

- Node.js package tests for `@librechat/code`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.