### PR TITLE
🎗️ feat: Add Versioned Helm Releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+# Categories for the changelog `gh release create --generate-notes` appends to
+# every release body (see .github/workflows/release.yml). Labels are matched
+# against the merged pull requests in the range; anything unlabelled lands in
+# "Other changes" rather than being dropped, which matters here because sync
+# pull requests from the internal monorepo usually carry no labels.
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+  categories:
+    - title: Security
+      labels:
+        - security
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other changes
+      labels:
+        - '*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,252 @@
+# Cuts tagged releases for the public code-interpreter repo. Like ci.yml this
+# file is inert inside the monorepo — GitHub only runs workflows from the repo
+# root — and becomes a root workflow in the published repo.
+#
+# Two entry points feed one job:
+#
+#   * workflow_dispatch — pick a version in the Actions UI. The chart is
+#     packaged before the tag is created, so a packaging failure aborts while
+#     the release is still un-cut and the version is still free to reuse.
+#   * push of a v* tag — for tags cut locally with `git tag -a … && git push`.
+#     Tags this workflow pushes itself carry GITHUB_TOKEN, and GitHub does not
+#     re-trigger workflows for those, so the two paths never double-publish.
+#
+# `main` accepts no direct pushes (see CONTRIBUTING.md), but the branch
+# ruleset does not cover tags, so the job can create them. GITHUB_TOKEN
+# defaults to read-only in this repository; the explicit `contents: write`
+# below is what lets the tag push and the release upload through.
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. v2.0.0 or v2.1.0-rc1. Must match helm/codeapi/Chart.yaml appVersion.'
+        required: true
+        type: string
+      draft:
+        description: 'Publish as a draft so the notes can be edited before going public'
+        type: boolean
+        default: false
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.event.inputs.version || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Tag and publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          # Full history and tags: resolving whether this release is the newest
+          # stable one compares it against every other tag in the repository.
+          fetch-depth: 0
+
+      - name: Resolve and validate version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_DRAFT: ${{ github.event.inputs.draft }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # Releases describe what shipped to main. Dispatching from a topic
+            # branch would tag a commit that is not on the release line.
+            if [ "$REF_TYPE" != "branch" ] || [ "$REF_NAME" != "main" ]; then
+              echo "::error::Releases must be cut from main; this run is on '$REF_NAME'"
+              exit 1
+            fi
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="$REF_NAME"
+          fi
+
+          # A bare "2.0.0" typed into the dispatch box is accepted; everything
+          # downstream works with the v-prefixed form the tag actually uses.
+          case "$VERSION" in
+            v*) ;;
+            *) VERSION="v$VERSION" ;;
+          esac
+
+          if [[ ! "$VERSION" =~ ^v[0-9]+[.][0-9]+[.][0-9]+(-rc[0-9]+)?$ ]]; then
+            echo "::error::Release tags must be v<major>.<minor>.<patch> or v<major>.<minor>.<patch>-rcN, for example v2.0.0 or v2.1.0-rc1 (got '$VERSION')"
+            exit 1
+          fi
+
+          # v2.1.0-rc1 -> 2.1.0. Release candidates carry the version they are
+          # candidates for, so they compare against the same appVersion.
+          BASE_VERSION="${VERSION%%-rc*}"
+          BASE_VERSION="${BASE_VERSION#v}"
+
+          read_chart_field() {
+            grep -m1 "^$1:" helm/codeapi/Chart.yaml \
+              | sed -E "s/^$1:[[:space:]]*//; s/[[:space:]]*#.*//; s/^[\"']//; s/[\"']\$//"
+          }
+          APP_VERSION="$(read_chart_field appVersion)"
+          CHART_VERSION="$(read_chart_field version)"
+
+          # The tag is the app version. Requiring the bump to have landed on
+          # main first keeps a deployed chart from reporting a version that no
+          # release ever carried.
+          if [ "$APP_VERSION" != "$BASE_VERSION" ]; then
+            echo "::error::Tag $VERSION does not match helm/codeapi/Chart.yaml appVersion ($APP_VERSION). Land the appVersion bump on main before releasing."
+            exit 1
+          fi
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] \
+             && git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "::error::Tag $VERSION already exists. Pick a new version, or delete the tag if it was cut in error."
+            exit 1
+          fi
+
+          case "$VERSION" in
+            *-rc*) PRERELEASE=true ;;
+            *) PRERELEASE=false ;;
+          esac
+
+          # `latest` moves only when this is the highest stable version, so
+          # re-cutting an older patch cannot drag it backwards. The tag under
+          # dispatch does not exist yet, hence adding it to the comparison.
+          LATEST=false
+          if [ "$PRERELEASE" = "false" ]; then
+            HIGHEST_STABLE="$(
+              {
+                git tag --list 'v[0-9]*'
+                printf '%s\n' "$VERSION"
+              } \
+                | grep -E '^v[0-9]+[.][0-9]+[.][0-9]+$' \
+                | sort -V \
+                | tail -n 1
+            )"
+            if [ "$HIGHEST_STABLE" = "$VERSION" ]; then
+              LATEST=true
+            fi
+          fi
+
+          DRAFT=false
+          if [ "$INPUT_DRAFT" = "true" ]; then
+            DRAFT=true
+          fi
+
+          {
+            echo "version=$VERSION"
+            echo "base_version=$BASE_VERSION"
+            echo "app_version=$APP_VERSION"
+            echo "chart_version=$CHART_VERSION"
+            echo "prerelease=$PRERELEASE"
+            echo "latest=$LATEST"
+            echo "draft=$DRAFT"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Releasing $VERSION (chart $CHART_VERSION, appVersion $APP_VERSION, prerelease=$PRERELEASE, latest=$LATEST, draft=$DRAFT)"
+
+      # helm is preinstalled on ubuntu-latest, the same way the chart tests in
+      # ci.yml depend on it.
+      - name: Package Helm chart
+        id: chart
+        run: |
+          set -euo pipefail
+
+          # Subcharts resolve through the Bitnami OCI mirror on Docker Hub,
+          # which rate-limits anonymous pulls. A transient 429 should cost a
+          # retry, not the release.
+          for attempt in 1 2 3; do
+            if helm dependency update helm/codeapi; then
+              break
+            fi
+            if [ "$attempt" = 3 ]; then
+              echo "::error::helm dependency update failed after 3 attempts"
+              exit 1
+            fi
+            sleep $(( attempt * 15 ))
+          done
+
+          helm package helm/codeapi --destination dist
+
+          CHART_PATH="$(ls dist/codeapi-*.tgz)"
+          {
+            echo "path=$CHART_PATH"
+            echo "name=$(basename "$CHART_PATH")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "$VERSION" -m "$VERSION"
+          git push origin "refs/tags/$VERSION"
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          APP_VERSION: ${{ steps.version.outputs.app_version }}
+          CHART_VERSION: ${{ steps.version.outputs.chart_version }}
+          CHART_PATH: ${{ steps.chart.outputs.path }}
+          CHART_NAME: ${{ steps.chart.outputs.name }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+          LATEST: ${{ steps.version.outputs.latest }}
+          DRAFT: ${{ steps.version.outputs.draft }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "::error::Release $VERSION already exists"
+            exit 1
+          fi
+
+          # Quoted heredoc so the markdown backticks stay literal; the
+          # placeholders are filled in afterwards.
+          cat > release-notes.md <<'NOTES'
+          Pin deployments to this tag instead of tracking `main`:
+
+          ```bash
+          git clone --branch __VERSION__ --depth 1 __REPO_URL__.git
+          ```
+
+          The attached `__CHART_NAME__` is the packaged Helm chart (chart `__CHART_VERSION__`, appVersion `__APP_VERSION__`) with its Redis and MinIO subcharts vendored, so it installs without adding any chart repositories:
+
+          ```bash
+          helm install codeapi ./__CHART_NAME__ -f my-values.yaml
+          ```
+
+          Chart configuration is documented in [helm/codeapi/README.md](__REPO_URL__/blob/__VERSION__/helm/codeapi/README.md).
+          NOTES
+
+          sed -i \
+            -e "s|__VERSION__|$VERSION|g" \
+            -e "s|__REPO_URL__|$REPO_URL|g" \
+            -e "s|__CHART_NAME__|$CHART_NAME|g" \
+            -e "s|__CHART_VERSION__|$CHART_VERSION|g" \
+            -e "s|__APP_VERSION__|$APP_VERSION|g" \
+            release-notes.md
+
+          # --generate-notes appends the merged-pull-request changelog below
+          # the body from --notes-file, categorised per .github/release.yml.
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes-file release-notes.md \
+            --generate-notes \
+            --verify-tag \
+            --prerelease="$PRERELEASE" \
+            --latest="$LATEST" \
+            --draft="$DRAFT" \
+            "$CHART_PATH#Helm chart ($CHART_NAME)"

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ packages/*/dist/
 # Helm artifacts
 helm/*/charts/*.tgz
 helm/*/Chart.lock
+/dist/
 
 # Local sandbox runtime data (docker volume mount)
 data/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,14 @@ Practical consequences:
 - **History is snapshot-based.** Commits here intentionally do not mirror the
   internal commit history.
 
+## Releases
+
+Tagged releases are cut from `main` as `vMAJOR.MINOR.PATCH` (with `-rcN` for
+release candidates), and each one carries the packaged Helm chart. The version
+comes from `helm/codeapi/Chart.yaml`'s `appVersion`, so a version bump lands on
+`main` through the pull request flow above before it can be released. See
+[docs/RELEASING.md](docs/RELEASING.md) for the full process.
+
 ## Development
 
 See the [README](README.md) for the architecture overview and

--- a/README.md
+++ b/README.md
@@ -102,6 +102,26 @@ privilege, keep hosts patched, and deploy responsibly. If you believe you
 have found a vulnerability, please report it privately rather than opening a
 public issue (see [CONTRIBUTING](CONTRIBUTING.md)).
 
+## Releases
+
+Deployments should pin a [tagged release](https://github.com/LibreChat-AI/code-interpreter/releases)
+rather than track `main`, which moves whenever an internal snapshot is merged:
+
+```bash
+git clone --branch v2.0.0 --depth 1 https://github.com/LibreChat-AI/code-interpreter.git
+```
+
+Every release attaches `codeapi-<chart version>.tgz`, the packaged Helm chart
+with its Redis and MinIO subcharts vendored:
+
+```bash
+helm install codeapi ./codeapi-0.3.0.tgz -f my-values.yaml
+```
+
+Versions are `vMAJOR.MINOR.PATCH`, with `-rcN` release candidates published as
+pre-releases. See [docs/RELEASING.md](docs/RELEASING.md) for how releases are
+cut.
+
 ## Local Development
 
 ```bash

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,71 @@
+# Releasing
+
+Deployments should track a tag, not `main`. This document covers how those
+tags are cut.
+
+## Versioning
+
+A release is named `vMAJOR.MINOR.PATCH`, optionally with a `-rcN` suffix for a
+release candidate — `v2.0.0`, `v2.1.0-rc1`. That version is the **app
+version**: `helm/codeapi/Chart.yaml`'s `appVersion` is its source of truth, and
+the release workflow refuses any tag that disagrees with it. A release
+candidate carries the version it is a candidate for, so `v2.1.0-rc1` also
+requires `appVersion: "2.1.0"`.
+
+Two other version numbers are deliberately independent:
+
+- `helm/codeapi/Chart.yaml`'s `version` is the **chart** version. Bump it when
+  the chart's templates or values change, not when the app changes. It names
+  the packaged chart attached to the release (`codeapi-<chart version>.tgz`).
+- `service/package.json`'s `version` tracks the Lambda service package alone.
+
+By convention `api/package.json`'s `version` is kept in step with `appVersion`,
+so the API package and the tag agree. Nothing enforces it.
+
+## Cutting a release
+
+1. Land the `appVersion` bump on `main` first. `main` takes no direct pushes
+   (see [CONTRIBUTING.md](../CONTRIBUTING.md)), so it arrives through a sync
+   pull request from the internal monorepo or a community pull request. Bump
+   the chart `version` too if the chart changed.
+2. Run the **Release** workflow from the Actions tab against `main`, entering
+   the version (`v2.1.0`). Tick *draft* to review the generated notes before
+   they go public.
+
+The workflow validates the version, packages the Helm chart, then creates the
+annotated tag and publishes the release. Packaging runs before tagging so a
+failure — a rate-limited subchart pull, most likely — leaves the version
+unused and the run safe to retry.
+
+A tag pushed by hand works as well, and takes the same path from validation
+onward:
+
+```bash
+git checkout main && git pull
+git tag -a v2.1.0 -m v2.1.0
+git push origin v2.1.0
+```
+
+## What the release contains
+
+- The tag, so a deployment can pin a commit.
+- Notes: a preamble on pinning and installing, followed by the merged
+  pull requests since the previous tag, categorised per
+  [.github/release.yml](../.github/release.yml).
+- `codeapi-<chart version>.tgz`, the packaged Helm chart with its Redis and
+  MinIO subcharts vendored, so it installs without adding chart repositories.
+
+Release candidates are marked as pre-releases. The *Latest* badge moves only
+when the release is stable **and** is the highest stable version in the
+repository, so re-cutting an older patch cannot drag it backwards.
+
+## If a release goes wrong
+
+Delete the release and its tag, then re-run the workflow:
+
+```bash
+gh release delete v2.1.0 --cleanup-tag --yes
+```
+
+Republishing the same version is only safe while nobody has deployed it. Once
+a tag is public, ship a new patch instead.


### PR DESCRIPTION
Closes #63

Deployments currently have to track `main`, which advances whenever an internal snapshot is merged. This adds versioned tags, each carrying the packaged Helm chart so a deployment can pin one.

## `.github/workflows/release.yml`

One job, two entry points:

- **`workflow_dispatch`** — enter a version in the Actions UI (must run against `main`), with an optional *draft* checkbox.
- **`push` of a `v*` tag** — for tags cut by hand. Tags the workflow pushes itself carry `GITHUB_TOKEN`, which GitHub deliberately does not re-trigger on, so the two paths never double-publish.

What it enforces:

- Tag format `vX.Y.Z` or `vX.Y.Z-rcN`; a bare `2.0.0` typed into the dispatch box is normalised.
- **Tag must equal `helm/codeapi/Chart.yaml` `appVersion`**, so a deployed chart cannot report a version no release ever carried. A release candidate compares against the version it is a candidate for.
- Dispatch must come from `main`; the tag must not already exist; the release must not already exist.
- `-rcN` publishes as a pre-release. *Latest* is set only when the release is stable **and** is the highest stable tag, so re-cutting an older patch cannot drag it backwards.

The chart is packaged **before** the tag is created, so a rate-limited Bitnami pull leaves the version unused and the run retryable; `helm dependency update` retries three times with backoff.

Each release carries the tag, notes (a pin-and-install preamble with the merged-pull-request changelog appended by `--generate-notes`), and `codeapi-<chart version>.tgz` with the Redis and MinIO subcharts vendored, so it installs without adding chart repositories.

`GITHUB_TOKEN` defaults to read-only in this repository, hence the explicit `contents: write`. The `protect-main` ruleset covers branches only, so the job can create tags.

## Also

- `.github/release.yml` categorises the generated notes by label. Unlabelled pull requests fall into *Other changes* rather than being dropped, which matters because sync pull requests carry no labels.
- `docs/RELEASING.md` — versioning scheme, how to cut a release, and how to unwind a bad one.
- Releases sections in `README.md` and `CONTRIBUTING.md`.
- `/dist/` gitignored, since the packaging step writes there.

## Verification

- `actionlint` + `shellcheck` clean.
- The version-resolution step was extracted and run against 14 simulated cases — normalisation, release-candidate handling, *latest* resolution against pre-existing tags, and all six rejection paths. All pass.
- `helm dependency update` + `helm package` run against the real chart, producing `codeapi-0.3.0.tgz` and leaving no untracked files.
- The `gh release create` invocation and its rendered notes checked against a mocked `gh`; every `=false` boolean flag confirmed to parse.

Once merged, `v2.0.0` can be dispatched with no source change — `appVersion` is already `2.0.0`.
