### PR TITLE
🧰 feat: Add Docker Supervisor CLI Mode

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -55,6 +55,21 @@ an arbitrary image into a supported security boundary. Image-specific Linux
 capabilities must be explicitly configured by the trusted launcher; the
 default grants none.
 
+To enable it from the bundled CLI, the host must give the worker access to its
+local Docker daemon and explicitly select a known runtime image:
+
+```bash
+LIBRECHAT_CODE_RUNTIME_SUPERVISOR=docker \
+LIBRECHAT_CODE_RUNTIME_IMAGE=ghcr.io/librechat-ai/code-interpreter-runtime:tag \
+LIBRECHAT_CODE_STATEFUL_WORKSPACE=true \
+librechat-code run
+```
+
+The image reference above is illustrative until the corresponding published
+runtime image ships. Docker mode never binds a runner port on the VM. Do not
+mount the Docker socket into the sandbox; only the trusted worker may control
+the daemon.
+
 ## Static compatibility mode
 
 Non-hardened development deployments may still run with a static token:

--- a/packages/code/src/cli.test.ts
+++ b/packages/code/src/cli.test.ts
@@ -47,3 +47,46 @@ test('CLI rejects invalid advertised capabilities before registration', () => {
     /LIBRECHAT_CODE_SANDBOX_PROFILE or LIBRECHAT_CODE_RUNTIMES is invalid/,
   );
 });
+
+test('CLI rejects an unknown runtime supervisor before entering the run loop', () => {
+  const result = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL('./cli.js', import.meta.url))],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        LIBRECHAT_CODE_URL: 'https://code.example/v1',
+        LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
+        LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
+        LIBRECHAT_CODE_RUNTIME_SUPERVISOR: 'podman',
+      },
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /LIBRECHAT_CODE_RUNTIME_SUPERVISOR must be either endpoint or docker/,
+  );
+});
+
+test('CLI requires a runtime image for Docker supervision', () => {
+  const result = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL('./cli.js', import.meta.url))],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        LIBRECHAT_CODE_URL: 'https://code.example/v1',
+        LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
+        LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
+        LIBRECHAT_CODE_RUNTIME_SUPERVISOR: 'docker',
+      },
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /LIBRECHAT_CODE_RUNTIME_IMAGE is required/);
+});

--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -136,7 +136,10 @@ async function run(runtimeSessionId?: string): Promise<void> {
     runtimeSupervisor:
       runtimeMode === 'docker'
         ? new DockerRuntimeSupervisor({
-            image: required('LIBRECHAT_CODE_RUNTIME_IMAGE'),
+            image:
+              runtimeSessionId == null
+                ? required('LIBRECHAT_CODE_RUNTIME_IMAGE')
+                : process.env.LIBRECHAT_CODE_RUNTIME_IMAGE?.trim(),
           })
         : new EndpointRuntimeSupervisor({
             endpoint: sandboxEndpoint,

--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -8,7 +8,7 @@ import {
   saveBridgeIdentity,
 } from './storage.js';
 import { BridgeWorker } from './worker.js';
-import { EndpointRuntimeSupervisor } from './runtime.js';
+import { DockerRuntimeSupervisor, EndpointRuntimeSupervisor } from './runtime.js';
 import {
   isValidBridgeWorkerCapabilities,
   isValidBridgeWorkerId,
@@ -86,10 +86,21 @@ async function run(runtimeSessionId?: string): Promise<void> {
   const statefulWorkspace =
     process.env.LIBRECHAT_CODE_STATEFUL_WORKSPACE?.trim().toLowerCase() ===
     'true';
+  const runtimeMode =
+    process.env.LIBRECHAT_CODE_RUNTIME_SUPERVISOR?.trim().toLowerCase() ?? 'endpoint';
+  if (runtimeMode !== 'endpoint' && runtimeMode !== 'docker') {
+    throw new Error(
+      'LIBRECHAT_CODE_RUNTIME_SUPERVISOR must be either endpoint or docker',
+    );
+  }
   const sandboxEndpoint =
     process.env.LIBRECHAT_CODE_SANDBOX_ENDPOINT ??
     'http://127.0.0.1:2000/api/v2';
-  if (statefulWorkspace && !sandboxEndpoint.includes('{runtimeSessionId}')) {
+  if (
+    runtimeMode === 'endpoint' &&
+    statefulWorkspace &&
+    !sandboxEndpoint.includes('{runtimeSessionId}')
+  ) {
     throw new Error(
       'LIBRECHAT_CODE_STATEFUL_WORKSPACE requires LIBRECHAT_CODE_SANDBOX_ENDPOINT to contain {runtimeSessionId}',
     );
@@ -103,7 +114,9 @@ async function run(runtimeSessionId?: string): Promise<void> {
     : undefined;
   const capabilities = {
     statefulWorkspace,
-    sandboxProfile: process.env.LIBRECHAT_CODE_SANDBOX_PROFILE ?? 'nsjail',
+    sandboxProfile:
+      process.env.LIBRECHAT_CODE_SANDBOX_PROFILE ??
+      (runtimeMode === 'docker' ? 'oci-docker' : 'nsjail'),
     runtimes: list(process.env.LIBRECHAT_CODE_RUNTIMES),
     policyDigest: createHash('sha256').update(policy).digest('hex'),
   };
@@ -120,10 +133,15 @@ async function run(runtimeSessionId?: string): Promise<void> {
     token: configuredToken,
     identity: workerIdentity,
     workerId,
-    runtimeSupervisor: new EndpointRuntimeSupervisor({
-      endpoint: sandboxEndpoint,
-      statefulWorkspace,
-    }),
+    runtimeSupervisor:
+      runtimeMode === 'docker'
+        ? new DockerRuntimeSupervisor({
+            image: required('LIBRECHAT_CODE_RUNTIME_IMAGE'),
+          })
+        : new EndpointRuntimeSupervisor({
+            endpoint: sandboxEndpoint,
+            statefulWorkspace,
+          }),
     capabilities,
     onIdentityChange:
       pairedIdentity && identityPath

--- a/packages/code/src/runtime.test.ts
+++ b/packages/code/src/runtime.test.ts
@@ -196,6 +196,18 @@ test('docker runtime supervisor ignores only confirmed missing-container removal
   await supervisor.reset('rt-user-1');
 });
 
+test('docker runtime supervisor resets a workspace without a configured image', async () => {
+  const client: ContainerRuntimeClient = {
+    async run(args) {
+      assert.deepEqual(args.slice(0, 3), ['container', 'rm', '--force']);
+      return 'removed\n';
+    },
+  };
+  const supervisor = new DockerRuntimeSupervisor({ client });
+
+  await supervisor.reset('rt-user-1');
+});
+
 test('docker runtime supervisor destroys stateless and reset stateful runtimes', async () => {
   const calls: string[][] = [];
   const client: ContainerRuntimeClient = {

--- a/packages/code/src/runtime.ts
+++ b/packages/code/src/runtime.ts
@@ -44,7 +44,7 @@ export interface ContainerRuntimeRunOptions {
 }
 
 export interface DockerRuntimeSupervisorOptions {
-  image: string;
+  image?: string;
   capabilities?: string[];
   dockerCommand?: string;
   runnerPort?: number;
@@ -139,8 +139,8 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
   private readonly capabilities: string[];
 
   constructor(private readonly options: DockerRuntimeSupervisorOptions) {
-    if (options.image.trim().length === 0) {
-      throw new Error('Docker runtime image is required');
+    if (options.image != null && options.image.trim().length === 0) {
+      throw new Error('Docker runtime image cannot be empty');
     }
     if (options.capabilities?.some((capability) => !CAPABILITY_PATTERN.test(capability))) {
       throw new Error('Docker runtime capabilities must be uppercase capability names');
@@ -188,6 +188,8 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
     runtimeSessionId: string,
     signal?: AbortSignal,
   ): Promise<boolean> {
+    const image = this.options.image?.trim();
+    if (!image) throw new Error('Docker runtime image is required for acquisition');
     const running = await this.containerRunning(name, signal);
     if (running) return false;
     if (running === false) {
@@ -213,7 +215,7 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
         `com.librechat.code.runtime-hash=${containerSuffix(runtimeSessionId)}`,
         '--env',
         'SANDBOX_SESSION_WORKSPACE_ENABLED=true',
-        this.options.image,
+        image,
       ],
       { signal },
     );


### PR DESCRIPTION
## Summary
- add explicit endpoint/docker runtime-supervisor selection to `librechat-code`
- require an image reference before Docker mode can start
- advertise Docker-backed workers as `oci-docker` by default

## Verification
- `npm test` in `packages/code` (68 passing)
- Docker supervisor live lifecycle verified in parent PR #73