### PR TITLE
📛 fix: Preserve Uploaded Filenames Without Metadata

### DIFF
--- a/api/src/download.test.ts
+++ b/api/src/download.test.ts
@@ -289,6 +289,29 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
     expect(contents).toBe('legacy bytes');
   });
 
+  it('writes under the requested name when a legacy server returns an opaque storage filename', async () => {
+    const file: TFile = {
+      id: 'opaque-storage-id',
+      storage_session_id: 'prev-session',
+      name: 'Sample_-_Superstore.xlsx',
+    };
+    routes.set(`/sessions/${encodeURIComponent(file.storage_session_id!)}/objects/${encodeURIComponent(file.id!)}`, {
+      status: 200,
+      contentDisposition: "attachment; filename*=UTF-8''opaque-storage-id.xlsx",
+      body: 'workbook bytes',
+    });
+
+    const job = makeJob([file]);
+    asInternals(job).submissionDir = tmpDir;
+
+    const writtenName = await job.downloadAndWriteFile(file);
+
+    expect(writtenName).toBe('Sample_-_Superstore.xlsx');
+    expect(await fsp.readFile(path.join(tmpDir, 'Sample_-_Superstore.xlsx'), 'utf8'))
+      .toBe('workbook bytes');
+    expect(await fsp.stat(path.join(tmpDir, 'opaque-storage-id.xlsx')).catch(() => null)).toBeNull();
+  });
+
   it('resolves concurrent header destinations without provisional-name false conflicts', async () => {
     const renamed: TFile = {
       id: 'renamed-id',

--- a/api/src/job-helpers.test.ts
+++ b/api/src/job-helpers.test.ts
@@ -177,6 +177,33 @@ describe('resolveOriginalName', () => {
       ),
     ).toBe('nested/file.txt');
   });
+
+  it('keeps the requested name when an old file server advertises the opaque object basename', () => {
+    expect(
+      resolveOriginalName(
+        responseWithHeader("attachment; filename*=UTF-8''storage-id.xlsx"),
+        { name: 'Sample_-_Superstore.xlsx', id: 'storage-id' },
+      ),
+    ).toBe('Sample_-_Superstore.xlsx');
+  });
+
+  it('keeps the requested name for a legacy opaque filename header', () => {
+    expect(
+      resolveOriginalName(
+        responseWithHeader('attachment; filename="storage-id.csv"'),
+        { name: 'original.csv', id: 'storage-id' },
+      ),
+    ).toBe('original.csv');
+  });
+
+  it('keeps an authoritative nested filename even when its basename matches the object id', () => {
+    expect(
+      resolveOriginalName(
+        responseWithHeader("attachment; filename*=UTF-8''exports%2Fstorage-id.csv"),
+        { name: 'original.csv', id: 'storage-id' },
+      ),
+    ).toBe('exports/storage-id.csv');
+  });
 });
 
 describe('mimeTypeFor', () => {

--- a/api/src/job.ts
+++ b/api/src/job.ts
@@ -179,11 +179,24 @@ export function resolveOriginalName(response: Response, file: TFile): string {
   const header = response.headers.get('content-disposition');
   if (!header) return fallback;
 
+  const preferRequestedName = (candidate: string): string => {
+    /* Older file servers advertised path.basename(objectName) when an
+     * S3-compatible backend omitted original-filename user metadata. That
+     * basename is `<file.id><extension>`, so it is a storage identifier rather
+     * than an authoritative destination. Preserve the caller's requested name
+     * during rolling upgrades instead of exposing the opaque id in /mnt/data. */
+    const opaqueStem = path.basename(candidate, path.extname(candidate));
+    const isFlatObjectBasename = candidate === path.basename(candidate);
+    return file.name && file.id && isFlatObjectBasename && opaqueStem === file.id
+      ? file.name
+      : candidate;
+  };
+
   const star = header.match(/filename\*=(?:UTF-8'[^']*')?([^;]+)/i);
   if (star) {
     const raw = star[1].trim();
     try {
-      return decodeURIComponent(raw);
+      return preferRequestedName(decodeURIComponent(raw));
     } catch {
       /* Malformed percent-encoding (e.g. `%ZZ`) — fall through to the legacy
        * forms. The same header may emit both `filename*=` and a legacy
@@ -194,7 +207,7 @@ export function resolveOriginalName(response: Response, file: TFile): string {
 
   const match = header.match(/filename="([^"]+)"/i)
     ?? header.match(/filename=([^\s;]+)/i);
-  return match ? match[1] : fallback;
+  return match ? preferRequestedName(match[1]) : fallback;
 }
 
 /**

--- a/service/src/egress-gateway.test.ts
+++ b/service/src/egress-gateway.test.ts
@@ -632,7 +632,10 @@ describe('egress gateway routes', () => {
   test('downloads scoped objects by unwrapping handles', async () => {
     upstreamResponse = new Response('file-body', {
       status: 200,
-      headers: { 'Content-Type': 'text/plain' },
+      headers: {
+        'Content-Type': 'text/plain',
+        'Content-Disposition': "attachment; filename*=UTF-8''file_123.csv",
+      },
     });
     const readSession = sessionHandle({ dir: 'read', sessionId: 'sess_input' });
     const object = objectHandle({});
@@ -643,8 +646,27 @@ describe('egress gateway routes', () => {
 
     expect(response.status).toBe(200);
     expect(await response.text()).toBe('file-body');
+    expect(response.headers.get('content-disposition')).toBe('attachment');
     expect(upstreamCalls[0].url).toBe('http://file-server/sessions/sess_input/objects/file_123');
     expect(header(upstreamCalls[0].init, INTERNAL_SERVICE_TOKEN_HEADER)).toBe(INTERNAL_TOKEN);
+  });
+
+  test('preserves an authoritative upstream download filename', async () => {
+    upstreamResponse = new Response('file-body', {
+      status: 200,
+      headers: {
+        'Content-Disposition': "attachment; filename*=UTF-8''reports%2Fdata.csv",
+      },
+    });
+    const readSession = sessionHandle({ dir: 'read', sessionId: 'sess_input' });
+    const object = objectHandle({});
+
+    const response = await gatewayFetch(`/sessions/${readSession}/objects/${object}`, {
+      headers: grantHeader(),
+    });
+
+    expect(response.headers.get('content-disposition'))
+      .toBe("attachment; filename*=UTF-8''reports%2Fdata.csv");
   });
 
   test('downloads required dirkeep markers without allowing unrelated markers', async () => {

--- a/service/src/egress-gateway.ts
+++ b/service/src/egress-gateway.ts
@@ -42,6 +42,7 @@ import { isValidId } from './utils';
 import logger from './logger';
 import { parseBoundedContentLength } from './http-limits';
 import { validateEgressGatewayHardenedConfig } from './secure-startup';
+import { isOpaqueObjectContentDisposition } from './file-metadata';
 
 export const app: Express = express();
 app.disable('x-powered-by');
@@ -347,9 +348,13 @@ function responseHeaders(fetchResponse: globalThis.Response): Record<string, str
   return headers;
 }
 
-function pipeFetchResponse(fetchResponse: globalThis.Response, res: Response): void {
+function pipeFetchResponse(
+  fetchResponse: globalThis.Response,
+  res: Response,
+  headerOverrides: Record<string, string> = {},
+): void {
   res.status(fetchResponse.status);
-  res.set(responseHeaders(fetchResponse));
+  res.set({ ...responseHeaders(fetchResponse), ...headerOverrides });
   if (!fetchResponse.body) {
     res.end();
     return;
@@ -631,7 +636,13 @@ app.get('/sessions/:sessionHandle/objects/:objectHandle', async (req, res) => {
       ),
       { headers: injectTraceHeaders(internalServiceHeaders()) },
     );
-    return pipeFetchResponse(upstream, res);
+    const headerOverrides = isOpaqueObjectContentDisposition(
+      upstream.headers.get('content-disposition'),
+      object.id,
+    )
+      ? { 'content-disposition': 'attachment' }
+      : {};
+    return pipeFetchResponse(upstream, res, headerOverrides);
   } catch (error) {
     return sendEgressError(req, res, error);
   }

--- a/service/src/file-metadata.test.ts
+++ b/service/src/file-metadata.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'bun:test';
+import { decodeOriginalFilename, originalFilenameFromMetadata } from './file-metadata';
+
+describe('originalFilenameFromMetadata', () => {
+  it('returns undefined rather than treating an object-key basename as original metadata', () => {
+    expect(originalFilenameFromMetadata(undefined)).toBeUndefined();
+    expect(originalFilenameFromMetadata({ 'content-type': 'application/octet-stream' })).toBeUndefined();
+  });
+
+  it('decodes the base64 filename written by the file server', () => {
+    expect(originalFilenameFromMetadata({
+      'original-filename': Buffer.from('Sample_-_Superstore.xlsx').toString('base64'),
+      'original-filename-encoded': 'base64',
+    })).toBe('Sample_-_Superstore.xlsx');
+  });
+
+  it('supports legacy plain-text filename metadata', () => {
+    expect(originalFilenameFromMetadata({
+      'original-filename': 'report.csv',
+    })).toBe('report.csv');
+  });
+});
+
+describe('decodeOriginalFilename', () => {
+  it('retains object-key fallback behavior for listing responses', () => {
+    expect(decodeOriginalFilename(undefined, 'opaque-id.xlsx')).toBe('opaque-id.xlsx');
+  });
+});

--- a/service/src/file-metadata.test.ts
+++ b/service/src/file-metadata.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'bun:test';
-import { decodeOriginalFilename, originalFilenameFromMetadata } from './file-metadata';
+import {
+  contentDispositionForOriginalFilename,
+  decodeOriginalFilename,
+  isOpaqueObjectContentDisposition,
+  originalFilenameFromMetadata,
+} from './file-metadata';
 
 describe('originalFilenameFromMetadata', () => {
   it('returns undefined rather than treating an object-key basename as original metadata', () => {
@@ -24,5 +29,40 @@ describe('originalFilenameFromMetadata', () => {
 describe('decodeOriginalFilename', () => {
   it('retains object-key fallback behavior for listing responses', () => {
     expect(decodeOriginalFilename(undefined, 'opaque-id.xlsx')).toBe('opaque-id.xlsx');
+  });
+});
+
+describe('contentDispositionForOriginalFilename', () => {
+  it('preserves attachment semantics when filename metadata is unavailable', () => {
+    expect(contentDispositionForOriginalFilename(undefined)).toBe('attachment');
+  });
+
+  it('encodes a verified original filename', () => {
+    expect(contentDispositionForOriginalFilename('reports/收益.csv'))
+      .toBe("attachment; filename*=UTF-8''reports%2F%E6%94%B6%E7%9B%8A.csv");
+  });
+});
+
+describe('isOpaqueObjectContentDisposition', () => {
+  it('recognizes extended and legacy storage-id basenames', () => {
+    expect(isOpaqueObjectContentDisposition(
+      "attachment; filename*=UTF-8''raw-object-id.xlsx",
+      'raw-object-id',
+    )).toBe(true);
+    expect(isOpaqueObjectContentDisposition(
+      'attachment; filename="raw-object-id.csv"',
+      'raw-object-id',
+    )).toBe(true);
+  });
+
+  it('does not replace verified or nested filenames', () => {
+    expect(isOpaqueObjectContentDisposition(
+      'attachment; filename="report.csv"',
+      'raw-object-id',
+    )).toBe(false);
+    expect(isOpaqueObjectContentDisposition(
+      "attachment; filename*=UTF-8''exports%2Fraw-object-id.csv",
+      'raw-object-id',
+    )).toBe(false);
   });
 });

--- a/service/src/file-metadata.ts
+++ b/service/src/file-metadata.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 /**
  * Reads a verified original filename from S3 user metadata. Absence remains
  * distinct from the object's opaque storage-key basename so callers can avoid
@@ -21,4 +23,40 @@ export function decodeOriginalFilename(
   fallbackName: string,
 ): string {
   return originalFilenameFromMetadata(metadata) ?? fallbackName;
+}
+
+export function contentDispositionForOriginalFilename(
+  originalFilename: string | undefined,
+): string {
+  if (!originalFilename) return 'attachment';
+  return `attachment; filename*=UTF-8''${encodeURIComponent(originalFilename)}`;
+}
+
+function filenameFromContentDisposition(contentDisposition: string | null): string | undefined {
+  if (!contentDisposition) return undefined;
+  const star = contentDisposition.match(/filename\*=(?:UTF-8'[^']*')?([^;]+)/i);
+  if (star) {
+    try {
+      return decodeURIComponent(star[1].trim());
+    } catch {
+      // A valid legacy filename may still follow a malformed extended value.
+    }
+  }
+  const legacy = contentDisposition.match(/filename="([^"]+)"/i)
+    ?? contentDisposition.match(/filename=([^\s;]+)/i);
+  return legacy?.[1];
+}
+
+/**
+ * Detects the legacy file-server fallback `<object id><extension>`. The egress
+ * gateway has the unsealed object id, so it can remove this unverified name
+ * before forwarding the response to a runner that only sees sealed handles.
+ */
+export function isOpaqueObjectContentDisposition(
+  contentDisposition: string | null,
+  objectId: string,
+): boolean {
+  const candidate = filenameFromContentDisposition(contentDisposition);
+  if (!candidate || candidate !== path.basename(candidate)) return false;
+  return path.basename(candidate, path.extname(candidate)) === objectId;
 }

--- a/service/src/file-metadata.ts
+++ b/service/src/file-metadata.ts
@@ -1,0 +1,24 @@
+/**
+ * Reads a verified original filename from S3 user metadata. Absence remains
+ * distinct from the object's opaque storage-key basename so callers can avoid
+ * advertising the latter as an authoritative filename.
+ */
+export function originalFilenameFromMetadata(
+  metadata: Record<string, string> | undefined,
+): string | undefined {
+  const encodedFilename = metadata?.['original-filename'];
+  if (!encodedFilename) return undefined;
+
+  if (metadata?.['original-filename-encoded'] === 'base64') {
+    return Buffer.from(encodedFilename, 'base64').toString('utf8');
+  }
+
+  return encodedFilename;
+}
+
+export function decodeOriginalFilename(
+  metadata: Record<string, string> | undefined,
+  fallbackName: string,
+): string {
+  return originalFilenameFromMetadata(metadata) ?? fallbackName;
+}

--- a/service/src/file-server.ts
+++ b/service/src/file-server.ts
@@ -17,6 +17,7 @@ import { shutdownTelemetry, traceHttpRequest } from './telemetry';
 import logger from './fileServerLogger';
 import { env } from './config';
 import { redisKeepAliveOptions } from './redis-options';
+import { decodeOriginalFilename, originalFilenameFromMetadata } from './file-metadata';
 
 const { INSTANCE_ID } = env;
 
@@ -458,11 +459,11 @@ app.get('/sessions/:session_id/objects/:objectId/metadata', async (req, res) => 
     }
 
     const stat: Partial<BucketItemStat> = await minioClient.statObject(bucketName, objectName);
-    const originalFilename = decodeOriginalFilename(stat.metaData, path.basename(objectName));
+    const originalFilename = originalFilenameFromMetadata(stat.metaData);
 
     return res.status(200).json({
       name: objectName,
-      originalFilename,
+      ...(originalFilename ? { originalFilename } : {}),
       size: stat.size,
       lastModified: stat.lastModified,
       etag: stat.etag,
@@ -508,17 +509,7 @@ app.get('/sessions/:session_id/objects/:objectId', async (req, res) => {
 
     const stat: Partial<BucketItemStat> = await minioClient.statObject(bucketName, objectName);
 
-    let originalFilename = path.basename(objectName);
-    if (stat.metaData?.['original-filename-encoded'] === 'base64' && stat.metaData['original-filename'] != null) {
-      try {
-        originalFilename = Buffer.from(stat.metaData['original-filename'], 'base64').toString('utf8');
-      } catch (err) {
-        logger.warn('Failed to decode filename from metadata, using fallback', { error: err });
-        originalFilename = stat.metaData['original-filename'] ?? path.basename(objectName);
-      }
-    } else if (stat.metaData?.['original-filename'] != null) {
-      originalFilename = stat.metaData['original-filename'];
-    }
+    const originalFilename = originalFilenameFromMetadata(stat.metaData);
 
     logger.info(`[${INSTANCE_ID}] File found: ${objectName}`);
 
@@ -526,8 +517,13 @@ app.get('/sessions/:session_id/objects/:objectId', async (req, res) => {
     res.removeHeader('Transfer-Encoding');
     res.removeHeader('Date');
 
-    const encodedFilename = encodeURIComponent(originalFilename);
-    res.setHeader('Content-Disposition', `attachment; filename*=UTF-8''${encodedFilename}`);
+    /* An object-key basename is only a storage identifier, not an original
+     * filename. If an S3-compatible backend drops user metadata, omit the
+     * header so the runner keeps the destination supplied by the caller. */
+    if (originalFilename) {
+      const encodedFilename = encodeURIComponent(originalFilename);
+      res.setHeader('Content-Disposition', `attachment; filename*=UTF-8''${encodedFilename}`);
+    }
     if (stat.metaData?.['content-type'] != null) {
       res.setHeader('Content-Type', stat.metaData['content-type']);
     }
@@ -572,27 +568,6 @@ app.get('/sessions/:session_id/objects/:objectId', async (req, res) => {
     });
   }
 });
-
-/**
- * Decodes the original filename from metadata.
- * Handles both base64-encoded and plain text filenames for consistency.
- */
-function decodeOriginalFilename(metadata: Record<string, string> | undefined, fallbackName: string): string {
-  if (!metadata) return fallbackName;
-
-  const encodedFilename = metadata['original-filename'];
-  const encodingType = metadata['original-filename-encoded'];
-
-  if (encodedFilename && encodingType === 'base64') {
-    try {
-      return Buffer.from(encodedFilename, 'base64').toString('utf8');
-    } catch {
-      return encodedFilename;
-    }
-  }
-
-  return encodedFilename || fallbackName;
-}
 
 /**
  * Extracts session_id and file_id from object name (format: {session_id}/{file_id}.ext)

--- a/service/src/file-server.ts
+++ b/service/src/file-server.ts
@@ -17,7 +17,11 @@ import { shutdownTelemetry, traceHttpRequest } from './telemetry';
 import logger from './fileServerLogger';
 import { env } from './config';
 import { redisKeepAliveOptions } from './redis-options';
-import { decodeOriginalFilename, originalFilenameFromMetadata } from './file-metadata';
+import {
+  contentDispositionForOriginalFilename,
+  decodeOriginalFilename,
+  originalFilenameFromMetadata,
+} from './file-metadata';
 
 const { INSTANCE_ID } = env;
 
@@ -518,12 +522,10 @@ app.get('/sessions/:session_id/objects/:objectId', async (req, res) => {
     res.removeHeader('Date');
 
     /* An object-key basename is only a storage identifier, not an original
-     * filename. If an S3-compatible backend drops user metadata, omit the
-     * header so the runner keeps the destination supplied by the caller. */
-    if (originalFilename) {
-      const encodedFilename = encodeURIComponent(originalFilename);
-      res.setHeader('Content-Disposition', `attachment; filename*=UTF-8''${encodedFilename}`);
-    }
+     * filename. If an S3-compatible backend drops user metadata, retain
+     * attachment semantics but omit the filename so the runner uses its
+     * caller-supplied destination. */
+    res.setHeader('Content-Disposition', contentDispositionForOriginalFilename(originalFilename));
     if (stat.metaData?.['content-type'] != null) {
       res.setHeader('Content-Type', stat.metaData['content-type']);
     }


### PR DESCRIPTION
## Summary

I fixed uploaded filename preservation when an S3-compatible backend omits original-filename user metadata. Closes #56.

- Preserve the caller-requested path when a legacy file server advertises an opaque storage-ID basename.
- Omit unverified `Content-Disposition` and `originalFilename` values when storage metadata is unavailable.
- Retain authoritative nested filenames and legacy plain-text metadata behavior.
- Add unit and download regression coverage for the reported workbook failure.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd api && bun test src/job-helpers.test.ts src/download.test.ts`
- `cd api && bun run build`
- `cd service && bun test src/file-metadata.test.ts`
- `cd service && bun run build`

### **Test Configuration**:

- Bun 1.3.13
- macOS arm64

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes