### PR TITLE
🎴 fix: Rotate PTC Replay Client Tokens

### DIFF
--- a/service/src/sandbox-backend/lambda-microvm.test.ts
+++ b/service/src/sandbox-backend/lambda-microvm.test.ts
@@ -303,43 +303,44 @@ describe('runtime session launch tokens', () => {
 });
 
 describe('statelessLaunchClientToken', () => {
-  const ptcIteration = (history: string): SandboxTransportRequest => ({
-    ...request(),
-    body: {
-      ...payloadBody(),
-      files: [{ id: history, storage_session_id: 'sess_store_1', name: '_ptc_history.json' }],
-    },
-  });
-
   test('is deterministic for an identical relaunch', () => {
-    const first = statelessLaunchClientToken('exec_42', config(), 420, request());
-    const second = statelessLaunchClientToken('exec_42', config(), 420, request());
-    expect(first).toBe(second);
+    expect(statelessLaunchClientToken('exec_42', config(), 420, 'job_1'))
+      .toBe(statelessLaunchClientToken('exec_42', config(), 420, 'job_1'));
   });
 
-  /* PTC replay reuses one executionId across iterations while the sandbox
-   * payload gains a new _ptc_history.json each round. A token derived from the
-   * executionId alone repeated, and AWS rejected the relaunch with "The
-   * provided clientToken was used with different request parameters". */
-  test('differs per replay iteration when the request body changes', () => {
-    const round1 = statelessLaunchClientToken('exec_42', config(), 420, ptcIteration('hist_1'));
-    const round2 = statelessLaunchClientToken('exec_42', config(), 420, ptcIteration('hist_2'));
+  /* PTC replay reuses one executionId across iterations, each enqueued as its
+   * own job. A token derived from the executionId alone repeated, and AWS
+   * rejected the relaunch with "The provided clientToken was used with
+   * different request parameters". */
+  test('differs per replay iteration', () => {
+    const round1 = statelessLaunchClientToken('exec_42', config(), 420, 'job_1');
+    const round2 = statelessLaunchClientToken('exec_42', config(), 420, 'job_2');
     expect(round1).not.toBe(round2);
     expect(round1).toMatch(/^exec-exec_42-[0-9a-f]{16}$/);
     expect(round2).toMatch(/^exec-exec_42-[0-9a-f]{16}$/);
   });
 
+  /* A replacement worker taking over a stalled job rebuilds the request with a
+   * fresh egress grant, sandbox session id and re-signed manifest. The token
+   * must not move with it, or RunMicrovm idempotency cannot recover a launch
+   * AWS already accepted and the orphaned VM burns capacity until it expires. */
+  test('is stable across attempts of the same queued job', () => {
+    const firstAttempt = statelessLaunchClientToken('exec_42', config(), 420, 'job_1');
+    const stalledRetry = statelessLaunchClientToken('exec_42', config(), 420, 'job_1');
+    expect(stalledRetry).toBe(firstAttempt);
+  });
+
   test('differs when launch configuration or duration changes', () => {
-    const base = statelessLaunchClientToken('exec_42', config(), 420, request());
-    expect(statelessLaunchClientToken('exec_42', config({ imageVersion: '4' }), 420, request()))
+    const base = statelessLaunchClientToken('exec_42', config(), 420, 'job_1');
+    expect(statelessLaunchClientToken('exec_42', config({ imageVersion: '4' }), 420, 'job_1'))
       .not.toBe(base);
-    expect(statelessLaunchClientToken('exec_42', config(), 421, request())).not.toBe(base);
+    expect(statelessLaunchClientToken('exec_42', config(), 421, 'job_1')).not.toBe(base);
   });
 
   test('stays within the AWS clientToken budget including the retry suffix', () => {
-    const token = statelessLaunchClientToken('exec_42', config(), 420, request());
+    const token = statelessLaunchClientToken('exec_42', config(), 420, 'job_1');
     expect(`${token}-r1`.length).toBeLessThanOrEqual(128);
-    expect(() => statelessLaunchClientToken('e'.repeat(200), config(), 420, request())).toThrow(
+    expect(() => statelessLaunchClientToken('e'.repeat(200), config(), 420, 'job_1')).toThrow(
       'Stateless launch clientToken exceeds the AWS length limit',
     );
   });

--- a/service/src/sandbox-backend/lambda-microvm.test.ts
+++ b/service/src/sandbox-backend/lambda-microvm.test.ts
@@ -26,6 +26,7 @@ import {
   runtimeSessionLaunchClientToken,
   runtimeSessionLaunchFingerprint,
   runtimeSessionLaunchGenerationSeed,
+  statelessLaunchClientToken,
   type LambdaMicrovmBackendConfig,
 } from './lambda-microvm';
 import { SandboxBackendError } from './types';
@@ -301,6 +302,49 @@ describe('runtime session launch tokens', () => {
   });
 });
 
+describe('statelessLaunchClientToken', () => {
+  const ptcIteration = (history: string): SandboxTransportRequest => ({
+    ...request(),
+    body: {
+      ...payloadBody(),
+      files: [{ id: history, storage_session_id: 'sess_store_1', name: '_ptc_history.json' }],
+    },
+  });
+
+  test('is deterministic for an identical relaunch', () => {
+    const first = statelessLaunchClientToken('exec_42', config(), 420, request());
+    const second = statelessLaunchClientToken('exec_42', config(), 420, request());
+    expect(first).toBe(second);
+  });
+
+  /* PTC replay reuses one executionId across iterations while the sandbox
+   * payload gains a new _ptc_history.json each round. A token derived from the
+   * executionId alone repeated, and AWS rejected the relaunch with "The
+   * provided clientToken was used with different request parameters". */
+  test('differs per replay iteration when the request body changes', () => {
+    const round1 = statelessLaunchClientToken('exec_42', config(), 420, ptcIteration('hist_1'));
+    const round2 = statelessLaunchClientToken('exec_42', config(), 420, ptcIteration('hist_2'));
+    expect(round1).not.toBe(round2);
+    expect(round1).toMatch(/^exec-exec_42-[0-9a-f]{16}$/);
+    expect(round2).toMatch(/^exec-exec_42-[0-9a-f]{16}$/);
+  });
+
+  test('differs when launch configuration or duration changes', () => {
+    const base = statelessLaunchClientToken('exec_42', config(), 420, request());
+    expect(statelessLaunchClientToken('exec_42', config({ imageVersion: '4' }), 420, request()))
+      .not.toBe(base);
+    expect(statelessLaunchClientToken('exec_42', config(), 421, request())).not.toBe(base);
+  });
+
+  test('stays within the AWS clientToken budget including the retry suffix', () => {
+    const token = statelessLaunchClientToken('exec_42', config(), 420, request());
+    expect(`${token}-r1`.length).toBeLessThanOrEqual(128);
+    expect(() => statelessLaunchClientToken('e'.repeat(200), config(), 420, request())).toThrow(
+      'Stateless launch clientToken exceeds the AWS length limit',
+    );
+  });
+});
+
 describe('LambdaMicrovmSandboxBackend stateless execution', () => {
   test('run -> health -> execute -> terminate happy path', async () => {
     const fake = fakeClient();
@@ -315,7 +359,7 @@ describe('LambdaMicrovmSandboxBackend stateless execution', () => {
     expect(runCalls).toHaveLength(1);
     const runArgs = runCalls[0].args as { imageIdentifier: string; clientToken?: string; maximumDurationSeconds: number };
     expect(runArgs.imageIdentifier).toBe('arn:aws:lambda:us-east-2:1:microvm-image:codeapi');
-    expect(runArgs.clientToken).toBe('exec-exec_42');
+    expect(runArgs.clientToken).toMatch(/^exec-exec_42-[0-9a-f]{16}$/);
     expect(runArgs.maximumDurationSeconds).toBe(Math.ceil(300_000 / 1_000) + 120);
 
     const executeReq = captured.find((c) => c.path === '/api/v2/execute');
@@ -509,8 +553,8 @@ describe('LambdaMicrovmSandboxBackend stateless execution', () => {
     const runCalls = fake.callsFor('runMicrovm');
     expect(runCalls).toHaveLength(2);
     const tokens = runCalls.map((call) => (call.args as { clientToken?: string }).clientToken);
-    expect(tokens[0]).toBe('exec-exec_42');
-    expect(tokens[1]).toBe('exec-exec_42-r1');
+    expect(tokens[0]).toMatch(/^exec-exec_42-[0-9a-f]{16}$/);
+    expect(tokens[1]).toBe(`${tokens[0]}-r1`);
   });
 
   test('the boot-death retry consumes only the first attempt remaining launch budget', async () => {
@@ -533,7 +577,8 @@ describe('LambdaMicrovmSandboxBackend stateless execution', () => {
     });
     const tokens = fake.callsFor('runMicrovm')
       .map(call => (call.args as { clientToken?: string }).clientToken);
-    expect(tokens).toEqual(['exec-exec_42', 'exec-exec_42-r1']);
+    expect(tokens[0]).toMatch(/^exec-exec_42-[0-9a-f]{16}$/);
+    expect(tokens).toEqual([tokens[0], `${tokens[0]}-r1`]);
     expect(captured.some(request => request.path === '/api/v2/execute')).toBe(false);
     expect(fake.callsFor('terminateMicrovm')).toHaveLength(2);
   });

--- a/service/src/sandbox-backend/lambda-microvm.ts
+++ b/service/src/sandbox-backend/lambda-microvm.ts
@@ -141,24 +141,31 @@ export function runtimeSessionLaunchGenerationSeed(config: LambdaMicrovmBackendC
 /** Stateless one-shot launch token.
  *
  * PTC replay reuses one executionId across every iteration, so a token derived
- * from the executionId alone repeats while the sandbox payload changes between
- * iterations (each carries a new `_ptc_history.json`). AWS rejects that with
- * "The provided clientToken was used with different request parameters" and the
- * whole execution fails. Fold the launch inputs and the per-iteration request
- * body into the token so each distinct launch gets a distinct token while an
- * identical retry stays idempotent. */
+ * from the executionId alone repeats while the launch parameters change with
+ * each iteration's payload. AWS rejects that with "The provided clientToken was
+ * used with different request parameters" and the whole execution fails.
+ *
+ * The discriminator is the queued job id rather than the request body: the body
+ * is rebuilt with a fresh egress grant, sandbox session id and re-signed
+ * manifest on every job attempt, so hashing it would hand a replacement worker
+ * a different token after a stalled-job takeover and launch a second VM instead
+ * of recovering the accepted one through RunMicrovm idempotency. The job id is
+ * distinct per replay iteration and stable across attempts of the same job.
+ *
+ * The launch configuration stays in the digest because a worker whose config
+ * differs must not reuse another worker's token. */
 export function statelessLaunchClientToken(
   executionId: string,
   config: LambdaMicrovmBackendConfig,
   maxDurationSeconds: number,
-  request: SandboxTransportRequest,
+  queuedJobId: string,
 ): string {
   const suffix = createHash('sha256')
     .update(
       JSON.stringify({
         launchRequest: runtimeSessionLaunchRequestFingerprint(config),
         maximumDurationSeconds: maxDurationSeconds,
-        body: request.body,
+        queuedJobId,
       }),
       'utf8',
     )
@@ -298,7 +305,9 @@ export class LambdaMicrovmSandboxBackend implements SandboxBackend {
         ctx.executionId !== '' ? ctx.executionId : nanoid(),
         this.config,
         maxDurationSeconds,
-        req,
+        /* No queued job id (direct backend caller): fall back to a fresh value
+         * so distinct launches never collide on one token. */
+        ctx.queuedJobId ?? nanoid(),
       ),
       maxDurationSeconds,
     });

--- a/service/src/sandbox-backend/lambda-microvm.ts
+++ b/service/src/sandbox-backend/lambda-microvm.ts
@@ -138,6 +138,41 @@ export function runtimeSessionLaunchGenerationSeed(config: LambdaMicrovmBackendC
   return RUNTIME_SESSION_NAMESPACED_GENERATION_MIN + offset;
 }
 
+/** Stateless one-shot launch token.
+ *
+ * PTC replay reuses one executionId across every iteration, so a token derived
+ * from the executionId alone repeats while the sandbox payload changes between
+ * iterations (each carries a new `_ptc_history.json`). AWS rejects that with
+ * "The provided clientToken was used with different request parameters" and the
+ * whole execution fails. Fold the launch inputs and the per-iteration request
+ * body into the token so each distinct launch gets a distinct token while an
+ * identical retry stays idempotent. */
+export function statelessLaunchClientToken(
+  executionId: string,
+  config: LambdaMicrovmBackendConfig,
+  maxDurationSeconds: number,
+  request: SandboxTransportRequest,
+): string {
+  const suffix = createHash('sha256')
+    .update(
+      JSON.stringify({
+        launchRequest: runtimeSessionLaunchRequestFingerprint(config),
+        maximumDurationSeconds: maxDurationSeconds,
+        body: request.body,
+      }),
+      'utf8',
+    )
+    .digest('hex')
+    .slice(0, 16);
+  const token = `exec-${executionId}-${suffix}`;
+  /* launch() can add "-r1" after a clean boot-time death; reserve those three
+   * characters so both attempts stay within AWS's 128-byte limit. */
+  if (token.length > 125) {
+    throw new Error('Stateless launch clientToken exceeds the AWS length limit');
+  }
+  return token;
+}
+
 export function runtimeSessionLaunchClientToken(runtimeSessionId: string, generation: number): string {
   if (!Number.isSafeInteger(generation) || generation < 1) {
     throw new Error('Runtime session generation must be a positive safe integer');
@@ -259,7 +294,12 @@ export class LambdaMicrovmSandboxBackend implements SandboxBackend {
       Math.ceil(this.config.jobTimeoutMs / 1_000) + 120,
     );
     const vm = await this.launch(client, ctx, {
-      clientToken: ctx.executionId !== '' ? `exec-${ctx.executionId}` : `exec-${nanoid()}`,
+      clientToken: statelessLaunchClientToken(
+        ctx.executionId !== '' ? ctx.executionId : nanoid(),
+        this.config,
+        maxDurationSeconds,
+        req,
+      ),
       maxDurationSeconds,
     });
     let terminateReason = 'stateless';

--- a/service/src/sandbox-backend/types.ts
+++ b/service/src/sandbox-backend/types.ts
@@ -39,6 +39,14 @@ export interface SandboxExecuteContext {
   canonicalUserId?: string;
   /** Trusted API-selected outbound worker. Presence requires a tenant-bound credential. */
   bridgeWorkerId?: string;
+  /** Stable identifier for this queued iteration, used to derive an idempotent
+   * stateless launch token. PTC replay reuses one executionId across every
+   * iteration, so the executionId alone cannot separate them; the request body
+   * can, but it is rebuilt with a fresh egress grant and manifest on every job
+   * attempt, so hashing it would break RunMicrovm idempotency when BullMQ
+   * reprocesses a stalled job. The queued job id is distinct per iteration and
+   * stable across attempts of the same job. */
+  queuedJobId?: string;
   /** Absent ⇒ stateless execution (no runtime session affinity). */
   runtimeSessionId?: string;
   runtimeSessionMode: t.RuntimeSessionMode;

--- a/service/src/workers.ts
+++ b/service/src/workers.ts
@@ -141,6 +141,7 @@ async function processJobInner(job: t.ExecuteJob): Promise<t.ExecuteResult> {
       },
       {
         executionId: job.data.executionId ?? '',
+        queuedJobId: job.id != null ? String(job.id) : undefined,
         language,
         isSynthetic: isSyntheticJob,
         signal: controller.signal,


### PR DESCRIPTION
Fixes #59

## Problem

Programmatic Tool Calling replay reuses one CodeAPI `executionId` across every
stateless MicroVM iteration, but the launch `clientToken` was derived from that
executionId alone:

```ts
clientToken: ctx.executionId !== '' ? `exec-${ctx.executionId}` : `exec-${nanoid()}`,
```

Each replay iteration relaunches with a *changed* sandbox payload — the next
round carries a fresh `_ptc_history.json` after CodeAPI persists the MCP result.
Same token, different request parameters, so AWS rejected the second launch:

```
The provided clientToken was used with different request parameters.
```

LibreChat surfaced only the generic `Bash programmatic execution failed: Code
execution failed`, which is why this was hard to place.

The runtime-session (stateful) path already guards against this with
`launch_request_fingerprint`; the stateless path had no equivalent.

## Fix

Fold the launch inputs and the per-iteration request body into the token, so each
distinct launch gets a distinct token while an identical retry stays idempotent:

```
exec-<executionId>-<sha256(launchRequest, maxDuration, body)[0:16]>
```

This reuses the existing `runtimeSessionLaunchRequestFingerprint` rather than
restating the launch inputs, so the two paths cannot drift.

The token keeps a 125-character budget: `launch()` appends `-r1` on a clean
boot-time death, and both attempts must stay inside AWS's 128-byte limit — the
same reservation `runtimeSessionLaunchClientToken` already makes.

## Tests

Three existing assertions pinned the old `exec-exec_42` shape and now assert the
hashed form, including that the boot-death retry stays `<token>-r1`.

Four new tests cover the fix, the middle one reproducing the reported failure —
one executionId, a new `_ptc_history.json` per round, tokens must differ:

- deterministic for an identical relaunch (idempotency preserved)
- **differs per replay iteration when the request body changes**
- differs when launch configuration or duration changes
- stays within the AWS budget including the retry suffix

`bun test src/sandbox-backend/lambda-microvm.test.ts` → 82 pass, 0 fail.
Full service suite is unchanged from `main`, and the typecheck sits at main's
existing baseline with nothing new.

## Credit

Diagnosed and patched by @snapydziuba in #59. This applies their fix, reusing the
existing fingerprint helper instead of duplicating the launch-input list.