### PR TITLE
🗑️ fix: Make Code Environment File Deletion Work

### DIFF
--- a/service/scripts/rehydrate-session-cache.ts
+++ b/service/scripts/rehydrate-session-cache.ts
@@ -16,10 +16,14 @@ import { redisKeepAliveOptions } from '../src/redis-options';
  *   {"type":"source","environment":"example","region":"region-1","namespace":"codeapi","query_start_utc":"2026-01-01T00:00:00Z","query_end_utc":"2026-01-02T00:00:00Z"}
  *   {"session_id":"<21-character id>","expected_session_key":"<expected key>"}
  *
- * The apply path uses SET NX and never replaces an existing owner.
+ * The apply path uses SET NX and never replaces an existing owner. Both the
+ * `session:<id>` cache key and the durable `session-owner:<id>` record are
+ * restored, so recovered sessions stay deletable past SESSION_CACHE_TTL
+ * rather than stranding again a day later.
  */
 
 const DEFAULT_SESSION_CACHE_TTL_SECONDS = 86400;
+const DEFAULT_SESSION_OWNER_TTL_SECONDS = 90 * 86400;
 const MAX_RECOVERY_CONTEXT_LENGTH = 128;
 const MAX_RECOVERY_SESSION_KEY_LENGTH = 512;
 const MAX_RECONNECT_ATTEMPTS = 5;
@@ -78,6 +82,7 @@ interface Options extends RecoveryScope {
   apply: boolean;
   inputPath?: string;
   ttlSeconds: number;
+  ownerTtlSeconds: number;
 }
 
 function usage(): string {
@@ -97,8 +102,15 @@ Options:
                           SESSION_RECOVERY_REGION.
   --namespace <value>     Expected source namespace. Defaults to
                           SESSION_RECOVERY_NAMESPACE.
-  --ttl-seconds <number>  Redis TTL for restored keys. Defaults to
-                          SESSION_CACHE_TTL or ${DEFAULT_SESSION_CACHE_TTL_SECONDS}.
+  --ttl-seconds <number>  Redis TTL for restored session cache keys.
+                          Defaults to SESSION_CACHE_TTL or
+                          ${DEFAULT_SESSION_CACHE_TTL_SECONDS}.
+  --owner-ttl-seconds <number>
+                          Redis TTL for the durable session-owner records
+                          restored alongside them. Defaults to
+                          SESSION_OWNER_TTL or
+                          ${DEFAULT_SESSION_OWNER_TTL_SECONDS}, and is never
+                          shorter than --ttl-seconds.
   --help                  Show this help.
 
 Keep recovery manifests outside the repository because expected_session_key
@@ -154,6 +166,10 @@ export function parseOptions(args: string[], env: NodeJS.ProcessEnv = process.en
   let ttlSeconds = configuredTtl != null && configuredTtl !== ''
     ? parsePositiveInteger(configuredTtl, 'SESSION_CACHE_TTL')
     : DEFAULT_SESSION_CACHE_TTL_SECONDS;
+  const configuredOwnerTtl = env.SESSION_OWNER_TTL?.trim();
+  let ownerTtlSeconds = configuredOwnerTtl != null && configuredOwnerTtl !== ''
+    ? parsePositiveInteger(configuredOwnerTtl, 'SESSION_OWNER_TTL')
+    : DEFAULT_SESSION_OWNER_TTL_SECONDS;
   let environment = env.SESSION_RECOVERY_ENVIRONMENT;
   let region = env.SESSION_RECOVERY_REGION;
   let namespace = env.SESSION_RECOVERY_NAMESPACE;
@@ -189,6 +205,13 @@ export function parseOptions(args: string[], env: NodeJS.ProcessEnv = process.en
       );
       index += 1;
       break;
+    case '--owner-ttl-seconds':
+      ownerTtlSeconds = parsePositiveInteger(
+        optionValue(args, index, '--owner-ttl-seconds'),
+        '--owner-ttl-seconds',
+      );
+      index += 1;
+      break;
     case '--help':
       break;
     default:
@@ -203,6 +226,9 @@ export function parseOptions(args: string[], env: NodeJS.ProcessEnv = process.en
     region: parseRecoveryContext(region, 'Recovery region'),
     namespace: parseRecoveryContext(namespace, 'Recovery namespace'),
     ttlSeconds,
+    /* The durable record is what keeps a recovered session deletable
+     * beyond the cache TTL, so it can never be the shorter of the two. */
+    ownerTtlSeconds: Math.max(ownerTtlSeconds, ttlSeconds),
   };
 }
 
@@ -320,11 +346,45 @@ export function parseRecoveryManifest(
   return { source, records: [...bySessionId.values()] };
 }
 
+/**
+ * Restores the durable owner record for a session the caller has just
+ * confirmed (or restored) ownership of. Best effort by design: the record
+ * only widens what can be deleted later, so a race or a pre-existing
+ * entry is reported and never overwritten, and the outcome does not move
+ * a record between summary buckets.
+ */
+async function restoreOwnerRecord(
+  store: RecoveryStore,
+  record: RecoveryRecord,
+  ownerTtlSeconds: number,
+): Promise<void> {
+  const ownerKey = `session-owner:${record.session_id}`;
+  const result = await store.set(
+    ownerKey,
+    record.expected_session_key,
+    'EX',
+    ownerTtlSeconds,
+    'NX',
+  );
+  if (result === 'OK') {
+    return;
+  }
+  const existing = await store.get(ownerKey);
+  if (existing !== null && existing !== record.expected_session_key) {
+    // eslint-disable-next-line no-console
+    console.error(`Conflict: ${record.session_id} has a durable owner record for a different owner`);
+  }
+}
+
 export async function recoverSessionCache(
   records: RecoveryRecord[],
   store: RecoveryStore,
-  options: Pick<Options, 'apply' | 'ttlSeconds'>,
+  options: Pick<Options, 'apply' | 'ttlSeconds'> & { ownerTtlSeconds?: number },
 ): Promise<RecoverySummary> {
+  const ownerTtlSeconds = Math.max(
+    options.ownerTtlSeconds ?? DEFAULT_SESSION_OWNER_TTL_SECONDS,
+    options.ttlSeconds,
+  );
   const summary: RecoverySummary = {
     input: records.length,
     missing: 0,
@@ -339,6 +399,9 @@ export async function recoverSessionCache(
       const current = await store.get(redisKey);
       if (current === record.expected_session_key) {
         summary.matching += 1;
+        if (options.apply) {
+          await restoreOwnerRecord(store, record, ownerTtlSeconds);
+        }
         continue;
       }
       if (current !== null) {
@@ -362,12 +425,14 @@ export async function recoverSessionCache(
       );
       if (result === 'OK') {
         summary.restored += 1;
+        await restoreOwnerRecord(store, record, ownerTtlSeconds);
         continue;
       }
 
       const racedValue = await store.get(redisKey);
       if (racedValue === record.expected_session_key) {
         summary.matching += 1;
+        await restoreOwnerRecord(store, record, ownerTtlSeconds);
       } else if (racedValue === null) {
         summary.missing += 1;
         // eslint-disable-next-line no-console

--- a/service/scripts/rehydrate-session-cache.ts
+++ b/service/scripts/rehydrate-session-cache.ts
@@ -19,7 +19,9 @@ import { redisKeepAliveOptions } from '../src/redis-options';
  * The apply path uses SET NX and never replaces an existing owner. Both the
  * `session:<id>` cache key and the durable `session-owner:<id>` record are
  * restored, so recovered sessions stay deletable past SESSION_CACHE_TTL
- * rather than stranding again a day later.
+ * rather than stranding again a day later. A durable owner record naming a
+ * different owner is reported as a conflict and the session is skipped
+ * entirely, in both dry-run and apply.
  */
 
 const DEFAULT_SESSION_CACHE_TTL_SECONDS = 86400;
@@ -52,6 +54,8 @@ export interface RecoveryStore {
     ttlSeconds: number,
     condition: 'NX',
   ): Promise<'OK' | null>;
+  ttl(key: string): Promise<number>;
+  expire(key: string, ttlSeconds: number): Promise<unknown>;
 }
 
 export interface RecoverySummary {
@@ -347,33 +351,53 @@ export function parseRecoveryManifest(
 }
 
 /**
- * Restores the durable owner record for a session the caller has just
- * confirmed (or restored) ownership of. Best effort by design: the record
- * only widens what can be deleted later, so a race or a pre-existing
- * entry is reported and never overwritten, and the outcome does not move
- * a record between summary buckets.
+ * Reconciles the durable owner record for a session before its cache key
+ * is touched. Never overwrites a different owner: a manifest that
+ * disagrees with what the service recorded is a conflict, and the record
+ * is left for an operator rather than partially recovered.
  */
-async function restoreOwnerRecord(
+async function reconcileOwnerRecord(
   store: RecoveryStore,
   record: RecoveryRecord,
   ownerTtlSeconds: number,
-): Promise<void> {
+  apply: boolean,
+): Promise<'ready' | 'conflict'> {
   const ownerKey = `session-owner:${record.session_id}`;
-  const result = await store.set(
-    ownerKey,
-    record.expected_session_key,
-    'EX',
-    ownerTtlSeconds,
-    'NX',
-  );
-  if (result === 'OK') {
-    return;
+  let existing = await store.get(ownerKey);
+
+  if (existing === null && apply) {
+    const result = await store.set(
+      ownerKey,
+      record.expected_session_key,
+      'EX',
+      ownerTtlSeconds,
+      'NX',
+    );
+    if (result === 'OK') {
+      return 'ready';
+    }
+    existing = await store.get(ownerKey);
   }
-  const existing = await store.get(ownerKey);
-  if (existing !== null && existing !== record.expected_session_key) {
-    // eslint-disable-next-line no-console
-    console.error(`Conflict: ${record.session_id} has a durable owner record for a different owner`);
+
+  if (existing === null) {
+    return 'ready';
   }
+  if (existing !== record.expected_session_key) {
+    return 'conflict';
+  }
+  if (!apply) {
+    return 'ready';
+  }
+
+  /* The value already matches, and `SET NX` cannot extend an expiry. A
+   * record near the end of its life would otherwise lapse before the cache
+   * key this run is about to restore, stranding the session again the
+   * moment recovery appeared to succeed. */
+  const remaining = await store.ttl(ownerKey);
+  if (remaining >= 0 && remaining < ownerTtlSeconds) {
+    await store.expire(ownerKey, ownerTtlSeconds);
+  }
+  return 'ready';
 }
 
 export async function recoverSessionCache(
@@ -395,13 +419,21 @@ export async function recoverSessionCache(
 
   for (const record of records) {
     try {
+      /* Reconciled first: a durable owner that disagrees with the manifest
+       * is the strongest ownership signal available, and restoring the
+       * cache key anyway would hand the manifest's claimant a day of
+       * access the service never granted it. */
+      if (await reconcileOwnerRecord(store, record, ownerTtlSeconds, options.apply) === 'conflict') {
+        summary.conflicts += 1;
+        // eslint-disable-next-line no-console
+        console.error(`Conflict: ${record.session_id} has a durable owner record for a different owner`);
+        continue;
+      }
+
       const redisKey = `session:${record.session_id}`;
       const current = await store.get(redisKey);
       if (current === record.expected_session_key) {
         summary.matching += 1;
-        if (options.apply) {
-          await restoreOwnerRecord(store, record, ownerTtlSeconds);
-        }
         continue;
       }
       if (current !== null) {
@@ -425,14 +457,12 @@ export async function recoverSessionCache(
       );
       if (result === 'OK') {
         summary.restored += 1;
-        await restoreOwnerRecord(store, record, ownerTtlSeconds);
         continue;
       }
 
       const racedValue = await store.get(redisKey);
       if (racedValue === record.expected_session_key) {
         summary.matching += 1;
-        await restoreOwnerRecord(store, record, ownerTtlSeconds);
       } else if (racedValue === null) {
         summary.missing += 1;
         // eslint-disable-next-line no-console

--- a/service/scripts/rehydrate-session-cache.ts
+++ b/service/scripts/rehydrate-session-cache.ts
@@ -56,6 +56,7 @@ export interface RecoveryStore {
   ): Promise<'OK' | null>;
   ttl(key: string): Promise<number>;
   expire(key: string, ttlSeconds: number): Promise<unknown>;
+  del(key: string): Promise<unknown>;
 }
 
 export interface RecoverySummary {
@@ -371,6 +372,23 @@ async function inspectOwnerRecord(
 }
 
 /**
+ * Extends the durable record when it would lapse before the cache key this
+ * run just restored. `SET NX` cannot do it: a record near the end of its
+ * life would otherwise strand the session again the moment recovery
+ * reported success.
+ */
+async function refreshOwnerTtl(
+  store: RecoveryStore,
+  ownerKey: string,
+  ownerTtlSeconds: number,
+): Promise<void> {
+  const remaining = await store.ttl(ownerKey);
+  if (remaining >= 0 && remaining < ownerTtlSeconds) {
+    await store.expire(ownerKey, ownerTtlSeconds);
+  }
+}
+
+/**
  * Creates or extends the durable owner record for a session whose cache
  * key has just been confirmed to name the same owner. Runs only after that
  * confirmation: writing it earlier would leave a record behind for a
@@ -382,10 +400,18 @@ async function ensureOwnerRecord(
   record: RecoveryRecord,
   ownerTtlSeconds: number,
   existing: string | null,
-): Promise<'ready' | 'conflict'> {
+): Promise<'ready' | 'conflict' | 'unresolved'> {
   const ownerKey = `session-owner:${record.session_id}`;
 
-  if (existing === null) {
+  if (existing !== null) {
+    await refreshOwnerTtl(store, ownerKey, ownerTtlSeconds);
+    return 'ready';
+  }
+
+  /* `SET NX` can lose to a writer whose key then expires before the
+   * follow-up read, leaving no record and no conflict to report. One retry
+   * settles that; anything past it is reported rather than assumed. */
+  for (let attempt = 0; attempt < 2; attempt += 1) {
     const result = await store.set(
       ownerKey,
       record.expected_session_key,
@@ -397,21 +423,34 @@ async function ensureOwnerRecord(
       return 'ready';
     }
     const raced = await store.get(ownerKey);
-    if (raced !== null && raced !== record.expected_session_key) {
+    if (raced === record.expected_session_key) {
+      await refreshOwnerTtl(store, ownerKey, ownerTtlSeconds);
+      return 'ready';
+    }
+    if (raced !== null) {
       return 'conflict';
     }
-    return 'ready';
   }
+  return 'unresolved';
+}
 
-  /* The record already matches, and `SET NX` cannot extend an expiry. One
-   * near the end of its life would otherwise lapse before the cache key
-   * this run just restored, stranding the session again the moment
-   * recovery reported success. */
-  const remaining = await store.ttl(ownerKey);
-  if (remaining >= 0 && remaining < ownerTtlSeconds) {
-    await store.expire(ownerKey, ownerTtlSeconds);
+/**
+ * Whether an apply would still have durable-record work to do. Keeps the
+ * dry run honest: a session whose cache key already matches can still need
+ * its owner record created or extended, and reporting it as fully in place
+ * invites operators to skip the apply.
+ */
+async function ownerRepairPending(
+  store: RecoveryStore,
+  record: RecoveryRecord,
+  ownerTtlSeconds: number,
+  existing: string | null,
+): Promise<boolean> {
+  if (existing === null) {
+    return true;
   }
-  return 'ready';
+  const remaining = await store.ttl(`session-owner:${record.session_id}`);
+  return remaining >= 0 && remaining < ownerTtlSeconds;
 }
 
 export async function recoverSessionCache(
@@ -445,29 +484,47 @@ export async function recoverSessionCache(
         continue;
       }
 
+      const redisKey = `session:${record.session_id}`;
+
       /* Deferred until the cache key agrees. The durable record outlives
        * the cache key by design, so creating one for an owner the live
-       * cache key contradicts would outlast the evidence against it. */
-      const commitOwnerRecord = async (): Promise<boolean> => {
+       * cache key contradicts would outlast the evidence against it.
+       * Returns the bucket the record lands in when the durable half did
+       * not settle, or null to keep the cache-key bucket. */
+      const settleOwnerRecord = async (
+        restoredCacheKey: boolean,
+      ): Promise<'conflicts' | 'missing' | null> => {
         if (!options.apply) {
-          return true;
+          const pending = await ownerRepairPending(store, record, ownerTtlSeconds, inspection.existing);
+          return pending ? 'missing' : null;
         }
-        if (await ensureOwnerRecord(store, record, ownerTtlSeconds, inspection.existing) === 'ready') {
-          return true;
+
+        const outcome = await ensureOwnerRecord(store, record, ownerTtlSeconds, inspection.existing);
+        if (outcome === 'ready') {
+          return null;
         }
-        summary.conflicts += 1;
+        if (outcome === 'conflict') {
+          if (restoredCacheKey) {
+            /* Undo the grant just made: left in place it would authorize
+             * the manifest owner to read and delete for `ttlSeconds` while
+             * the durable record names somebody else. */
+            await store.del(redisKey);
+          }
+          // eslint-disable-next-line no-console
+          console.error(`Conflict: ${record.session_id} durable owner record changed during recovery`);
+          return 'conflicts';
+        }
+        /* The cache key stays: a session without a durable record is no
+         * worse off than before this run, and removing the grant would
+         * leave the operator with nothing at all. */
         // eslint-disable-next-line no-console
-        console.error(`Conflict: ${record.session_id} durable owner record changed during recovery`);
-        return false;
+        console.error(`Missing: ${record.session_id} durable owner record could not be created`);
+        return 'missing';
       };
 
-      const redisKey = `session:${record.session_id}`;
       const current = await store.get(redisKey);
       if (current === record.expected_session_key) {
-        if (!await commitOwnerRecord()) {
-          continue;
-        }
-        summary.matching += 1;
+        summary[await settleOwnerRecord(false) ?? 'matching'] += 1;
         continue;
       }
       if (current !== null) {
@@ -490,19 +547,13 @@ export async function recoverSessionCache(
         'NX',
       );
       if (result === 'OK') {
-        if (!await commitOwnerRecord()) {
-          continue;
-        }
-        summary.restored += 1;
+        summary[await settleOwnerRecord(true) ?? 'restored'] += 1;
         continue;
       }
 
       const racedValue = await store.get(redisKey);
       if (racedValue === record.expected_session_key) {
-        if (!await commitOwnerRecord()) {
-          continue;
-        }
-        summary.matching += 1;
+        summary[await settleOwnerRecord(false) ?? 'matching'] += 1;
       } else if (racedValue === null) {
         summary.missing += 1;
         // eslint-disable-next-line no-console

--- a/service/scripts/rehydrate-session-cache.ts
+++ b/service/scripts/rehydrate-session-cache.ts
@@ -350,22 +350,42 @@ export function parseRecoveryManifest(
   return { source, records: [...bySessionId.values()] };
 }
 
+type OwnerInspection =
+  | { status: 'agrees'; existing: string | null }
+  | { status: 'conflict' };
+
 /**
- * Reconciles the durable owner record for a session before its cache key
- * is touched. Never overwrites a different owner: a manifest that
- * disagrees with what the service recorded is a conflict, and the record
- * is left for an operator rather than partially recovered.
+ * Reads the durable owner record without writing. A record naming a
+ * different owner is the strongest ownership signal available, so it
+ * settles the session before anything is restored.
  */
-async function reconcileOwnerRecord(
+async function inspectOwnerRecord(
+  store: RecoveryStore,
+  record: RecoveryRecord,
+): Promise<OwnerInspection> {
+  const existing = await store.get(`session-owner:${record.session_id}`);
+  if (existing !== null && existing !== record.expected_session_key) {
+    return { status: 'conflict' };
+  }
+  return { status: 'agrees', existing };
+}
+
+/**
+ * Creates or extends the durable owner record for a session whose cache
+ * key has just been confirmed to name the same owner. Runs only after that
+ * confirmation: writing it earlier would leave a record behind for a
+ * manifest owner the live cache key contradicts, and `sessionAuth` would
+ * later authorize deletion through it.
+ */
+async function ensureOwnerRecord(
   store: RecoveryStore,
   record: RecoveryRecord,
   ownerTtlSeconds: number,
-  apply: boolean,
+  existing: string | null,
 ): Promise<'ready' | 'conflict'> {
   const ownerKey = `session-owner:${record.session_id}`;
-  let existing = await store.get(ownerKey);
 
-  if (existing === null && apply) {
+  if (existing === null) {
     const result = await store.set(
       ownerKey,
       record.expected_session_key,
@@ -376,23 +396,17 @@ async function reconcileOwnerRecord(
     if (result === 'OK') {
       return 'ready';
     }
-    existing = await store.get(ownerKey);
-  }
-
-  if (existing === null) {
-    return 'ready';
-  }
-  if (existing !== record.expected_session_key) {
-    return 'conflict';
-  }
-  if (!apply) {
+    const raced = await store.get(ownerKey);
+    if (raced !== null && raced !== record.expected_session_key) {
+      return 'conflict';
+    }
     return 'ready';
   }
 
-  /* The value already matches, and `SET NX` cannot extend an expiry. A
-   * record near the end of its life would otherwise lapse before the cache
-   * key this run is about to restore, stranding the session again the
-   * moment recovery appeared to succeed. */
+  /* The record already matches, and `SET NX` cannot extend an expiry. One
+   * near the end of its life would otherwise lapse before the cache key
+   * this run just restored, stranding the session again the moment
+   * recovery reported success. */
   const remaining = await store.ttl(ownerKey);
   if (remaining >= 0 && remaining < ownerTtlSeconds) {
     await store.expire(ownerKey, ownerTtlSeconds);
@@ -419,20 +433,40 @@ export async function recoverSessionCache(
 
   for (const record of records) {
     try {
-      /* Reconciled first: a durable owner that disagrees with the manifest
-       * is the strongest ownership signal available, and restoring the
-       * cache key anyway would hand the manifest's claimant a day of
-       * access the service never granted it. */
-      if (await reconcileOwnerRecord(store, record, ownerTtlSeconds, options.apply) === 'conflict') {
+      /* Inspected first, and read-only: a durable owner that disagrees
+       * with the manifest settles the session before anything is written,
+       * including the cache key — restoring that would hand the manifest's
+       * claimant a day of access the service never granted it. */
+      const inspection = await inspectOwnerRecord(store, record);
+      if (inspection.status === 'conflict') {
         summary.conflicts += 1;
         // eslint-disable-next-line no-console
         console.error(`Conflict: ${record.session_id} has a durable owner record for a different owner`);
         continue;
       }
 
+      /* Deferred until the cache key agrees. The durable record outlives
+       * the cache key by design, so creating one for an owner the live
+       * cache key contradicts would outlast the evidence against it. */
+      const commitOwnerRecord = async (): Promise<boolean> => {
+        if (!options.apply) {
+          return true;
+        }
+        if (await ensureOwnerRecord(store, record, ownerTtlSeconds, inspection.existing) === 'ready') {
+          return true;
+        }
+        summary.conflicts += 1;
+        // eslint-disable-next-line no-console
+        console.error(`Conflict: ${record.session_id} durable owner record changed during recovery`);
+        return false;
+      };
+
       const redisKey = `session:${record.session_id}`;
       const current = await store.get(redisKey);
       if (current === record.expected_session_key) {
+        if (!await commitOwnerRecord()) {
+          continue;
+        }
         summary.matching += 1;
         continue;
       }
@@ -456,12 +490,18 @@ export async function recoverSessionCache(
         'NX',
       );
       if (result === 'OK') {
+        if (!await commitOwnerRecord()) {
+          continue;
+        }
         summary.restored += 1;
         continue;
       }
 
       const racedValue = await store.get(redisKey);
       if (racedValue === record.expected_session_key) {
+        if (!await commitOwnerRecord()) {
+          continue;
+        }
         summary.matching += 1;
       } else if (racedValue === null) {
         summary.missing += 1;

--- a/service/scripts/rehydrate-session-cache.ts
+++ b/service/scripts/rehydrate-session-cache.ts
@@ -26,6 +26,8 @@ import { redisKeepAliveOptions } from '../src/redis-options';
 
 const DEFAULT_SESSION_CACHE_TTL_SECONDS = 86400;
 const DEFAULT_SESSION_OWNER_TTL_SECONDS = 90 * 86400;
+/** Redis `TTL` reply for a key that does not exist. */
+const KEY_ABSENT_TTL = -2;
 const MAX_RECOVERY_CONTEXT_LENGTH = 128;
 const MAX_RECOVERY_SESSION_KEY_LENGTH = 512;
 const MAX_RECONNECT_ATTEMPTS = 5;
@@ -55,7 +57,7 @@ export interface RecoveryStore {
     condition: 'NX',
   ): Promise<'OK' | null>;
   ttl(key: string): Promise<number>;
-  expire(key: string, ttlSeconds: number): Promise<unknown>;
+  expire(key: string, ttlSeconds: number): Promise<number>;
   del(key: string): Promise<unknown>;
 }
 
@@ -376,16 +378,33 @@ async function inspectOwnerRecord(
  * run just restored. `SET NX` cannot do it: a record near the end of its
  * life would otherwise strand the session again the moment recovery
  * reported success.
+ *
+ * The read, the extension and the confirmation are three round trips, so
+ * the record is re-read afterwards rather than assumed: it can expire in
+ * between (the caller then creates it fresh) or name somebody else (a
+ * conflict). Extending a record that turns out to belong to another owner
+ * prolongs a claim the service itself wrote and grants nothing new, but
+ * reporting the session as recovered on that basis would be a lie.
  */
 async function refreshOwnerTtl(
   store: RecoveryStore,
   ownerKey: string,
+  record: RecoveryRecord,
   ownerTtlSeconds: number,
-): Promise<void> {
+): Promise<'ready' | 'conflict' | 'vanished'> {
   const remaining = await store.ttl(ownerKey);
-  if (remaining >= 0 && remaining < ownerTtlSeconds) {
-    await store.expire(ownerKey, ownerTtlSeconds);
+  if (remaining === KEY_ABSENT_TTL) {
+    return 'vanished';
   }
+  if (remaining >= 0 && remaining < ownerTtlSeconds && await store.expire(ownerKey, ownerTtlSeconds) === 0) {
+    return 'vanished';
+  }
+
+  const confirmed = await store.get(ownerKey);
+  if (confirmed === null) {
+    return 'vanished';
+  }
+  return confirmed === record.expected_session_key ? 'ready' : 'conflict';
 }
 
 /**
@@ -404,8 +423,12 @@ async function ensureOwnerRecord(
   const ownerKey = `session-owner:${record.session_id}`;
 
   if (existing !== null) {
-    await refreshOwnerTtl(store, ownerKey, ownerTtlSeconds);
-    return 'ready';
+    const refreshed = await refreshOwnerTtl(store, ownerKey, record, ownerTtlSeconds);
+    if (refreshed !== 'vanished') {
+      return refreshed;
+    }
+    /* Expired between the inspection and the refresh. Fall through and
+     * create it as though it had never been there. */
   }
 
   /* `SET NX` can lose to a writer whose key then expires before the
@@ -424,8 +447,11 @@ async function ensureOwnerRecord(
     }
     const raced = await store.get(ownerKey);
     if (raced === record.expected_session_key) {
-      await refreshOwnerTtl(store, ownerKey, ownerTtlSeconds);
-      return 'ready';
+      const refreshed = await refreshOwnerTtl(store, ownerKey, record, ownerTtlSeconds);
+      if (refreshed !== 'vanished') {
+        return refreshed;
+      }
+      continue;
     }
     if (raced !== null) {
       return 'conflict';

--- a/service/src/config.ts
+++ b/service/src/config.ts
@@ -336,6 +336,16 @@ export const env = {
   FETCH_MAX_REQUESTS: Number(process.env.FETCH_MAX_REQUESTS) || 120, // 120 requests per minute
   // Redis Key Cache Config
   SESSION_CACHE_TTL: Number(process.env.SESSION_CACHE_TTL) || 86400,
+  /** TTL for the durable `session-owner:<session_id>` record that backs
+   *  deletion after `SESSION_CACHE_TTL` has lapsed (see
+   *  `session-ownership.ts`). Sized to outlive a client's retention
+   *  window — LibreChat sweeps expired files at 30 days by default, and a
+   *  shorter value here reinstates the leak it exists to close. Clamped
+   *  so it can never be tighter than the cache TTL. */
+  SESSION_OWNER_TTL: Math.max(
+    Number(process.env.SESSION_OWNER_TTL) || 90 * 86400,
+    Number(process.env.SESSION_CACHE_TTL) || 86400,
+  ),
   /** Strict tenant isolation. When true, sessionKey resolution fails closed
    *  (500) on requests whose auth context lacks `tenantId`, instead of
    *  silently falling back to the `'legacy'` tenant prefix. Default OFF in

--- a/service/src/middleware/auth.ts
+++ b/service/src/middleware/auth.ts
@@ -4,6 +4,7 @@ import { connection } from '../queue';
 import { isValidId } from '../utils';
 import { env } from '../config';
 import { resolveSessionKey, parseUploadSessionKeyInput, SessionKeyResolutionError } from '../session-key';
+import { authorizeSessionOwnership } from '../session-ownership';
 import { LibreChatJwtAuthProvider, CodeApiJwtAuthError } from '../auth/librechat-jwt';
 import { applyPrincipal, type CodeApiPrincipal } from '../auth/principal';
 import { applyLocalPrincipal } from '../auth/local';
@@ -238,10 +239,26 @@ export const sessionAuth = async (req: AuthenticatedRequest, res: Response, next
     }
     throw err;
   }
-  const cachedSessionKey = await connection.get(`session:${session_id}`);
-  if (cachedSessionKey !== sessionKey) {
-    logger.error(`Unauthorized download: Cached session key: ${cachedSessionKey} | Expected session key: ${sessionKey} | Session ID: ${session_id} | File ID: ${fileId}`);
+
+  /* A delete may fall back to the durable owner record once the session
+   * cache key has expired; reads keep the `SESSION_CACHE_TTL` window they
+   * have always had. Without the fallback an object is deletable only for
+   * the 24h following upload and is stranded in the bucket forever after
+   * that — see `session-ownership.ts`. */
+  const isDelete = req.method === 'DELETE';
+  const ownership = await authorizeSessionOwnership(connection, {
+    /* Narrowed by the `isValidId` guard above, which is not a type
+     * predicate. */
+    session_id: session_id as string,
+    expectedSessionKey: sessionKey,
+    allowExpiredCache: isDelete,
+  });
+  if (!ownership.authorized) {
+    logger.error(`Unauthorized ${isDelete ? 'delete' : 'download'}: Cached session key: ${ownership.cachedSessionKey} | Expected session key: ${sessionKey} | Session ID: ${session_id} | File ID: ${fileId} | Reason: ${ownership.reason}`);
     return res.status(403).json({ error: 'Unauthorized' });
+  }
+  if (ownership.source === 'owner') {
+    logger.info(`Delete authorized from durable owner record - Session ID: ${session_id} | File ID: ${fileId}`);
   }
 
   req.sessionKey = sessionKey;

--- a/service/src/middleware/auth.ts
+++ b/service/src/middleware/auth.ts
@@ -246,13 +246,22 @@ export const sessionAuth = async (req: AuthenticatedRequest, res: Response, next
    * the 24h following upload and is stranded in the bucket forever after
    * that — see `session-ownership.ts`. */
   const isDelete = req.method === 'DELETE';
-  const ownership = await authorizeSessionOwnership(connection, {
-    /* Narrowed by the `isValidId` guard above, which is not a type
-     * predicate. */
-    session_id: session_id as string,
-    expectedSessionKey: sessionKey,
-    allowExpiredCache: isDelete,
-  });
+  let ownership: Awaited<ReturnType<typeof authorizeSessionOwnership>>;
+  try {
+    ownership = await authorizeSessionOwnership(connection, {
+      /* Narrowed by the `isValidId` guard above, which is not a type
+       * predicate. */
+      session_id: session_id as string,
+      expectedSessionKey: sessionKey,
+      allowExpiredCache: isDelete,
+    });
+  } catch (err) {
+    /* Express 4 does not forward a rejected async middleware, so an
+     * unavailable Redis — or an ACL that grants `session:*` but not
+     * `session-owner:*` — would hang the request instead of answering. */
+    logger.error(`Session ownership lookup failed - Session ID: ${session_id} | File ID: ${fileId}`, err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
   if (!ownership.authorized) {
     logger.error(`Unauthorized ${isDelete ? 'delete' : 'download'}: Cached session key: ${ownership.cachedSessionKey} | Expected session key: ${sessionKey} | Session ID: ${session_id} | File ID: ${fileId} | Reason: ${ownership.reason}`);
     return res.status(403).json({ error: 'Unauthorized' });

--- a/service/src/rehydrate-session-cache.test.ts
+++ b/service/src/rehydrate-session-cache.test.ts
@@ -45,6 +45,21 @@ class MemoryStore implements RecoveryStore {
     this.ttls.set(key, ttlSeconds);
     return 'OK';
   }
+
+  async ttl(key: string): Promise<number> {
+    if (!this.values.has(key)) {
+      return -2;
+    }
+    return this.ttls.get(key) ?? -1;
+  }
+
+  async expire(key: string, ttlSeconds: number): Promise<number> {
+    if (!this.values.has(key)) {
+      return 0;
+    }
+    this.ttls.set(key, ttlSeconds);
+    return 1;
+  }
 }
 
 describe('rehydrate-session-cache', () => {
@@ -212,9 +227,56 @@ describe('rehydrate-session-cache', () => {
     expect(store.values.get(`session-owner:${SESSION_ID}`)).toBe(SESSION_KEY);
   });
 
-  it('never replaces an existing owner record', async () => {
+  it('reports a conflicting owner record and restores nothing for that session', async () => {
     const store = new MemoryStore();
     store.values.set(`session-owner:${SESSION_ID}`, 'tenant-id:user:someone-else');
+
+    const summary = await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: true, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    expect(summary).toEqual({ input: 1, missing: 0, restored: 0, matching: 0, conflicts: 1 });
+    expect(store.values.get(`session-owner:${SESSION_ID}`)).toBe('tenant-id:user:someone-else');
+    /* The manifest's claimant must not get a day of access the service
+     * never granted it. */
+    expect(store.values.has(`session:${SESSION_ID}`)).toBe(false);
+  });
+
+  it('surfaces a conflicting owner record during a dry run', async () => {
+    const store = new MemoryStore();
+    store.values.set(`session-owner:${SESSION_ID}`, 'tenant-id:user:someone-else');
+
+    const summary = await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: false, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    expect(summary).toEqual({ input: 1, missing: 0, restored: 0, matching: 0, conflicts: 1 });
+    expect(store.values.size).toBe(1);
+  });
+
+  it('extends a matching owner record that would expire before the restored cache key', async () => {
+    const store = new MemoryStore();
+    store.values.set(`session-owner:${SESSION_ID}`, SESSION_KEY);
+    store.ttls.set(`session-owner:${SESSION_ID}`, 600);
+
+    const summary = await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: true, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    expect(summary).toMatchObject({ restored: 1, conflicts: 0 });
+    expect(store.ttls.get(`session-owner:${SESSION_ID}`)).toBe(7776000);
+  });
+
+  it('leaves a longer-lived owner record alone', async () => {
+    const store = new MemoryStore();
+    store.values.set(`session-owner:${SESSION_ID}`, SESSION_KEY);
+    store.ttls.set(`session-owner:${SESSION_ID}`, 9999999);
 
     await recoverSessionCache(
       [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
@@ -222,7 +284,7 @@ describe('rehydrate-session-cache', () => {
       { apply: true, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
     );
 
-    expect(store.values.get(`session-owner:${SESSION_ID}`)).toBe('tenant-id:user:someone-else');
+    expect(store.ttls.get(`session-owner:${SESSION_ID}`)).toBe(9999999);
   });
 
   it('does not write during a dry run', async () => {
@@ -258,15 +320,23 @@ describe('rehydrate-session-cache', () => {
   it('preserves partial counts when a Redis operation fails', async () => {
     let reads = 0;
     const store: RecoveryStore = {
+      /* Two reads per record: the durable owner record, then the cache
+       * key. The first record resolves as matching; the second fails. */
       async get(): Promise<string | null> {
         reads += 1;
-        if (reads === 1) {
+        if (reads <= 2) {
           return SESSION_KEY;
         }
         throw new Error('Redis unavailable');
       },
       async set(): Promise<'OK' | null> {
         throw new Error('unexpected set');
+      },
+      async ttl(): Promise<number> {
+        return 7776000;
+      },
+      async expire(): Promise<number> {
+        throw new Error('unexpected expire');
       },
     };
 
@@ -299,6 +369,12 @@ describe('rehydrate-session-cache', () => {
       },
       async set(): Promise<null> {
         return null;
+      },
+      async ttl(): Promise<number> {
+        return -2;
+      },
+      async expire(): Promise<number> {
+        return 0;
       },
     };
 

--- a/service/src/rehydrate-session-cache.test.ts
+++ b/service/src/rehydrate-session-cache.test.ts
@@ -372,6 +372,59 @@ describe('rehydrate-session-cache', () => {
     expect(summary).toEqual({ input: 1, missing: 0, restored: 0, matching: 1, conflicts: 0 });
   });
 
+  it('creates the owner record when it expires between inspection and refresh', async () => {
+    const store = new MemoryStore();
+    store.values.set(`session:${SESSION_ID}`, SESSION_KEY);
+    store.values.set(`session-owner:${SESSION_ID}`, SESSION_KEY);
+    store.ttls.set(`session-owner:${SESSION_ID}`, 600);
+    const realTtl = store.ttl.bind(store);
+    let ttlReads = 0;
+    store.ttl = async (key: string): Promise<number> => {
+      ttlReads += 1;
+      if (ttlReads === 1) {
+        /* Lapses in the window between the inspection read and the
+         * extension it was about to perform. */
+        store.values.delete(`session-owner:${SESSION_ID}`);
+        store.ttls.delete(`session-owner:${SESSION_ID}`);
+        return -2;
+      }
+      return realTtl(key);
+    };
+
+    const summary = await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: true, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    expect(summary).toEqual({ input: 1, missing: 0, restored: 0, matching: 1, conflicts: 0 });
+    expect(store.values.get(`session-owner:${SESSION_ID}`)).toBe(SESSION_KEY);
+    expect(store.ttls.get(`session-owner:${SESSION_ID}`)).toBe(7776000);
+  });
+
+  it('reports an owner record replaced during the refresh as a conflict', async () => {
+    const store = new MemoryStore();
+    store.values.set(`session:${SESSION_ID}`, SESSION_KEY);
+    store.values.set(`session-owner:${SESSION_ID}`, SESSION_KEY);
+    store.ttls.set(`session-owner:${SESSION_ID}`, 600);
+    const realExpire = store.expire.bind(store);
+    store.expire = async (key: string, ttlSeconds: number): Promise<number> => {
+      const result = await realExpire(key, ttlSeconds);
+      store.values.set(`session-owner:${SESSION_ID}`, 'tenant-id:user:someone-else');
+      return result;
+    };
+
+    const summary = await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: true, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    /* The extension itself is harmless — it prolongs a claim the service
+     * wrote — but the session must not be reported as recovered. */
+    expect(summary).toEqual({ input: 1, missing: 0, restored: 0, matching: 0, conflicts: 1 });
+  });
+
   it('surfaces a conflicting owner record during a dry run', async () => {
     const store = new MemoryStore();
     store.values.set(`session-owner:${SESSION_ID}`, 'tenant-id:user:someone-else');
@@ -448,11 +501,12 @@ describe('rehydrate-session-cache', () => {
   it('preserves partial counts when a Redis operation fails', async () => {
     let reads = 0;
     const store: RecoveryStore = {
-      /* Two reads per record: the durable owner record, then the cache
-       * key. The first record resolves as matching; the second fails. */
+      /* Three reads to settle the first record: the durable owner, the
+       * cache key, then the owner re-read that confirms the refresh. The
+       * second record fails on its first read. */
       async get(): Promise<string | null> {
         reads += 1;
-        if (reads <= 2) {
+        if (reads <= 3) {
           return SESSION_KEY;
         }
         throw new Error('Redis unavailable');

--- a/service/src/rehydrate-session-cache.test.ts
+++ b/service/src/rehydrate-session-cache.test.ts
@@ -25,6 +25,7 @@ const SOURCE = {
 
 class MemoryStore implements RecoveryStore {
   readonly values = new Map<string, string>();
+  readonly ttls = new Map<string, number>();
 
   async get(key: string): Promise<string | null> {
     return this.values.get(key) ?? null;
@@ -34,13 +35,14 @@ class MemoryStore implements RecoveryStore {
     key: string,
     value: string,
     _expiryMode: 'EX',
-    _ttlSeconds: number,
+    ttlSeconds: number,
     _condition: 'NX',
   ): Promise<'OK' | null> {
     if (this.values.has(key)) {
       return null;
     }
     this.values.set(key, value);
+    this.ttls.set(key, ttlSeconds);
     return 'OK';
   }
 }
@@ -154,6 +156,73 @@ describe('rehydrate-session-cache', () => {
 
   it('requires the recovery scope', () => {
     expect(() => parseOptions([], {})).toThrow('Recovery environment');
+  });
+
+  it('defaults the owner TTL past the cache TTL and never below it', () => {
+    expect(parseOptions([], {
+      SESSION_RECOVERY_ENVIRONMENT: 'configured-env',
+      SESSION_RECOVERY_REGION: 'configured-region',
+      SESSION_RECOVERY_NAMESPACE: 'configured-namespace',
+    })).toMatchObject({ ttlSeconds: 86400, ownerTtlSeconds: 90 * 86400 });
+
+    expect(parseOptions(['--owner-ttl-seconds', '604800'], {
+      SESSION_RECOVERY_ENVIRONMENT: 'configured-env',
+      SESSION_RECOVERY_REGION: 'configured-region',
+      SESSION_RECOVERY_NAMESPACE: 'configured-namespace',
+    })).toMatchObject({ ownerTtlSeconds: 604800 });
+
+    /* A shorter owner TTL would re-strand the session it just recovered. */
+    expect(parseOptions([
+      '--ttl-seconds', '86400',
+      '--owner-ttl-seconds', '600',
+    ], {
+      SESSION_RECOVERY_ENVIRONMENT: 'configured-env',
+      SESSION_RECOVERY_REGION: 'configured-region',
+      SESSION_RECOVERY_NAMESPACE: 'configured-namespace',
+    })).toMatchObject({ ttlSeconds: 86400, ownerTtlSeconds: 86400 });
+  });
+
+  it('restores the durable owner record alongside the cache key', async () => {
+    const store = new MemoryStore();
+
+    const summary = await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: true, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    expect(summary).toMatchObject({ restored: 1, conflicts: 0 });
+    expect(store.values.get(`session:${SESSION_ID}`)).toBe(SESSION_KEY);
+    expect(store.ttls.get(`session:${SESSION_ID}`)).toBe(86400);
+    expect(store.values.get(`session-owner:${SESSION_ID}`)).toBe(SESSION_KEY);
+    expect(store.ttls.get(`session-owner:${SESSION_ID}`)).toBe(7776000);
+  });
+
+  it('backfills the owner record for a session whose cache key is still live', async () => {
+    const store = new MemoryStore();
+    store.values.set(`session:${SESSION_ID}`, SESSION_KEY);
+
+    const summary = await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: true, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    expect(summary).toMatchObject({ matching: 1, restored: 0, conflicts: 0 });
+    expect(store.values.get(`session-owner:${SESSION_ID}`)).toBe(SESSION_KEY);
+  });
+
+  it('never replaces an existing owner record', async () => {
+    const store = new MemoryStore();
+    store.values.set(`session-owner:${SESSION_ID}`, 'tenant-id:user:someone-else');
+
+    await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: true, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    expect(store.values.get(`session-owner:${SESSION_ID}`)).toBe('tenant-id:user:someone-else');
   });
 
   it('does not write during a dry run', async () => {

--- a/service/src/rehydrate-session-cache.test.ts
+++ b/service/src/rehydrate-session-cache.test.ts
@@ -60,6 +60,35 @@ class MemoryStore implements RecoveryStore {
     this.ttls.set(key, ttlSeconds);
     return 1;
   }
+
+  async del(key: string): Promise<number> {
+    this.ttls.delete(key);
+    return this.values.delete(key) ? 1 : 0;
+  }
+}
+
+/** Loses every `SET NX` on the durable owner key, optionally planting a
+ *  different owner for the follow-up read to find. */
+class RacingOwnerStore extends MemoryStore {
+  constructor(private readonly ownerAfterRace: string | null) {
+    super();
+  }
+
+  async set(
+    key: string,
+    value: string,
+    expiryMode: 'EX',
+    ttlSeconds: number,
+    condition: 'NX',
+  ): Promise<'OK' | null> {
+    if (!key.startsWith('session-owner:')) {
+      return super.set(key, value, expiryMode, ttlSeconds, condition);
+    }
+    if (this.ownerAfterRace !== null) {
+      this.values.set(key, this.ownerAfterRace);
+    }
+    return null;
+  }
 }
 
 describe('rehydrate-session-cache', () => {
@@ -261,6 +290,88 @@ describe('rehydrate-session-cache', () => {
     expect(store.values.has(`session-owner:${SESSION_ID}`)).toBe(false);
   });
 
+  it('rolls back a restored cache key when the owner record turns out to be another owner', async () => {
+    const store = new RacingOwnerStore('tenant-id:user:someone-else');
+
+    const summary = await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: true, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    expect(summary).toEqual({ input: 1, missing: 0, restored: 0, matching: 0, conflicts: 1 });
+    /* Left in place, the grant would authorize the manifest owner for a
+     * full ttlSeconds against a session the durable record says is not
+     * theirs. */
+    expect(store.values.has(`session:${SESSION_ID}`)).toBe(false);
+  });
+
+  it('reports an owner record that cannot be created as missing', async () => {
+    const store = new RacingOwnerStore(null);
+
+    const summary = await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: true, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    /* `missing` during an apply is what drives the nonzero exit — the run
+     * must not look like a completed recovery. */
+    expect(summary).toEqual({ input: 1, missing: 1, restored: 0, matching: 0, conflicts: 0 });
+    expect(store.values.has(`session-owner:${SESSION_ID}`)).toBe(false);
+    /* The cache key stays: no durable record is where this session already
+     * was, and removing it would leave the operator with nothing. */
+    expect(store.values.get(`session:${SESSION_ID}`)).toBe(SESSION_KEY);
+  });
+
+  it('reports pending owner work during a dry run', async () => {
+    const store = new MemoryStore();
+    store.values.set(`session:${SESSION_ID}`, SESSION_KEY);
+
+    const summary = await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: false, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    /* Counting this as `matching` would tell an operator the session is
+     * fully in place and invite them to skip the apply that creates its
+     * durable record. */
+    expect(summary).toEqual({ input: 1, missing: 1, restored: 0, matching: 0, conflicts: 0 });
+    expect(store.values.has(`session-owner:${SESSION_ID}`)).toBe(false);
+  });
+
+  it('reports a short-lived owner record as pending work during a dry run', async () => {
+    const store = new MemoryStore();
+    store.values.set(`session:${SESSION_ID}`, SESSION_KEY);
+    store.values.set(`session-owner:${SESSION_ID}`, SESSION_KEY);
+    store.ttls.set(`session-owner:${SESSION_ID}`, 600);
+
+    const summary = await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: false, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    expect(summary).toEqual({ input: 1, missing: 1, restored: 0, matching: 0, conflicts: 0 });
+    expect(store.ttls.get(`session-owner:${SESSION_ID}`)).toBe(600);
+  });
+
+  it('counts a fully in-place session as matching during a dry run', async () => {
+    const store = new MemoryStore();
+    store.values.set(`session:${SESSION_ID}`, SESSION_KEY);
+    store.values.set(`session-owner:${SESSION_ID}`, SESSION_KEY);
+    store.ttls.set(`session-owner:${SESSION_ID}`, 7776000);
+
+    const summary = await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: false, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    expect(summary).toEqual({ input: 1, missing: 0, restored: 0, matching: 1, conflicts: 0 });
+  });
+
   it('surfaces a conflicting owner record during a dry run', async () => {
     const store = new MemoryStore();
     store.values.set(`session-owner:${SESSION_ID}`, 'tenant-id:user:someone-else');
@@ -355,6 +466,9 @@ describe('rehydrate-session-cache', () => {
       async expire(): Promise<number> {
         throw new Error('unexpected expire');
       },
+      async del(): Promise<number> {
+        throw new Error('unexpected del');
+      },
     };
 
     try {
@@ -391,6 +505,9 @@ describe('rehydrate-session-cache', () => {
         return -2;
       },
       async expire(): Promise<number> {
+        return 0;
+      },
+      async del(): Promise<number> {
         return 0;
       },
     };

--- a/service/src/rehydrate-session-cache.test.ts
+++ b/service/src/rehydrate-session-cache.test.ts
@@ -244,6 +244,23 @@ describe('rehydrate-session-cache', () => {
     expect(store.values.has(`session:${SESSION_ID}`)).toBe(false);
   });
 
+  it('creates no durable owner record when the live cache key names another owner', async () => {
+    const store = new MemoryStore();
+    store.values.set(`session:${SESSION_ID}`, 'tenant-id:user:someone-else');
+
+    const summary = await recoverSessionCache(
+      [{ session_id: SESSION_ID, expected_session_key: SESSION_KEY }],
+      store,
+      { apply: true, ttlSeconds: 86400, ownerTtlSeconds: 7776000 },
+    );
+
+    expect(summary).toEqual({ input: 1, missing: 0, restored: 0, matching: 0, conflicts: 1 });
+    /* A durable record written here would outlive the cache key that
+     * contradicts it, and `sessionAuth` would then authorize the manifest
+     * owner to delete the real owner's files. */
+    expect(store.values.has(`session-owner:${SESSION_ID}`)).toBe(false);
+  });
+
   it('surfaces a conflicting owner record during a dry run', async () => {
     const store = new MemoryStore();
     store.values.set(`session-owner:${SESSION_ID}`, 'tenant-id:user:someone-else');

--- a/service/src/service/programmatic-router.ts
+++ b/service/src/service/programmatic-router.ts
@@ -1316,7 +1316,12 @@ async function handleBlocking(
   const execution_id = nanoid();
   const identity = getExecutionIdentity(req, userId);
 
-  void recordSessionOwnership(connection, session_id, sessionKey);
+  /* Awaited: a partial registration (cache key written, durable record
+   * refused — a Redis ACL scoped to `session:*` would do it) would let the
+   * job write files that become undeletable once `SESSION_CACHE_TTL`
+   * lapses. The caller turns a rejection into a 500 before anything is
+   * enqueued. */
+  await recordSessionOwnership(connection, session_id, sessionKey);
 
   const executionState: ExecutionState = {
     execution_id,

--- a/service/src/service/programmatic-router.ts
+++ b/service/src/service/programmatic-router.ts
@@ -40,6 +40,7 @@ import {
 } from '../sandbox-egress';
 import { findUnregisteredToolCall } from '../tool-scope';
 import { summarizeRequestedFiles } from '../execution-log';
+import { clearSessionOwnership, recordSessionOwnership } from '../session-ownership';
 import { FileRefAuthorizationError, authorizeRequestedFiles } from './file-authorization';
 import {
   buildReplayExecutionState,
@@ -562,7 +563,7 @@ async function handleReplayInitial(
     code.includes('import matplotlib') || code.includes('import seaborn')
   );
 
-  await connection.set(`session:${session_id}`, sessionKey, 'EX', env.SESSION_CACHE_TTL);
+  await recordSessionOwnership(connection, session_id, sessionKey);
 
   const state = buildReplayExecutionState({
     executionId: execution_id,
@@ -605,7 +606,7 @@ async function handleReplayInitial(
         bytes: err.bytes,
         cap: err.cap,
       });
-      await connection.del(`session:${session_id}`).catch(() => {});
+      await clearSessionOwnership(connection, session_id).catch(() => {});
       ptcReplayStateOversize.inc();
       res.status(413).json({
         error: `Request too large: serialized execution state is ${err.bytes} bytes (max ${err.cap}). Reduce the size of "code", "tools", or "files".`,
@@ -1315,7 +1316,7 @@ async function handleBlocking(
   const execution_id = nanoid();
   const identity = getExecutionIdentity(req, userId);
 
-  connection.set(`session:${session_id}`, sessionKey, 'EX', env.SESSION_CACHE_TTL);
+  void recordSessionOwnership(connection, session_id, sessionKey);
 
   const executionState: ExecutionState = {
     execution_id,

--- a/service/src/service/router.ts
+++ b/service/src/service/router.ts
@@ -220,7 +220,16 @@ router.post('/exec', executionLimiter, async (req: t.AuthenticatedRequest, res) 
    * sandbox invocation." */
   const session_id = nanoid();
   const execution_id = nanoid();
-  await recordSessionOwnership(connection, session_id, sessionKey);
+  /* Guarded: registration runs before the route's `try`, and Express 4
+   * does not forward a rejected async handler to the error middleware —
+   * an unavailable Redis, or an ACL that permits `session:*` but not
+   * `session-owner:*`, would hang the request instead of answering. */
+  try {
+    await recordSessionOwnership(connection, session_id, sessionKey);
+  } catch (error) {
+    logger.error(`[${INSTANCE_ID}] Error registering session ownership - Session ID: ${session_id}:`, error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
 
   try {
     if (!isSyntheticRequest) {

--- a/service/src/service/router.ts
+++ b/service/src/service/router.ts
@@ -932,7 +932,13 @@ const deleteSessionObject = async (req: t.AuthenticatedRequest, res: Response) =
      * as retryable and has it re-issuing the same DELETE for an object
      * that no longer exists on every subsequent pass. */
     if (axios.isAxiosError(error) && error.response?.status === 404) {
-      await connection.del(`upload:${req.sessionKey}${session_id}${fileId}`);
+      /* Best effort: this runs inside the catch block, where a rejection
+       * has no handler above it — Express 4 does not forward async
+       * rejections, so it would hang the request instead of answering.
+       * The key expires on its own, and the object is already gone. */
+      await connection.del(`upload:${req.sessionKey}${session_id}${fileId}`).catch((err: unknown) => {
+        logger.warn(`[${INSTANCE_ID}] Failed to clear upload key for absent file - Session ID: ${session_id} | File ID: ${fileId}:`, err);
+      });
       logger.info(`[${INSTANCE_ID}] File already absent: Session ID: ${session_id} | File ID: ${fileId}`);
       return res.status(404).json({ error: 'File not found' });
     }

--- a/service/src/service/router.ts
+++ b/service/src/service/router.ts
@@ -24,6 +24,7 @@ import { captureTraceCarrier, withSpan } from '../telemetry';
 import { Jobs, Languages } from '../enum';
 import { FileRefAuthorizationError, authorizeRequestedFiles } from './file-authorization';
 import { createUploadSessionRegistrar } from './upload-session';
+import { recordSessionOwnership } from '../session-ownership';
 import { prepareSandboxJobSecurity } from '../sandbox-egress';
 import {
   BridgeWorkerSelectionError,
@@ -219,7 +220,7 @@ router.post('/exec', executionLimiter, async (req: t.AuthenticatedRequest, res) 
    * sandbox invocation." */
   const session_id = nanoid();
   const execution_id = nanoid();
-  await connection.set(`session:${session_id}`, sessionKey, 'EX', env.SESSION_CACHE_TTL);
+  await recordSessionOwnership(connection, session_id, sessionKey);
 
   try {
     if (!isSyntheticRequest) {
@@ -478,7 +479,7 @@ router.post('/upload', uploadLimiter, async (req: t.AuthenticatedRequest, res: R
         if (readOnly) {
           putHeaders['X-Read-Only'] = 'true';
         }
-        connection.set(`session:${session_id}`, sessionKey, 'EX', env.SESSION_CACHE_TTL)
+        recordSessionOwnership(connection, session_id, sessionKey)
           .then(() => {
             logger.info(`[${INSTANCE_ID}] Upload: Session ID: ${session_id} | User ID: ${userId} | Session key: ${sessionKey}`);
             return axios.put<t.UploadResult>(
@@ -600,7 +601,7 @@ router.post('/upload/batch', uploadLimiter, async (req: t.AuthenticatedRequest, 
 
     const ensureSessionRegistered = createUploadSessionRegistrar((sessionKey) => {
       logger.info(`[${INSTANCE_ID}] Batch upload: Session ID: ${session_id} | User ID: ${userId} | Session key: ${sessionKey}`);
-      return connection.set(`session:${session_id}`, sessionKey, 'EX', env.SESSION_CACHE_TTL);
+      return recordSessionOwnership(connection, session_id, sessionKey);
     });
 
     const planFileSize = planLimits[req.planId ?? '']?.max_file_size ?? planLimits.default.max_file_size;
@@ -904,7 +905,15 @@ router.get('/sessions/:session_id/objects/:fileId', fetchLimiter, sessionAuth, a
   }
 });
 
-router.delete('/files/:session_id/:fileId', fetchLimiter, sessionAuth, async (req: t.AuthenticatedRequest, res: Response) => {
+/**
+ * Remove a session object.
+ *
+ * Mounted on two paths (see the registrations below); both are gated by
+ * `sessionAuth`, so the caller has to own the `(session_id, entity_id)`
+ * pair the object was stored under, and both proxy the same file-server
+ * route.
+ */
+const deleteSessionObject = async (req: t.AuthenticatedRequest, res: Response) => {
   const { session_id, fileId } = req.params;
 
   try {
@@ -917,12 +926,40 @@ router.delete('/files/:session_id/:fileId', fetchLimiter, sessionAuth, async (re
     logger.info(`[${INSTANCE_ID}] File deleted: Session ID: ${session_id} | File ID: ${fileId}`);
     return res.status(200).json(response.data);
   } catch (error) {
+    /* The file-server answers 404 when the object is already gone. Pass
+     * that through instead of collapsing it into a 500: a client sweeping
+     * expired files can retire the reference on 404, whereas a 500 reads
+     * as retryable and has it re-issuing the same DELETE for an object
+     * that no longer exists on every subsequent pass. */
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      await connection.del(`upload:${req.sessionKey}${session_id}${fileId}`);
+      logger.info(`[${INSTANCE_ID}] File already absent: Session ID: ${session_id} | File ID: ${fileId}`);
+      return res.status(404).json({ error: 'File not found' });
+    }
     const errorDetails = getAxiosErrorDetails(error);
     logger.error(`[${INSTANCE_ID}] Error deleting file - Session ID: ${session_id} | File ID: ${fileId}:`, errorDetails);
     return res.status(500).json({
       error: 'Error deleting file',
     });
   }
-});
+};
+
+router.delete('/files/:session_id/:fileId', fetchLimiter, sessionAuth, deleteSessionObject);
+
+/**
+ * Alias of the route above, on the path LibreChat's `deleteCodeEnvFile`
+ * targets — the file-server's own DELETE path, which is not itself
+ * exposed on `/v1`.
+ *
+ * Until LibreChat v0.8.6 this was the only path the client tried, and the
+ * 404 from an unmounted method was indistinguishable from "the object is
+ * already gone": every deletion silently failed and objects accumulated
+ * with nothing to alert on. Newer clients fall back to `/files/...`, but
+ * mounting the alias costs nothing and makes deletion work for
+ * deployments still running an older client.
+ *
+ * GET on this same path is the metadata proxy above.
+ */
+router.delete('/sessions/:session_id/objects/:fileId', fetchLimiter, sessionAuth, deleteSessionObject);
 
 export default router;

--- a/service/src/session-ownership.test.ts
+++ b/service/src/session-ownership.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  authorizeSessionOwnership,
+  clearSessionOwnership,
+  recordSessionOwnership,
+  sessionCacheKey,
+  sessionOwnerKey,
+  type SessionOwnershipStore,
+} from './session-ownership';
+
+interface Written {
+  value: string;
+  ttl: number;
+}
+
+function createStore(seed: Record<string, string> = {}) {
+  const values = new Map<string, string>(Object.entries(seed));
+  const writes: Record<string, Written> = {};
+  const store: SessionOwnershipStore = {
+    get: async (key) => values.get(key) ?? null,
+    set: async (key, value, _expiryMode, ttlSeconds) => {
+      values.set(key, value);
+      writes[key] = { value, ttl: ttlSeconds };
+      return 'OK';
+    },
+    del: async (...keys) => {
+      let removed = 0;
+      for (const key of keys) {
+        if (values.delete(key)) removed += 1;
+      }
+      return removed;
+    },
+  };
+  return { store, writes, values };
+}
+
+const SESSION_ID = 'session-1';
+const OWNER = 'tenant-1:user:user-1';
+
+describe('recordSessionOwnership', () => {
+  test('writes the cache key and the durable owner record together', async () => {
+    const { store, writes } = createStore();
+
+    await recordSessionOwnership(store, SESSION_ID, OWNER, { cacheTtl: 100, ownerTtl: 9000 });
+
+    expect(writes[sessionCacheKey(SESSION_ID)]).toEqual({ value: OWNER, ttl: 100 });
+    expect(writes[sessionOwnerKey(SESSION_ID)]).toEqual({ value: OWNER, ttl: 9000 });
+  });
+});
+
+describe('clearSessionOwnership', () => {
+  test('rolls back both records', async () => {
+    const { store, values } = createStore();
+    await recordSessionOwnership(store, SESSION_ID, OWNER, { cacheTtl: 100, ownerTtl: 9000 });
+
+    await clearSessionOwnership(store, SESSION_ID);
+
+    expect(values.has(sessionCacheKey(SESSION_ID))).toBe(false);
+    expect(values.has(sessionOwnerKey(SESSION_ID))).toBe(false);
+  });
+});
+
+describe('authorizeSessionOwnership', () => {
+  test('authorizes from the cache key while it is live', async () => {
+    const { store } = createStore({ [sessionCacheKey(SESSION_ID)]: OWNER });
+
+    const result = await authorizeSessionOwnership(store, {
+      session_id: SESSION_ID,
+      expectedSessionKey: OWNER,
+      allowExpiredCache: false,
+    });
+
+    expect(result).toEqual({ authorized: true, source: 'session' });
+  });
+
+  test('denies a read once the cache key has expired, even with an owner record', async () => {
+    const { store } = createStore({ [sessionOwnerKey(SESSION_ID)]: OWNER });
+
+    const result = await authorizeSessionOwnership(store, {
+      session_id: SESSION_ID,
+      expectedSessionKey: OWNER,
+      allowExpiredCache: false,
+    });
+
+    expect(result).toEqual({ authorized: false, reason: 'expired', cachedSessionKey: null });
+  });
+
+  test('authorizes a delete from the owner record once the cache key has expired', async () => {
+    const { store } = createStore({ [sessionOwnerKey(SESSION_ID)]: OWNER });
+
+    const result = await authorizeSessionOwnership(store, {
+      session_id: SESSION_ID,
+      expectedSessionKey: OWNER,
+      allowExpiredCache: true,
+    });
+
+    expect(result).toEqual({ authorized: true, source: 'owner' });
+  });
+
+  test('a live cache key naming another owner is authoritative and blocks the fallback', async () => {
+    const { store } = createStore({
+      [sessionCacheKey(SESSION_ID)]: 'tenant-1:user:someone-else',
+      /* Stale owner record that would otherwise match — a re-registered
+       * session must not be deletable by its previous owner. */
+      [sessionOwnerKey(SESSION_ID)]: OWNER,
+    });
+
+    const result = await authorizeSessionOwnership(store, {
+      session_id: SESSION_ID,
+      expectedSessionKey: OWNER,
+      allowExpiredCache: true,
+    });
+
+    expect(result).toEqual({
+      authorized: false,
+      reason: 'mismatch',
+      cachedSessionKey: 'tenant-1:user:someone-else',
+    });
+  });
+
+  test('denies a delete when the owner record names someone else', async () => {
+    const { store } = createStore({ [sessionOwnerKey(SESSION_ID)]: 'tenant-2:user:user-2' });
+
+    const result = await authorizeSessionOwnership(store, {
+      session_id: SESSION_ID,
+      expectedSessionKey: OWNER,
+      allowExpiredCache: true,
+    });
+
+    expect(result).toEqual({
+      authorized: false,
+      reason: 'mismatch',
+      cachedSessionKey: 'tenant-2:user:user-2',
+    });
+  });
+
+  test('reports sessions that predate the owner record as unknown', async () => {
+    const { store } = createStore();
+
+    const result = await authorizeSessionOwnership(store, {
+      session_id: SESSION_ID,
+      expectedSessionKey: OWNER,
+      allowExpiredCache: true,
+    });
+
+    expect(result).toEqual({ authorized: false, reason: 'unknown', cachedSessionKey: null });
+  });
+
+  test('a session registered through recordSessionOwnership stays deletable past the cache TTL', async () => {
+    const { store, values } = createStore();
+    await recordSessionOwnership(store, SESSION_ID, OWNER, { cacheTtl: 1, ownerTtl: 9000 });
+
+    /* Simulate the cache key aging out while the owner record lives on. */
+    values.delete(sessionCacheKey(SESSION_ID));
+
+    expect(
+      await authorizeSessionOwnership(store, {
+        session_id: SESSION_ID,
+        expectedSessionKey: OWNER,
+        allowExpiredCache: true,
+      }),
+    ).toEqual({ authorized: true, source: 'owner' });
+  });
+});

--- a/service/src/session-ownership.ts
+++ b/service/src/session-ownership.ts
@@ -1,0 +1,126 @@
+import { env } from './config';
+
+/**
+ * Ownership of a session's stored objects is recorded twice.
+ *
+ * `session:<session_id>` is the hot path: `sessionAuth` compares it on
+ * every download, metadata fetch and execution input, and its
+ * `SESSION_CACHE_TTL` (24h by default) is deliberately short — it bounds
+ * how long a sandbox invocation's outputs stay reachable.
+ *
+ * That bound is wrong for deletion. A file is deletable only while
+ * someone can still prove they own it, so with one key the window in
+ * which an object can be removed closes a day after upload and the
+ * object is stranded for the life of the deployment: unreadable,
+ * unusable as an execution input, and undeletable through every route.
+ * Clients sweeping their own retention window are typically far outside
+ * 24h when they get there (LibreChat's default retention is 30 days), so
+ * in practice every swept object failed to delete and the bucket only
+ * ever grew.
+ *
+ * `session-owner:<session_id>` is the durable half: same value, TTL
+ * `SESSION_OWNER_TTL`, consulted only when the cache key has expired and
+ * only for deletes. Read access keeps the original 24h bound.
+ */
+
+/** The subset of the Redis client these helpers need — narrow enough to
+ *  fake in tests without standing up a connection. */
+export interface SessionOwnershipStore {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, expiryMode: 'EX', ttlSeconds: number): Promise<unknown>;
+  del(...keys: string[]): Promise<unknown>;
+}
+
+export const sessionCacheKey = (session_id: string): string => `session:${session_id}`;
+export const sessionOwnerKey = (session_id: string): string => `session-owner:${session_id}`;
+
+export interface SessionOwnershipTtls {
+  cacheTtl?: number;
+  ownerTtl?: number;
+}
+
+/**
+ * Register `sessionKey` as the owner of `session_id`, writing both the
+ * cache key and the durable owner record. Replaces the bare
+ * `connection.set('session:…')` at every site that opens a session, so
+ * the two can never drift apart.
+ */
+export function recordSessionOwnership(
+  store: SessionOwnershipStore,
+  session_id: string,
+  sessionKey: string,
+  ttls: SessionOwnershipTtls = {},
+): Promise<unknown> {
+  const cacheTtl = ttls.cacheTtl ?? env.SESSION_CACHE_TTL;
+  const ownerTtl = ttls.ownerTtl ?? env.SESSION_OWNER_TTL;
+  return Promise.all([
+    store.set(sessionCacheKey(session_id), sessionKey, 'EX', cacheTtl),
+    store.set(sessionOwnerKey(session_id), sessionKey, 'EX', ownerTtl),
+  ]);
+}
+
+/**
+ * Roll back a registration, dropping both records. Used where a request
+ * is rejected after opening a session — leaving the durable half behind
+ * would keep an owner record alive for `SESSION_OWNER_TTL` on a session
+ * that never stored anything.
+ */
+export function clearSessionOwnership(
+  store: SessionOwnershipStore,
+  session_id: string,
+): Promise<unknown> {
+  return store.del(sessionCacheKey(session_id), sessionOwnerKey(session_id));
+}
+
+export type SessionOwnershipSource = 'session' | 'owner';
+
+/** `expired`: nothing live, and the durable record was not consulted or
+ *  had also lapsed. `unknown`: the session predates the owner record, so
+ *  ownership can no longer be established (recoverable with
+ *  `scripts/rehydrate-session-cache.ts`). `mismatch`: a recorded owner
+ *  exists and it is somebody else. */
+export type SessionOwnershipDenial = 'expired' | 'unknown' | 'mismatch';
+
+export type SessionOwnershipResult =
+  | { authorized: true; source: SessionOwnershipSource }
+  | { authorized: false; reason: SessionOwnershipDenial; cachedSessionKey: string | null };
+
+/**
+ * Decide whether `expectedSessionKey` owns `session_id`.
+ *
+ * A live cache key is always authoritative — when one exists and names a
+ * different owner the answer is no, and the durable record is not
+ * consulted. The fallback only covers the case where the cache key is
+ * simply gone.
+ */
+export async function authorizeSessionOwnership(
+  store: SessionOwnershipStore,
+  args: {
+    session_id: string;
+    expectedSessionKey: string;
+    /** Enable the durable fallback. Deletes pass true; reads keep the
+     *  `SESSION_CACHE_TTL` window they have always had. */
+    allowExpiredCache: boolean;
+  },
+): Promise<SessionOwnershipResult> {
+  const { session_id, expectedSessionKey, allowExpiredCache } = args;
+  const cachedSessionKey = await store.get(sessionCacheKey(session_id));
+  if (cachedSessionKey === expectedSessionKey) {
+    return { authorized: true, source: 'session' };
+  }
+  if (cachedSessionKey !== null) {
+    return { authorized: false, reason: 'mismatch', cachedSessionKey };
+  }
+  if (!allowExpiredCache) {
+    return { authorized: false, reason: 'expired', cachedSessionKey };
+  }
+
+  const recordedOwner = await store.get(sessionOwnerKey(session_id));
+  if (recordedOwner === expectedSessionKey) {
+    return { authorized: true, source: 'owner' };
+  }
+  if (recordedOwner === null) {
+    return { authorized: false, reason: 'unknown', cachedSessionKey };
+  }
+  return { authorized: false, reason: 'mismatch', cachedSessionKey: recordedOwner };
+}


### PR DESCRIPTION
Fixes the two sequential defects behind danny-avila/LibreChat#15511, where a
six-week-old deployment had accumulated 13 GiB across 29,177 objects with no
owner and no layer reporting a problem.

## 1. The delete route the client calls is not mounted

`deleteCodeEnvFile` issues `DELETE /v1/sessions/:session_id/objects/:fileId`
— the file-server's own path, which is not exposed on `/v1`, where only
`GET` is mounted. Every deletion 404s before `sessionAuth` is reached, and a
404 is indistinguishable from "the object is already gone", so the caller
clears its state and the bucket only ever grows.

This mounts `DELETE` on that path as an alias of the existing
`/v1/files/:session_id/:fileId` handler.

To be precise about what the alias does and does not buy: `deleteCodeEnvFile`
and its `/files/...` fallback were introduced in the *same* commit
(danny-avila/LibreChat#13424, first released in v0.8.6), so no released
client has ever issued a code-environment DELETE without the fallback — this
is not an old-client compatibility shim. What it removes is a guaranteed
404 on the first attempt of every delete the client makes, and the trap that
caused this bug: `/sessions/:session_id/objects/:fileId` is the path the
file-server itself exposes and the one a client is most likely to be written
against, and a 404 from an unmounted method there is indistinguishable from
"the object is already gone". Forks that carry only the original path — which
is how this was reported — start deleting again.

The handler also passes the file-server's 404 through instead of collapsing
it into a 500. A 500 reads as retryable: a client sweeping its retention
window re-issues the same DELETE every hour, forever, for an object that no
longer exists (~500 futile DELETEs/day on the reporting deployment).

## 2. Deletion authorization expires 24h after upload

Correcting the route alone changes the response from 404 to 403 and still
deletes nothing.

`sessionAuth` authorizes against `session:<session_id>`, whose
`SESSION_CACHE_TTL` defaults to 86400s and is not refreshed by use. Once it
lapses the object cannot be read, used as an execution input, *or* deleted,
by anyone, through any route — it is stranded for the life of the
deployment. Clients are typically well outside that window when they get
there; LibreChat's default retention is 30 days, so on shipped defaults every
retention-swept file is already 29 days past the point where it could be
authorized for deletion.

Ownership is now recorded twice:

| | key | TTL | consulted by |
|---|---|---|---|
| cache | `session:<id>` | `SESSION_CACHE_TTL` (24h) | every read, and deletes |
| durable | `session-owner:<id>` | `SESSION_OWNER_TTL` (90d) | deletes, only once the cache key is gone |

Both are written wherever a session is opened, and a rejected registration
rolls back both. The fallback is deliberately narrow:

- **DELETE only.** Reads keep the `SESSION_CACHE_TTL` window they have
  always had; this does not widen read access.
- **A live cache key is authoritative.** When one exists and names a
  different owner the answer is no and the durable record is not consulted,
  so a re-registered session is never deletable by its previous owner.
- **`SESSION_OWNER_TTL` is clamped** so it can never be shorter than
  `SESSION_CACHE_TTL`, and defaults past any realistic client retention
  window.

Sessions that predate this change have no durable record and are denied with
`reason: unknown` — recoverable with `scripts/rehydrate-session-cache.ts`,
which now restores both records (`--owner-ttl-seconds`) and backfills the
durable one for sessions whose cache key is still live. Without that, a
rehydrated session strands again 24 hours later.

## Not addressed here

- **Objects already stranded** on existing deployments. Recover ownership
  with the rehydrate script, or clear them with a bucket lifecycle policy.
- **The sweep's missing give-up/backoff** in LibreChat's
  `packages/api/src/files/sweep.ts` — client-side, separate change. The 404
  pass-through above removes the permanent-retry case it currently hits.

## Verification

- `bunx tsc --noEmit` — clean apart from four errors present on `main`
  (`egress-grant.ts`, `replay-state.ts`, and two test-file module-flag ones).
- `bun run test` — 696 pass. The two failures (`tool-input-signature.test.ts`
  jq canonicalization) fail identically on an unmodified tree and are a local
  jq version artifact.
- New `src/session-ownership.test.ts` covers the cache/durable split, the
  read-vs-delete asymmetry, live-key precedence over a stale owner record,
  and the pre-upgrade `unknown` case. `rehydrate-session-cache.test.ts` gains
  owner-record restore, backfill, never-replace, and TTL clamping.
