### PR TITLE
🪫 chore: Detect Compose Sandbox Clock Drift

### DIFF
--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -42,6 +42,11 @@ services:
       - CODEAPI_INTERNAL_SERVICE_TOKEN=${CODEAPI_INTERNAL_SERVICE_TOKEN:-localdev-internal-service-token}
       - SANDBOX_ALLOWED_LOCAL_NETWORK_PORT=3033
       - SANDBOX_FORWARD_TARGET=tool_call_server:3033
+      # Guest clock drift silently fails every exec with "not_yet_valid"
+      # once it passes the 30s execution-manifest tolerance (#37). Opt in so
+      # the healthcheck reports it; set the limit to 0 to disable.
+      - SANDBOX_RUNNER_CLOCK_SKEW_LIVENESS_LIMIT_SECONDS=${SANDBOX_RUNNER_CLOCK_SKEW_LIVENESS_LIMIT_SECONDS:-10}
+      - SANDBOX_RUNNER_HEALTHCHECK_TIMEOUT_SECONDS=${SANDBOX_RUNNER_HEALTHCHECK_TIMEOUT_SECONDS:-2}
     healthcheck:
       test: ["CMD", "/usr/local/bin/sandbox-runner-healthcheck.sh"]
       interval: 10s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -161,6 +161,11 @@ services:
             - SANDBOX_FORWARD_TARGET=egress_gateway:3190
             - SANDBOX_REQUIRE_EGRESS_MANIFEST=${SANDBOX_REQUIRE_EGRESS_MANIFEST:-true}
             - SANDBOX_EXECUTION_MANIFEST_PUBLIC_KEY=${SANDBOX_EXECUTION_MANIFEST_PUBLIC_KEY:-MCowBQYDK2VwAyEAeY3PRoTS3adfU6E3gQUB5hSZdrdMSw6OrKkH4UhYh0U=}
+            # Guest clock drift silently fails every exec with "not_yet_valid"
+            # once it passes the 30s execution-manifest tolerance (#37). Opt in
+            # so the healthcheck reports it; set the limit to 0 to disable.
+            - SANDBOX_RUNNER_CLOCK_SKEW_LIVENESS_LIMIT_SECONDS=${SANDBOX_RUNNER_CLOCK_SKEW_LIVENESS_LIMIT_SECONDS:-10}
+            - SANDBOX_RUNNER_HEALTHCHECK_TIMEOUT_SECONDS=${SANDBOX_RUNNER_HEALTHCHECK_TIMEOUT_SECONDS:-2}
         depends_on:
             egress_gateway:
                 condition: service_healthy


### PR DESCRIPTION
Fixes #37

## Problem

Guest clock drift past the 30-second execution-manifest tolerance makes every
`/v1/exec` fail with `not_yet_valid`, while **both** health endpoints keep
reporting healthy. The stack looks fine while nothing runs, and only a manual
restart of the sandbox-runner recovers it.

Two independent reporters hit this, days apart, on long-running containers:

```
{"level":40,"reason":"not_yet_valid","status":403,"msg":"Rejected sandbox request by execution manifest"}
```

## Root cause of the gap

`docker/sandbox-runner-healthcheck.sh` already detects exactly this — it compares
the guest's HTTP `Date` against the host interval that enclosed the request. But
the guard stays disabled unless an orchestrator opts in, by design:

> Compose and standalone Docker callers only observe health status, so the
> clock-skew guard stays disabled unless an orchestrator explicitly opts in.
> — `tests/sandbox_runner_healthcheck.sh`

The Helm chart opts in (`workerSandbox.sandboxRunner.clockSkewLivenessLimitSeconds: 10`).
The Compose files never did, so the check was dead there — and both reports came
from Compose deployments.

## Fix

Opt in from the two Compose files that actually run the sandbox-runner, at the
same 10s the chart uses. `docker-compose.scalable.yml` has no sandbox service and
needs nothing.

This deliberately does **not** change the script's `:-0` fallback — that would
silently overturn the documented decision above and its guard test. The
orchestrator opts in; the script's contract is unchanged.

The probe timeout is pinned to 2s because the script defaults to 5s while
`docker-compose.yaml`'s healthcheck timeout is 3s — the check could otherwise be
killed mid-request. 10 + 2 stays well under the 30s manifest tolerance.

Both values remain overridable, and setting the limit to `0` disables the check.

## Caveat

A Compose `HEALTHCHECK` marks a container unhealthy; it does not restart it. This
buys **detection** — `docker ps` now shows the real state instead of a green
container that fails every execution. Recovery still needs a restart policy or
watchdog. Drift also keeps accumulating, so a guest clock sync is the real fix.

## Verification

- `bash tests/sandbox_runner_healthcheck.sh` passes.
- Both Compose files parse, and the new entries follow the existing
  `${VAR:-default}` pattern.
- `tests/block_root_package_delivery.sh` exercises `docker compose config` on
  these files but needs a working Docker daemon, which I did not have locally —
  CI will be its first run against this change.