### PR TITLE
🛳 fix: Fetch Bitnami Subcharts From OCI

### DIFF
--- a/helm/codeapi/Chart.yaml
+++ b/helm/codeapi/Chart.yaml
@@ -18,12 +18,17 @@ maintainers:
     url: https://github.com/danny-avila
 
 # Dependencies (we'll use these for Redis and MinIO)
+# Bitnami distributes charts OCI-only. The classic charts.bitnami.com/bitnami
+# index still lists these versions but resolves them to an oci:// download URL,
+# which HTTP-repository getters (notably FluxCD's source-controller) cannot
+# follow -- dependency resolution fails outright. Point at the OCI registry
+# directly; requires Helm >= 3.8.
 dependencies:
   - name: redis
     version: "24.1.0"
-    repository: "https://charts.bitnami.com/bitnami"
+    repository: "oci://registry-1.docker.io/bitnamicharts"
     condition: redis.enabled
   - name: minio
     version: "17.0.21"
-    repository: "https://charts.bitnami.com/bitnami"
+    repository: "oci://registry-1.docker.io/bitnamicharts"
     condition: minio.enabled

--- a/helm/codeapi/Chart.yaml
+++ b/helm/codeapi/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: codeapi
 description: A Helm chart for Code Interpreter API - scalable code execution service
 type: application
-version: 0.3.0       # Chart version (bump this when you change the chart)
+version: 0.3.1       # Chart version (bump this when you change the chart)
 appVersion: "2.0.0"  # App version (bump this when you change the app)
 
 # Keywords for searching

--- a/helm/codeapi/README.md
+++ b/helm/codeapi/README.md
@@ -6,7 +6,9 @@ Deploy the horizontally-scalable Code Interpreter API stack to Kubernetes.
 
 - Docker Desktop with Kubernetes enabled, OR
 - Minikube installed (`brew install minikube` / `choco install minikube`)
-- Helm 3.x (`brew install helm` / `choco install kubernetes-helm`)
+- Helm >= 3.8 (`brew install helm` / `choco install kubernetes-helm`) — the
+  redis and minio subcharts are pulled from an OCI registry, which older Helm
+  releases only support behind an experimental flag
 - kubectl (`brew install kubectl` / `choco install kubernetes-cli`)
 
 ## Execution manifest signing keys (required)

--- a/helm/setup-local.sh
+++ b/helm/setup-local.sh
@@ -32,9 +32,38 @@ check_command() {
     echo "✓ $1 found"
 }
 
+# The chart's subchart dependencies are OCI references, which Helm only
+# resolves without an experimental flag from 3.8 onward.
+check_helm_version() {
+    local required_major=3 required_minor=8
+    local raw major minor
+    raw=$(helm version --template '{{.Version}}' 2>/dev/null || true)
+    if [ -z "$raw" ]; then
+        echo "❌ could not determine the installed Helm version (need >= ${required_major}.${required_minor})."
+        exit 1
+    fi
+    raw=${raw#v}
+    major=${raw%%.*}
+    minor=${raw#*.}
+    minor=${minor%%.*}
+    case "$major$minor" in
+        *[!0-9]*|'')
+            echo "❌ could not parse the installed Helm version '$raw' (need >= ${required_major}.${required_minor})."
+            exit 1
+            ;;
+    esac
+    if [ "$major" -lt "$required_major" ] ||
+        { [ "$major" -eq "$required_major" ] && [ "$minor" -lt "$required_minor" ]; }; then
+        echo "❌ Helm $raw is too old. The chart's OCI subchart dependencies need >= ${required_major}.${required_minor}."
+        exit 1
+    fi
+    echo "✓ helm $raw supports OCI dependencies"
+}
+
 echo "📋 Checking prerequisites..."
 check_command docker
 check_command helm
+check_helm_version
 check_command kubectl
 check_command "$CLUSTER_TYPE"
 echo ""
@@ -96,8 +125,8 @@ fi
 
 # Add Helm repos and update dependencies
 echo "📚 Setting up Helm dependencies..."
-helm repo add bitnami https://charts.bitnami.com/bitnami 2>/dev/null || true
-helm repo update
+# Subcharts resolve from oci://registry-1.docker.io/bitnamicharts, so no
+# classic chart repository needs registering.
 helm dependency update ./helm/codeapi
 echo ""
 


### PR DESCRIPTION
Fixes #21

## Problem

`helm/codeapi/Chart.yaml` declares its redis and minio dependencies against the
legacy Bitnami HTTPS repo. Bitnami has since moved chart distribution to
OCI-only. The classic `charts.bitnami.com/bitnami` index still *lists* these
versions, but the underlying download URL is now an `oci://` reference.

Any tooling that resolves dependencies through the classic HTTP(S) Helm
repository getter — notably FluxCD's source-controller — cannot follow that
scheme, and resolution fails outright:

```
dependency build error: failed to add remote dependency 'redis':
chart download of version '24.1.0' failed:
Get "oci://registry-1.docker.io/bitnamicharts/redis:24.1.0": unsupported protocol scheme "oci"
```

minio is pinned against the same repo, so it fails identically once redis is
worked around.

## Fix

Point both dependencies at the OCI registry directly. Requires Helm >= 3.8, which
has been the case since 2022; FluxCD resolves `oci://` natively.

Chart versions are unchanged — `redis 24.1.0` and `minio 17.0.21` are the same
artifacts, fetched over a scheme the getters can actually follow.

## Verification

Both versions confirmed present on the OCI registry before changing anything:

```
helm show chart oci://registry-1.docker.io/bitnamicharts/redis --version 24.1.0
helm show chart oci://registry-1.docker.io/bitnamicharts/minio --version 17.0.21
```

Then end-to-end, which is what actually failed before:

```
$ helm dependency build helm/codeapi
Downloading redis from repo oci://registry-1.docker.io/bitnamicharts
Pulled: registry-1.docker.io/bitnamicharts/redis:24.1.0
Downloading minio from repo oci://registry-1.docker.io/bitnamicharts
Pulled: registry-1.docker.io/bitnamicharts/minio:17.0.21
```

`helm template` then renders 42 objects with the real subcharts in place (21
without them), so the chart is unaffected beyond dependency resolution.

## Note

This fixes chart *resolution* only. It does not address #11 (MinIO Community
Edition being unmaintained), which is a separate question about what the
self-hosted storage role should be.

## Credit

Reported with a precise root cause by @meroo36 in #21.