### PR TITLE
🧱 feat: Compose Sandboxed Workspace Commands

### DIFF
--- a/docs/remote-bridge/README.md
+++ b/docs/remote-bridge/README.md
@@ -142,6 +142,13 @@ default operations are read-only. The bridge protocol reserves a bounded
 advertise it. A later layer must bind it to a sandboxed process boundary and
 LibreChat's tool-approval hooks before it becomes dispatchable.
 
+The package exposes `SandboxWorkspaceTools` for composing that boundary without
+ever invoking a host shell. It requires an explicit sandbox implementation and
+an allowlist of workspace IDs, preserves per-workspace operation restrictions,
+validates bounded results, and treats an unknown command failure as an uncertain
+mutation. The built-in CLI remains command-disabled until its supported NsJail
+adapter can safely map a registered directory without changing host ownership.
+
 Stateful deployments must also set `LIBRECHAT_CODE_STATEFUL_WORKSPACE=true`
 and route the CLI's `{runtimeSessionId}` endpoint template to an isolated,
 persistent local runner per session. A single sandbox endpoint is stateless and

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -222,6 +222,15 @@ be advertised without durable quarantine storage. `LocalWorkspaceTools` never
 runs them in the worker host process; the CLI does not advertise command support
 until a sandbox runtime executor is configured.
 
+`SandboxWorkspaceTools` is the composition boundary for that runtime. It adds
+`execute_command` only to workspace IDs explicitly backed by a
+`WorkspaceCommandSandbox`, delegates every file operation to the confined local
+executor, and validates the sandbox's complete result before returning it. It
+does not include a shell fallback. Invalid responses and unknown sandbox errors
+are reported as potentially committed mutations so the worker's durable
+quarantine remains armed. A concrete runtime adapter must prove its mount and
+identity behavior before the CLI can enable this composition.
+
 Reads reject absolute paths, traversal, escaping symlinks, non-regular files,
 and files larger than 1 MiB. The opened file is checked against its canonical
 in-workspace inode before it is read. Text search uses `rg` only to enumerate a

--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -25,6 +25,7 @@ import type { FileHandle } from 'node:fs/promises';
 import {
   isWorkspaceToolResult,
   LocalWorkspaceTools,
+  SandboxWorkspaceTools,
   WorkspaceToolError,
 } from './workspace.js';
 
@@ -1543,4 +1544,139 @@ test('validates search result paths against the requested scope', () => {
     }),
     false,
   );
+});
+
+test('composes sandboxed commands without exposing them on unconfigured workspaces', async (t) => {
+  const first = await mkdtemp(join(tmpdir(), 'librechat-code-workspace-'));
+  const second = await mkdtemp(join(tmpdir(), 'librechat-code-workspace-'));
+  t.after(() => Promise.all([
+    rm(first, { recursive: true, force: true }),
+    rm(second, { recursive: true, force: true }),
+  ]));
+  await writeFile(join(first, 'README.md'), 'first');
+  const local = await LocalWorkspaceTools.create({
+    workspaces: [
+      { id: 'sandboxed', root: first, writable: true },
+      { id: 'read-only', root: second },
+    ],
+  });
+  const requests: object[] = [];
+  const tools = new SandboxWorkspaceTools({
+    workspaceTools: local,
+    commandWorkspaces: ['sandboxed'],
+    commandSandbox: {
+      async execute(request) {
+        requests.push(request);
+        return {
+          protocolVersion: 1,
+          operation: 'execute_command',
+          workspaceId: request.workspaceId,
+          exitCode: 0,
+          stdout: 'ok\n',
+          stderr: '',
+          truncated: false,
+          timedOut: false,
+        };
+      },
+    },
+  });
+
+  assert.deepEqual(tools.capabilities.operations, [
+    'read_file',
+    'search_text',
+    'list_files',
+    'write_file',
+    'edit_file',
+    'execute_command',
+  ]);
+  assert.deepEqual(
+    tools.capabilities.workspaces.find(({ id }) => id === 'sandboxed')?.operations,
+    tools.capabilities.operations,
+  );
+  assert.deepEqual(
+    tools.capabilities.workspaces.find(({ id }) => id === 'read-only')?.operations,
+    ['read_file', 'search_text', 'list_files'],
+  );
+  const command = {
+    protocolVersion: 1 as const,
+    operation: 'execute_command' as const,
+    workspaceId: 'sandboxed',
+    command: 'pwd',
+  };
+  assert.deepEqual(await tools.execute(command), {
+    protocolVersion: 1,
+    operation: 'execute_command',
+    workspaceId: 'sandboxed',
+    exitCode: 0,
+    stdout: 'ok\n',
+    stderr: '',
+    truncated: false,
+    timedOut: false,
+  });
+  assert.deepEqual(requests, [command]);
+  assert.equal(
+    (await tools.execute({
+      protocolVersion: 1,
+      operation: 'read_file',
+      workspaceId: 'sandboxed',
+      path: 'README.md',
+    })).operation,
+    'read_file',
+  );
+  await assert.rejects(
+    tools.execute({ ...command, workspaceId: 'read-only' }),
+    (error: unknown) =>
+      error instanceof WorkspaceToolError && error.code === 'COMMAND_DISABLED',
+  );
+});
+
+test('fails closed on invalid or failed sandbox command results', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-workspace-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const local = await LocalWorkspaceTools.create({
+    workspaces: [{ id: 'primary', root }],
+  });
+  const request = {
+    protocolVersion: 1 as const,
+    operation: 'execute_command' as const,
+    workspaceId: 'primary',
+    command: 'pwd',
+  };
+  for (const execute of [
+    async () => ({ ...request, exitCode: 0, stdout: 'ok', stderr: '' }),
+    async () => { throw new Error('container details'); },
+  ]) {
+    const tools = new SandboxWorkspaceTools({
+      workspaceTools: local,
+      commandWorkspaces: ['primary'],
+      commandSandbox: { execute },
+    });
+    await assert.rejects(
+      tools.execute(request),
+      (error: unknown) =>
+        error instanceof WorkspaceToolError &&
+        error.code === 'COMMAND_UNAVAILABLE' &&
+        error.mutationMayHaveCommitted === true &&
+        !error.message.includes('container details'),
+    );
+  }
+});
+
+test('rejects empty, duplicate, and unknown sandbox workspace registration', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-workspace-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const local = await LocalWorkspaceTools.create({
+    workspaces: [{ id: 'primary', root }],
+  });
+  for (const commandWorkspaces of [[], ['primary', 'primary'], ['unknown']]) {
+    assert.throws(
+      () => new SandboxWorkspaceTools({
+        workspaceTools: local,
+        commandWorkspaces,
+        commandSandbox: { async execute() { return {}; } },
+      }),
+      (error: unknown) =>
+        error instanceof WorkspaceToolError && error.code === 'REGISTRATION_INVALID',
+    );
+  }
 });

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -85,6 +85,25 @@ export interface WorkspaceToolExecutor {
   ): Promise<WorkspaceToolResult>;
 }
 
+/**
+ * Sandboxed command boundary used by {@link SandboxWorkspaceTools}. The
+ * implementation is responsible for process, filesystem, and network
+ * confinement; this package deliberately never falls back to a host shell.
+ */
+export interface WorkspaceCommandSandbox {
+  execute(
+    request: WorkspaceExecuteCommandRequest,
+    signal?: AbortSignal,
+  ): Promise<unknown>;
+}
+
+export interface SandboxWorkspaceToolsOptions {
+  workspaceTools: WorkspaceToolExecutor;
+  commandSandbox: WorkspaceCommandSandbox;
+  /** Workspace IDs whose sandbox is configured and may run commands. */
+  commandWorkspaces: string[];
+}
+
 const MAX_SEARCH_CANDIDATE_BYTES = 1024 * 1024;
 const MAX_SEARCH_CANDIDATES = 20_000;
 const SEARCH_TIMEOUT_MS = 10_000;
@@ -1426,5 +1445,91 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
       truncated,
       ...(truncated ? { nextStartLine: endLine + 1 } : {}),
     };
+  }
+}
+
+/**
+ * Composes ordinary workspace tools with an explicitly supplied sandboxed
+ * command boundary. Command failures are intentionally not declared atomic:
+ * callers must retain their durable mutation quarantine until settlement.
+ */
+export class SandboxWorkspaceTools implements WorkspaceToolExecutor {
+  readonly capabilities: BridgeWorkspaceToolCapabilities;
+  private readonly commandWorkspaces: ReadonlySet<string>;
+
+  constructor(private readonly options: SandboxWorkspaceToolsOptions) {
+    const base = options.workspaceTools.capabilities;
+    const registeredIds = new Set(base.workspaces.map(({ id }) => id));
+    const commandWorkspaces = new Set(options.commandWorkspaces);
+    if (
+      commandWorkspaces.size === 0 ||
+      commandWorkspaces.size !== options.commandWorkspaces.length ||
+      [...commandWorkspaces].some((id) => !registeredIds.has(id))
+    ) {
+      throw new WorkspaceToolError(
+        'Invalid sandbox workspace registration',
+        'REGISTRATION_INVALID',
+      );
+    }
+    this.commandWorkspaces = commandWorkspaces;
+    this.capabilities = {
+      protocolVersion: BRIDGE_PROTOCOL_VERSION,
+      operations: [...new Set([...base.operations, 'execute_command' as const])],
+      workspaces: base.workspaces.map((workspace) => ({
+        ...workspace,
+        operations: [
+          ...(workspace.operations ?? base.operations),
+          ...(commandWorkspaces.has(workspace.id)
+            ? (['execute_command'] as const)
+            : []),
+        ],
+      })),
+    };
+    if (!isValidBridgeWorkspaceToolCapabilities(this.capabilities)) {
+      throw new WorkspaceToolError(
+        'Invalid sandbox workspace registration',
+        'REGISTRATION_INVALID',
+      );
+    }
+  }
+
+  async execute(
+    request: WorkspaceToolRequest,
+    signal?: AbortSignal,
+  ): Promise<WorkspaceToolResult> {
+    if (request.operation !== 'execute_command') {
+      return this.options.workspaceTools.execute(request, signal);
+    }
+    if (!this.commandWorkspaces.has(request.workspaceId)) {
+      throw new WorkspaceToolError(
+        'Command execution is disabled for this workspace',
+        'COMMAND_DISABLED',
+      );
+    }
+    if (signal?.aborted) {
+      throw new WorkspaceToolError(
+        'Workspace command execution aborted',
+        'EXECUTION_ABORTED',
+      );
+    }
+    let result: unknown;
+    try {
+      result = await this.options.commandSandbox.execute(request, signal);
+    } catch (error) {
+      if (error instanceof WorkspaceToolError) throw error;
+      throw new WorkspaceToolError(
+        'Sandboxed command execution unavailable',
+        'COMMAND_UNAVAILABLE',
+        true,
+      );
+    }
+    if (!isWorkspaceToolResult(request, result)) {
+      throw new WorkspaceToolError(
+        'Sandboxed command returned an invalid result',
+        'COMMAND_UNAVAILABLE',
+        true,
+      );
+    }
+    return result;
   }
 }


### PR DESCRIPTION
## Summary

I added the fail-closed composition boundary that connects existing workspace file tools to an explicitly supplied sandbox command executor without introducing a host-shell fallback.

- Add `SandboxWorkspaceTools` and `WorkspaceCommandSandbox` as provider-neutral runtime contracts.
- Advertise `execute_command` only for explicitly configured workspace IDs while preserving every per-workspace operation restriction.
- Delegate reads, searches, listings, writes, and edits to the existing confined executor.
- Validate complete command results against the originating bounded request.
- Treat malformed responses and unknown sandbox failures as potentially committed mutations so durable quarantine remains armed.
- Document why CLI command support stays disabled until a concrete NsJail mount and identity profile is proven.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Documentation update

## Testing

- Ran `npm test` in `packages/code`: 206 passed, 1 platform-specific skip.

### **Test Configuration**:

- macOS arm64
- Node.js package test runner

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.