### PR TITLE
🧰 feat: Add Docker Runtime Supervisor

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -37,6 +37,24 @@ Use `--identity <path>` while pairing and
 `LIBRECHAT_CODE_IDENTITY_FILE=<path>` while running to override the identity
 file location.
 
+## Docker runtime supervisor (programmatic adapter)
+
+`DockerRuntimeSupervisor` is the first self-contained local OCI adapter. It
+owns one named container per runtime session, does not publish the runner port,
+starts the container with `--network none`, drops every Linux capability, and
+sets `no-new-privileges`. The trusted worker invokes the runner only through
+`docker exec` to `127.0.0.1` inside that container. The sandbox therefore has
+neither an inbound host port nor network egress.
+
+It is exported for use by a deployment-specific worker launcher. It requires a
+runtime image that provides the Code Interpreter `/api/v2/health` and
+`/api/v2/execute` endpoints and supports
+`SANDBOX_SESSION_WORKSPACE_ENABLED=true`. A dedicated LibreChat runtime image
+and CLI selector are the next layer; this adapter intentionally does not turn
+an arbitrary image into a supported security boundary. Image-specific Linux
+capabilities must be explicitly configured by the trusted launcher; the
+default grants none.
+
 ## Static compatibility mode
 
 Non-hardened development deployments may still run with a static token:

--- a/packages/code/src/runtime.test.ts
+++ b/packages/code/src/runtime.test.ts
@@ -67,7 +67,7 @@ test('docker runtime supervisor creates a networkless stateful runtime and execu
     async run(args) {
       calls.push(args);
       if (args[0] === 'container' && args[1] === 'inspect') {
-        throw new Error('container missing');
+        throw new Error('No such container');
       }
       if (args[0] === 'run') return 'container-id\n';
       if (args[0] === 'exec' && args.some(value => value.includes('/api/v2/health'))) return '200';
@@ -103,12 +103,16 @@ test('docker runtime supervisor creates a networkless stateful runtime and execu
     'no-new-privileges:true',
   ]);
   assert.equal(run?.includes('rt-user-1'), false);
+  const health = calls.find(
+    args => args[0] === 'exec' && args.some(value => value.includes('/api/v2/health')),
+  );
+  assert.ok(health?.includes('--max-time'));
 });
 
 test('docker runtime supervisor rejects malformed runtime response framing', async () => {
   const client: ContainerRuntimeClient = {
     async run(args) {
-      if (args[0] === 'container' && args[1] === 'inspect') throw new Error('container missing');
+      if (args[0] === 'container' && args[1] === 'inspect') throw new Error('No such container');
       if (args[0] === 'run') return 'container-id\n';
       if (args[0] === 'exec' && args.some(value => value.includes('/api/v2/health'))) return '200';
       if (args[0] === 'exec' && args.some(value => value.includes('/api/v2/execute'))) return 'not framed';
@@ -124,12 +128,61 @@ test('docker runtime supervisor rejects malformed runtime response framing', asy
   await assert.rejects(execute({ body: '{}', headers: {} }), /invalid HTTP response/);
 });
 
+test('docker runtime supervisor preserves an existing stateful container after a health failure', async () => {
+  const calls: string[][] = [];
+  const client: ContainerRuntimeClient = {
+    async run(args) {
+      calls.push(args);
+      if (args[0] === 'container' && args[1] === 'inspect') return 'true\n';
+      if (args[0] === 'exec') throw new Error('runner unavailable');
+      throw new Error(`Unexpected Docker command: ${args.join(' ')}`);
+    },
+  };
+  const supervisor = new DockerRuntimeSupervisor({
+    image: 'example/code-runtime:latest',
+    client,
+    startupTimeoutMs: 1,
+  });
+
+  await assert.rejects(supervisor.acquire(assignment('rt-user-1')), /did not become healthy/);
+  assert.equal(calls.some(args => args[0] === 'container' && args[1] === 'rm'), false);
+});
+
+test('docker runtime supervisor propagates removal failures and forwards reset cancellation', async () => {
+  const controller = new AbortController();
+  let receivedSignal: AbortSignal | undefined;
+  const client: ContainerRuntimeClient = {
+    async run(args, options) {
+      if (args[0] === 'container' && args[1] === 'rm') {
+        receivedSignal = options?.signal;
+        throw new Error('Docker daemon unavailable');
+      }
+      throw new Error(`Unexpected Docker command: ${args.join(' ')}`);
+    },
+  };
+  const supervisor = new DockerRuntimeSupervisor({ image: 'example/code-runtime:latest', client });
+
+  await assert.rejects(supervisor.reset('rt-user-1', controller.signal), /Docker daemon unavailable/);
+  assert.equal(receivedSignal, controller.signal);
+});
+
+test('docker runtime supervisor ignores only confirmed missing-container removal', async () => {
+  const client: ContainerRuntimeClient = {
+    async run() {
+      throw new Error('Error response from daemon: No such container: runtime');
+    },
+  };
+  const supervisor = new DockerRuntimeSupervisor({ image: 'example/code-runtime:latest', client });
+
+  await supervisor.reset('rt-user-1');
+});
+
 test('docker runtime supervisor destroys stateless and reset stateful runtimes', async () => {
   const calls: string[][] = [];
   const client: ContainerRuntimeClient = {
     async run(args) {
       calls.push(args);
-      if (args[0] === 'container' && args[1] === 'inspect') throw new Error('container missing');
+      if (args[0] === 'container' && args[1] === 'inspect') throw new Error('No such container');
       if (args[0] === 'run') return 'container-id\n';
       if (args[0] === 'exec' && args.some(value => value.includes('/api/v2/health'))) return '200';
       if (args[0] === 'container' && args[1] === 'rm') return 'removed\n';

--- a/packages/code/src/runtime.test.ts
+++ b/packages/code/src/runtime.test.ts
@@ -1,7 +1,23 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { EndpointRuntimeSupervisor } from './runtime.js';
+import { DockerRuntimeSupervisor, EndpointRuntimeSupervisor } from './runtime.js';
+
+import type { ContainerRuntimeClient } from './runtime.js';
+
+function assignment(runtimeSessionId?: string) {
+  return {
+    protocolVersion: 1 as const,
+    assignmentId: 'assignment-1',
+    workerId: 'worker-1',
+    incarnationId: 'incarnation-1',
+    generation: 1,
+    leaseToken: 'lease-token',
+    expiresAt: new Date().toISOString(),
+    ...(runtimeSessionId ? { runtimeSessionId } : {}),
+    request: { body: {}, headers: {} },
+  };
+}
 
 test('endpoint runtime supervisor resolves an isolated endpoint for stateful work', async () => {
   const supervisor = new EndpointRuntimeSupervisor({
@@ -9,17 +25,7 @@ test('endpoint runtime supervisor resolves an isolated endpoint for stateful wor
     statefulWorkspace: true,
   });
 
-  const lease = await supervisor.acquire({
-    protocolVersion: 1,
-    assignmentId: 'assignment-1',
-    workerId: 'worker-1',
-    incarnationId: 'incarnation-1',
-    generation: 1,
-    leaseToken: 'lease-token',
-    expiresAt: new Date().toISOString(),
-    runtimeSessionId: 'rt/user 1',
-    request: { body: {}, headers: {} },
-  });
+  const lease = await supervisor.acquire(assignment('rt/user 1'));
 
   assert.equal(lease.sessionId, 'rt/user 1');
   assert.equal(
@@ -35,17 +41,7 @@ test('endpoint runtime supervisor refuses stateful work without an isolated rout
   });
 
   await assert.rejects(
-    supervisor.acquire({
-      protocolVersion: 1,
-      assignmentId: 'assignment-1',
-      workerId: 'worker-1',
-      incarnationId: 'incarnation-1',
-      generation: 1,
-      leaseToken: 'lease-token',
-      expiresAt: new Date().toISOString(),
-      runtimeSessionId: 'rt-1',
-      request: { body: {}, headers: {} },
-    }),
+    supervisor.acquire(assignment('rt-1')),
     /runtime supervisor endpoint containing/,
   );
 });
@@ -56,20 +52,101 @@ test('endpoint runtime supervisor gives stateless work an ephemeral session rout
     statefulWorkspace: false,
   });
 
-  const lease = await supervisor.acquire({
-    protocolVersion: 1,
-    assignmentId: 'assignment-1',
-    workerId: 'worker-1',
-    incarnationId: 'incarnation-1',
-    generation: 1,
-    leaseToken: 'lease-token',
-    expiresAt: new Date().toISOString(),
-    request: { body: {}, headers: {} },
-  });
+  const lease = await supervisor.acquire(assignment());
 
   assert.equal(lease.sessionId, 'assignment-assignment-1');
   assert.equal(
     lease.endpoint,
     'http://127.0.0.1:2000/sessions/assignment-assignment-1/api/v2',
   );
+});
+
+test('docker runtime supervisor creates a networkless stateful runtime and executes through its loopback', async () => {
+  const calls: string[][] = [];
+  const client: ContainerRuntimeClient = {
+    async run(args) {
+      calls.push(args);
+      if (args[0] === 'container' && args[1] === 'inspect') {
+        throw new Error('container missing');
+      }
+      if (args[0] === 'run') return 'container-id\n';
+      if (args[0] === 'exec' && args.some(value => value.includes('/api/v2/health'))) return '200';
+      if (args[0] === 'exec' && args.some(value => value.includes('/api/v2/execute'))) {
+        const writeOut = args[args.indexOf('--write-out') + 1] ?? '';
+        return `{"session_id":"run-1"}${writeOut.replace('%{http_code}', '200')}`;
+      }
+      throw new Error(`Unexpected Docker command: ${args.join(' ')}`);
+    },
+  };
+  const supervisor = new DockerRuntimeSupervisor({
+    image: 'example/code-runtime:latest',
+    client,
+  });
+
+  const lease = await supervisor.acquire(assignment('rt-user-1'));
+
+  const result = await lease.execute?.({ body: '{}', headers: { 'X-Test': '1' } });
+  assert.equal(result?.status, 200);
+  assert.equal(result?.body, '{"session_id":"run-1"}');
+  assert.equal(lease.sessionId, 'rt-user-1');
+  const run = calls.find(args => args[0] === 'run');
+  assert.deepEqual(run?.slice(0, 10), [
+    'run',
+    '--detach',
+    '--name',
+    run?.[3] ?? '',
+    '--network',
+    'none',
+    '--cap-drop',
+    'ALL',
+    '--security-opt',
+    'no-new-privileges:true',
+  ]);
+  assert.equal(run?.includes('rt-user-1'), false);
+});
+
+test('docker runtime supervisor rejects malformed runtime response framing', async () => {
+  const client: ContainerRuntimeClient = {
+    async run(args) {
+      if (args[0] === 'container' && args[1] === 'inspect') throw new Error('container missing');
+      if (args[0] === 'run') return 'container-id\n';
+      if (args[0] === 'exec' && args.some(value => value.includes('/api/v2/health'))) return '200';
+      if (args[0] === 'exec' && args.some(value => value.includes('/api/v2/execute'))) return 'not framed';
+      if (args[0] === 'container' && args[1] === 'rm') return 'removed\n';
+      throw new Error(`Unexpected Docker command: ${args.join(' ')}`);
+    },
+  };
+  const supervisor = new DockerRuntimeSupervisor({ image: 'example/code-runtime:latest', client });
+  const lease = await supervisor.acquire(assignment('rt-user-1'));
+
+  const execute = lease.execute;
+  assert.ok(execute);
+  await assert.rejects(execute({ body: '{}', headers: {} }), /invalid HTTP response/);
+});
+
+test('docker runtime supervisor destroys stateless and reset stateful runtimes', async () => {
+  const calls: string[][] = [];
+  const client: ContainerRuntimeClient = {
+    async run(args) {
+      calls.push(args);
+      if (args[0] === 'container' && args[1] === 'inspect') throw new Error('container missing');
+      if (args[0] === 'run') return 'container-id\n';
+      if (args[0] === 'exec' && args.some(value => value.includes('/api/v2/health'))) return '200';
+      if (args[0] === 'container' && args[1] === 'rm') return 'removed\n';
+      throw new Error(`Unexpected Docker command: ${args.join(' ')}`);
+    },
+  };
+  const supervisor = new DockerRuntimeSupervisor({
+    image: 'example/code-runtime:latest',
+    client,
+  });
+
+  const lease = await supervisor.acquire(assignment());
+  await lease.release?.();
+  await supervisor.reset('rt-user-1');
+  await supervisor.quarantine?.('rt-user-2', 'ambiguous result');
+
+  const removals = calls.filter(args => args[0] === 'container' && args[1] === 'rm');
+  assert.equal(removals.length, 3);
+  assert.ok(removals.every(args => args[2] === '--force'));
 });

--- a/packages/code/src/runtime.test.ts
+++ b/packages/code/src/runtime.test.ts
@@ -166,6 +166,25 @@ test('docker runtime supervisor propagates removal failures and forwards reset c
   assert.equal(receivedSignal, controller.signal);
 });
 
+test('docker runtime supervisor cleans up stateless containers after interrupted creation', async () => {
+  const calls: string[][] = [];
+  const client: ContainerRuntimeClient = {
+    async run(args) {
+      calls.push(args);
+      if (args[0] === 'container' && args[1] === 'inspect') {
+        throw new Error('No such container');
+      }
+      if (args[0] === 'run') throw new DOMException('aborted', 'AbortError');
+      if (args[0] === 'container' && args[1] === 'rm') return 'removed\n';
+      throw new Error(`Unexpected Docker command: ${args.join(' ')}`);
+    },
+  };
+  const supervisor = new DockerRuntimeSupervisor({ image: 'example/code-runtime:latest', client });
+
+  await assert.rejects(supervisor.acquire(assignment()), /aborted/);
+  assert.equal(calls.some(args => args[0] === 'container' && args[1] === 'rm'), true);
+});
+
 test('docker runtime supervisor ignores only confirmed missing-container removal', async () => {
   const client: ContainerRuntimeClient = {
     async run() {

--- a/packages/code/src/runtime.ts
+++ b/packages/code/src/runtime.ts
@@ -78,6 +78,11 @@ function containerName(runtimeSessionId: string): string {
   return `${CONTAINER_PREFIX}${containerSuffix(runtimeSessionId)}`;
 }
 
+function isMissingContainerError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /(?:no such container|no such object)/i.test(error.message);
+}
+
 class DockerCliClient implements ContainerRuntimeClient {
   private readonly command: string;
 
@@ -150,7 +155,7 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
     const sessionId = assignmentSessionId(assignment);
     if (sessionId == null) throw new Error('Runtime assignment ID is required');
     const name = containerName(sessionId);
-    await this.ensureContainer(name, sessionId, signal);
+    const created = await this.ensureContainer(name, sessionId, signal);
     try {
       await this.waitForHealth(name, signal);
       return {
@@ -159,13 +164,13 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
         release: assignment.runtimeSessionId == null ? async () => this.remove(name) : undefined,
       };
     } catch (error) {
-      await this.remove(name).catch(() => undefined);
+      if (created) await this.remove(name);
       throw error;
     }
   }
 
-  async reset(runtimeSessionId: string): Promise<void> {
-    await this.remove(containerName(runtimeSessionId));
+  async reset(runtimeSessionId: string, signal?: AbortSignal): Promise<void> {
+    await this.remove(containerName(runtimeSessionId), signal);
   }
 
   async quarantine(
@@ -180,12 +185,12 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
     name: string,
     runtimeSessionId: string,
     signal?: AbortSignal,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const running = await this.containerRunning(name, signal);
-    if (running) return;
+    if (running) return false;
     if (running === false) {
       await this.client.run(['start', name], { signal });
-      return;
+      return false;
     }
     await this.client.run(
       [
@@ -210,6 +215,7 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
       ],
       { signal },
     );
+    return true;
   }
 
   private async containerRunning(name: string, signal?: AbortSignal): Promise<boolean | undefined> {
@@ -219,8 +225,9 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
         { signal },
       );
       return value.trim() === 'true';
-    } catch {
-      return undefined;
+    } catch (error) {
+      if (isMissingContainerError(error)) return undefined;
+      throw error;
     }
   }
 
@@ -230,6 +237,7 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
     while (Date.now() < deadline) {
       if (signal?.aborted) throw signal.reason ?? new DOMException('aborted', 'AbortError');
       try {
+        const remainingMs = Math.max(1, deadline - Date.now());
         const status = await this.client.run(
           [
             'exec',
@@ -237,6 +245,8 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
             'curl',
             '--silent',
             '--show-error',
+            '--max-time',
+            (remainingMs / 1000).toFixed(3),
             '--output',
             '/dev/null',
             '--write-out',
@@ -295,11 +305,11 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
     };
   }
 
-  private async remove(name: string): Promise<void> {
+  private async remove(name: string, signal?: AbortSignal): Promise<void> {
     try {
-      await this.client.run(['container', 'rm', '--force', name]);
-    } catch {
-      // A missing container is the desired reset and quarantine state.
+      await this.client.run(['container', 'rm', '--force', name], { signal });
+    } catch (error) {
+      if (!isMissingContainerError(error)) throw error;
     }
   }
 }

--- a/packages/code/src/runtime.ts
+++ b/packages/code/src/runtime.ts
@@ -110,6 +110,7 @@ class DockerCliClient implements ContainerRuntimeClient {
       };
       process.stdout.on('data', (chunk: Buffer) => append(stdout, chunk));
       process.stderr.on('data', (chunk: Buffer) => append(stderr, chunk));
+      process.stdin.once('error', reject);
       process.once('error', reject);
       process.once('close', (code) => {
         if (code === 0) {
@@ -155,8 +156,9 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
     const sessionId = assignmentSessionId(assignment);
     if (sessionId == null) throw new Error('Runtime assignment ID is required');
     const name = containerName(sessionId);
-    const created = await this.ensureContainer(name, sessionId, signal);
+    let created = false;
     try {
+      created = await this.ensureContainer(name, sessionId, signal);
       await this.waitForHealth(name, signal);
       return {
         sessionId,
@@ -164,7 +166,7 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
         release: assignment.runtimeSessionId == null ? async () => this.remove(name) : undefined,
       };
     } catch (error) {
-      if (created) await this.remove(name);
+      if (created || assignment.runtimeSessionId == null) await this.remove(name);
       throw error;
     }
   }

--- a/packages/code/src/runtime.ts
+++ b/packages/code/src/runtime.ts
@@ -1,11 +1,26 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { spawn } from 'node:child_process';
+
 import type { BridgeAssignment } from './protocol.js';
 
 export const RUNTIME_SESSION_PLACEHOLDER = '{runtimeSessionId}';
 
 export interface RuntimeLease {
-  endpoint: string;
+  endpoint?: string;
   sessionId?: string;
+  execute?(request: RuntimeExecutionRequest): Promise<RuntimeExecutionResponse>;
   release?(): Promise<void>;
+}
+
+export interface RuntimeExecutionRequest {
+  body: string;
+  headers: Record<string, string>;
+  signal?: AbortSignal;
+}
+
+export interface RuntimeExecutionResponse {
+  status: number;
+  body: string;
 }
 
 export interface RuntimeSupervisor {
@@ -19,6 +34,32 @@ export interface EndpointRuntimeSupervisorOptions {
   statefulWorkspace: boolean;
 }
 
+export interface ContainerRuntimeClient {
+  run(args: string[], options?: ContainerRuntimeRunOptions): Promise<string>;
+}
+
+export interface ContainerRuntimeRunOptions {
+  input?: string;
+  signal?: AbortSignal;
+}
+
+export interface DockerRuntimeSupervisorOptions {
+  image: string;
+  capabilities?: string[];
+  dockerCommand?: string;
+  runnerPort?: number;
+  startupTimeoutMs?: number;
+  healthPath?: string;
+  client?: ContainerRuntimeClient;
+}
+
+const DEFAULT_RUNNER_PORT = 2000;
+const DEFAULT_STARTUP_TIMEOUT_MS = 30_000;
+const DEFAULT_HEALTH_PATH = '/api/v2/health';
+const CONTAINER_PREFIX = 'librechat-code-';
+const CAPABILITY_PATTERN = /^[A-Z_]{1,32}$/;
+const MAX_DOCKER_COMMAND_OUTPUT_BYTES = 64 * 1024 * 1024;
+
 function normalizedEndpoint(value: string): string {
   return value.replace(/\/+$/, '');
 }
@@ -27,6 +68,240 @@ function assignmentSessionId(assignment: BridgeAssignment): string | undefined {
   if (assignment.runtimeSessionId != null) return assignment.runtimeSessionId;
   if (assignment.assignmentId.length === 0) return undefined;
   return `assignment-${assignment.assignmentId}`;
+}
+
+function containerSuffix(runtimeSessionId: string): string {
+  return createHash('sha256').update(runtimeSessionId).digest('hex').slice(0, 24);
+}
+
+function containerName(runtimeSessionId: string): string {
+  return `${CONTAINER_PREFIX}${containerSuffix(runtimeSessionId)}`;
+}
+
+class DockerCliClient implements ContainerRuntimeClient {
+  private readonly command: string;
+
+  constructor(command = 'docker') {
+    this.command = command;
+  }
+
+  async run(args: string[], options: ContainerRuntimeRunOptions = {}): Promise<string> {
+    return await new Promise<string>((resolve, reject) => {
+      const process = spawn(this.command, args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        signal: options.signal,
+      });
+      const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
+      let outputBytes = 0;
+      const append = (chunks: Buffer[], chunk: Buffer): void => {
+        outputBytes += chunk.length;
+        if (outputBytes > MAX_DOCKER_COMMAND_OUTPUT_BYTES) {
+          process.kill('SIGKILL');
+          reject(new Error('Docker runtime command exceeded its output limit'));
+          return;
+        }
+        chunks.push(chunk);
+      };
+      process.stdout.on('data', (chunk: Buffer) => append(stdout, chunk));
+      process.stderr.on('data', (chunk: Buffer) => append(stderr, chunk));
+      process.once('error', reject);
+      process.once('close', (code) => {
+        if (code === 0) {
+          resolve(Buffer.concat(stdout).toString('utf8'));
+          return;
+        }
+        const detail = Buffer.concat(stderr).toString('utf8').slice(0, 4096);
+        reject(new Error(`Docker runtime command exited ${code ?? 'unknown'}${detail ? `: ${detail}` : ''}`));
+      });
+      process.stdin.end(options.input);
+    });
+  }
+}
+
+/**
+ * Local OCI runtime adapter. The supervisor, not the sandbox container, talks
+ * to Docker. Each runtime has no network, and the trusted worker reaches its
+ * loopback API through Docker exec; stateful containers survive leases until
+ * reset or quarantine.
+ */
+export class DockerRuntimeSupervisor implements RuntimeSupervisor {
+  private readonly client: ContainerRuntimeClient;
+  private readonly runnerPort: number;
+  private readonly startupTimeoutMs: number;
+  private readonly healthPath: string;
+  private readonly capabilities: string[];
+
+  constructor(private readonly options: DockerRuntimeSupervisorOptions) {
+    if (options.image.trim().length === 0) {
+      throw new Error('Docker runtime image is required');
+    }
+    if (options.capabilities?.some((capability) => !CAPABILITY_PATTERN.test(capability))) {
+      throw new Error('Docker runtime capabilities must be uppercase capability names');
+    }
+    this.client = options.client ?? new DockerCliClient(options.dockerCommand);
+    this.runnerPort = options.runnerPort ?? DEFAULT_RUNNER_PORT;
+    this.startupTimeoutMs = options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
+    this.healthPath = options.healthPath ?? DEFAULT_HEALTH_PATH;
+    this.capabilities = options.capabilities ?? [];
+  }
+
+  async acquire(assignment: BridgeAssignment, signal?: AbortSignal): Promise<RuntimeLease> {
+    const sessionId = assignmentSessionId(assignment);
+    if (sessionId == null) throw new Error('Runtime assignment ID is required');
+    const name = containerName(sessionId);
+    await this.ensureContainer(name, sessionId, signal);
+    try {
+      await this.waitForHealth(name, signal);
+      return {
+        sessionId,
+        execute: async (request) => this.execute(name, request),
+        release: assignment.runtimeSessionId == null ? async () => this.remove(name) : undefined,
+      };
+    } catch (error) {
+      await this.remove(name).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async reset(runtimeSessionId: string): Promise<void> {
+    await this.remove(containerName(runtimeSessionId));
+  }
+
+  async quarantine(
+    runtimeSessionId: string,
+    _reason: string,
+    _cause?: unknown,
+  ): Promise<void> {
+    await this.remove(containerName(runtimeSessionId));
+  }
+
+  private async ensureContainer(
+    name: string,
+    runtimeSessionId: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const running = await this.containerRunning(name, signal);
+    if (running) return;
+    if (running === false) {
+      await this.client.run(['start', name], { signal });
+      return;
+    }
+    await this.client.run(
+      [
+        'run',
+        '--detach',
+        '--name',
+        name,
+        '--network',
+        'none',
+        '--cap-drop',
+        'ALL',
+        ...this.capabilities.flatMap((capability) => ['--cap-add', capability]),
+        '--security-opt',
+        'no-new-privileges:true',
+        '--label',
+        'com.librechat.code.runtime=true',
+        '--label',
+        `com.librechat.code.runtime-hash=${containerSuffix(runtimeSessionId)}`,
+        '--env',
+        'SANDBOX_SESSION_WORKSPACE_ENABLED=true',
+        this.options.image,
+      ],
+      { signal },
+    );
+  }
+
+  private async containerRunning(name: string, signal?: AbortSignal): Promise<boolean | undefined> {
+    try {
+      const value = await this.client.run(
+        ['container', 'inspect', '--format', '{{.State.Running}}', name],
+        { signal },
+      );
+      return value.trim() === 'true';
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async waitForHealth(name: string, signal?: AbortSignal): Promise<void> {
+    const deadline = Date.now() + this.startupTimeoutMs;
+    let lastError: unknown;
+    while (Date.now() < deadline) {
+      if (signal?.aborted) throw signal.reason ?? new DOMException('aborted', 'AbortError');
+      try {
+        const status = await this.client.run(
+          [
+            'exec',
+            name,
+            'curl',
+            '--silent',
+            '--show-error',
+            '--output',
+            '/dev/null',
+            '--write-out',
+            '%{http_code}',
+            `http://127.0.0.1:${this.runnerPort}${this.healthPath}`,
+          ],
+          { signal },
+        );
+        if (status.trim() === '200') return;
+        lastError = new Error(`Runtime health check returned HTTP ${status.trim() || 'unknown'}`);
+      } catch (error) {
+        lastError = error;
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    }
+    throw new Error(
+      `Docker runtime did not become healthy within ${this.startupTimeoutMs}ms${
+        lastError instanceof Error ? `: ${lastError.message}` : ''
+      }`,
+    );
+  }
+
+  private async execute(
+    name: string,
+    request: RuntimeExecutionRequest,
+  ): Promise<RuntimeExecutionResponse> {
+    if (Object.entries(request.headers).some(([name, value]) => name.includes('\r') || name.includes('\n') || value.includes('\r') || value.includes('\n'))) {
+      throw new Error('Runtime request headers cannot contain line breaks');
+    }
+    const marker = randomBytes(32).toString('hex');
+    const output = await this.client.run(
+      [
+        'exec',
+        '--interactive',
+        name,
+        'curl',
+        '--silent',
+        '--show-error',
+        '--request',
+        'POST',
+        ...Object.entries(request.headers).flatMap(([name, value]) => ['--header', `${name}: ${value}`]),
+        '--data-binary',
+        '@-',
+        '--write-out',
+        `\n${marker}%{http_code}`,
+        `http://127.0.0.1:${this.runnerPort}/api/v2/execute`,
+      ],
+      { input: request.body, signal: request.signal },
+    );
+    const suffix = new RegExp(`\\n${marker}(\\d{3})$`);
+    const match = output.match(suffix);
+    if (match?.[1] == null) throw new Error('Docker runtime returned an invalid HTTP response');
+    return {
+      status: Number(match[1]),
+      body: output.slice(0, -match[0].length),
+    };
+  }
+
+  private async remove(name: string): Promise<void> {
+    try {
+      await this.client.run(['container', 'rm', '--force', name]);
+    } catch {
+      // A missing container is the desired reset and quarantine state.
+    }
+  }
 }
 
 /**

--- a/packages/code/src/worker.ts
+++ b/packages/code/src/worker.ts
@@ -593,7 +593,6 @@ export class BridgeWorker {
       if (executionController.signal.aborted) {
         throw executionController.signal.reason ?? new DOMException('aborted', 'AbortError');
       }
-      const sandboxExecuteUrl = `${runtimeLease.endpoint.replace(/\/+$/, '')}/execute`;
       const headers = {
         ...assignment.request.headers,
         ...(runtimeLease.sessionId
@@ -607,28 +606,25 @@ export class BridgeWorker {
         );
       }
       sandboxStarted = true;
-      const response = await this.fetchImpl(
-        sandboxExecuteUrl,
+      const response = await this.executeRuntime(
+        runtimeLease,
+        sandboxRequestBody,
         {
-          method: 'POST',
-          headers: {
-            ...headers,
-            'Content-Type': 'application/json',
-          },
-          body: sandboxRequestBody,
-          signal: executionController.signal,
+          ...headers,
+          'Content-Type': 'application/json',
         },
+        executionController.signal,
       );
       let payload: object = {};
       try {
-        payload = (await response.json()) as object;
+        payload = JSON.parse(response.body) as object;
       } catch (error) {
-        if (response.ok) throw error;
+        if (response.status >= 200 && response.status < 300) throw error;
       }
       if (credentialMaintenanceError != null) {
         throw credentialMaintenanceError;
       }
-      if (!response.ok) {
+      if (response.status < 200 || response.status >= 300) {
         sandboxRejectedExecution =
           response.status >= 400 &&
           response.status < 500 &&
@@ -738,6 +734,28 @@ export class BridgeWorker {
       return assignment.remainingMs ?? 0;
     }
     return Math.max(0, Date.parse(assignment.expiresAt) - Date.now());
+  }
+
+  private async executeRuntime(
+    lease: RuntimeLease,
+    body: string,
+    headers: Record<string, string>,
+    signal: AbortSignal,
+  ): Promise<{ status: number; body: string }> {
+    if (lease.execute != null) {
+      return await lease.execute({ body, headers, signal });
+    }
+    if (lease.endpoint == null) {
+      throw new BridgeProtocolError('Runtime lease does not provide an execution transport');
+    }
+    const endpoint = lease.endpoint.replace(/\/+$/, '');
+    const response = await this.fetchImpl(`${endpoint}/execute`, {
+      method: 'POST',
+      headers,
+      body,
+      signal,
+    });
+    return { status: response.status, body: await response.text() };
   }
 
   private async releaseRuntimeLease(


### PR DESCRIPTION
## Summary
- add a local OCI runtime supervisor for stateful code sessions
- keep sandbox containers networkless, capability-free by default, and unreachable from the host
- execute only through trusted-worker `docker exec` loopback transport

## Verification
- `npm test` in `packages/code` (66 passing)
- live Docker lifecycle: acquire, loopback health, execute, reset; verified no runtime container remained