### PR TITLE
🧰 feat: Run BYOM Commands in NsJail

### DIFF
--- a/api/src/api/v2-session-binding.test.ts
+++ b/api/src/api/v2-session-binding.test.ts
@@ -20,6 +20,8 @@ let baseUrl: string;
 let packageDir: string;
 const savedSessionWorkspaceEnabled = config.session_workspace_enabled;
 const savedRequireExecutionManifest = config.require_execution_manifest;
+const savedExternalWorkspaceEnabled = config.external_workspace_enabled;
+const savedExternalWorkspaceToken = config.external_workspace_token;
 const testLanguage = 'headerless-session-regression';
 const testVersion = '1.0.0';
 
@@ -49,6 +51,8 @@ afterAll(async () => {
 afterEach(() => {
   config.session_workspace_enabled = savedSessionWorkspaceEnabled;
   config.require_execution_manifest = savedRequireExecutionManifest;
+  config.external_workspace_enabled = savedExternalWorkspaceEnabled;
+  config.external_workspace_token = savedExternalWorkspaceToken;
   resetSessionWorkspaceStateForTests();
 });
 
@@ -65,6 +69,62 @@ const execute = (runtimeSessionId?: string) =>
       files: [{ name: 'main.txt', content: 'test' }],
     }),
   });
+
+describe('workspace command route boundary', () => {
+  test('stays hidden unless the external workspace profile is enabled', async () => {
+    config.external_workspace_enabled = false;
+    const response = await fetch(`${baseUrl}/api/v2/workspace/execute`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{',
+    });
+    expect(response.status).toBe(404);
+  });
+
+  test('authenticates before parsing or binding a command request', async () => {
+    config.external_workspace_enabled = true;
+    config.external_workspace_token = 'a'.repeat(32);
+    config.session_workspace_enabled = true;
+    const unauthorized = await fetch(`${baseUrl}/api/v2/workspace/execute`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Runtime-Session-Id': 'rt_must_not_bind',
+      },
+      body: '{',
+    });
+    expect(unauthorized.status).toBe(401);
+    expect(getBoundSessionWorkspace()).toBeUndefined();
+
+    const authenticated = await fetch(`${baseUrl}/api/v2/workspace/execute`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-LibreChat-Workspace-Token': 'a'.repeat(32),
+      },
+      body: JSON.stringify({ command: 'pwd' }),
+    });
+    expect(authenticated.status).toBe(400);
+    expect(await authenticated.json()).toEqual({
+      message: 'X-Runtime-Session-Id is required',
+    });
+  });
+
+  test('parses the worst-case escaped valid command envelope', async () => {
+    config.external_workspace_enabled = true;
+    config.external_workspace_token = 'a'.repeat(32);
+    const response = await fetch(`${baseUrl}/api/v2/workspace/execute`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-LibreChat-Workspace-Token': 'a'.repeat(32),
+        'X-Runtime-Session-Id': 'rt_maximum_escaped_command',
+      },
+      body: JSON.stringify({ command: '\u0001'.repeat(32 * 1024) }),
+    });
+    expect(response.status).not.toBe(413);
+  });
+});
 
 describe('per-request session binding', () => {
   test('a headerless execute does not inherit the runner session bound by a prior request', async () => {

--- a/api/src/api/v2.ts
+++ b/api/src/api/v2.ts
@@ -36,6 +36,11 @@ import {
   HostedAppError,
   hostedAppSupervisor,
 } from '../hosted-app';
+import {
+  executeWorkspaceCommand,
+  hasWorkspaceCommandToken,
+  WorkspaceCommandRequestError,
+} from '../workspace-command';
 
 const router = express.Router();
 const SYNTHETIC_PRINCIPAL_SOURCE = 'synthetic_test';
@@ -382,6 +387,20 @@ function manifestErrorStatus(error: ExecutionManifestError): number {
   return 403;
 }
 
+router.use('/workspace/execute', (req: Request, res: Response, next: NextFunction) => {
+  if (req.method !== 'POST') return next();
+  if (!config.external_workspace_enabled) {
+    return res.status(404).json({ message: 'Not Found' });
+  }
+  if (!hasWorkspaceCommandToken(
+    config.external_workspace_token,
+    req.header('X-LibreChat-Workspace-Token'),
+  )) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  next();
+});
+
 router.use((req: Request, res: Response, next: NextFunction) => {
   if (['GET', 'HEAD', 'OPTIONS'].includes(req.method)) return next();
   /* Checkpoint restore and additive file delivery stream tar.gz bodies, not JSON. */
@@ -610,6 +629,40 @@ router.post('/execute', express.json({ limit: config.execute_body_limit }), asyn
       language: metricsLanguage,
       outcome: metricsOutcome,
       durationSeconds: (performance.now() - started) / 1000,
+    });
+  }
+});
+
+router.post('/workspace/execute', express.json({ limit: '256kb' }), async (req: Request, res: Response) => {
+  let binding;
+  try {
+    binding = parseSessionBindingFromHeader(req.headers[RUNTIME_SESSION_ID_HEADER]);
+  } catch (error) {
+    return res.status(400).json({
+      message: error instanceof Error ? error.message : 'Invalid runtime session',
+    });
+  }
+  if (!binding) {
+    return res.status(400).json({ message: 'X-Runtime-Session-Id is required' });
+  }
+  if (!bindSessionWorkspace(binding)) {
+    return res.status(409).json({
+      error: 'session_workspace_dirty',
+      message: 'Runner is bound to a different runtime session',
+    });
+  }
+  try {
+    return res.status(200).json(await executeWorkspaceCommand(req.body, {
+      workspaceRoot: config.external_workspace_root,
+    }));
+  } catch (error) {
+    if (error instanceof WorkspaceCommandRequestError) {
+      return res.status(400).json({ message: error.message });
+    }
+    logger.error({ err: error }, 'Sandboxed workspace command failed');
+    return res.status(500).json({
+      error: 'sandbox_execution_failed',
+      message: 'Sandboxed workspace command failed',
     });
   }
 });

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -71,6 +71,10 @@ export const config = {
    * session mode. An enabled runner additionally binds each request to a
    * workspace through the authenticated X-Runtime-Session-Id header. */
   session_workspace_enabled: (process.env.SANDBOX_SESSION_WORKSPACE_ENABLED ?? 'false') === 'true',
+  external_workspace_enabled: (process.env.SANDBOX_EXTERNAL_WORKSPACE_ENABLED ?? 'false') === 'true',
+  external_workspace_root: cleanDirectory(process.env.SANDBOX_EXTERNAL_WORKSPACE_ROOT)
+    ?? '/mnt/workspace',
+  external_workspace_token: process.env.SANDBOX_EXTERNAL_WORKSPACE_TOKEN ?? '',
   /**
    * Enables the Lambda-only hosted-app runner surface. This must only be set
    * on a dedicated app-host MicroVM image: user application processes share

--- a/api/src/workspace-command.test.ts
+++ b/api/src/workspace-command.test.ts
@@ -1,0 +1,145 @@
+import { mkdtemp, mkdir, realpath, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, test } from 'bun:test';
+import semver from 'semver';
+
+import type { Runtime } from './runtime';
+import {
+  executeWorkspaceCommand,
+  hasWorkspaceCommandToken,
+  WorkspaceCommandRequestError,
+} from './workspace-command';
+import type { WorkspaceCommandExecutionOptions } from './workspace-command';
+
+const runtime: Runtime = {
+  language: 'bash',
+  version: new semver.SemVer('5.2.0'),
+  aliases: [],
+  pkgdir: '/pkgs/bash/5.2.0',
+  compiled: false,
+  env_vars: { PATH: '/usr/bin:/bin' },
+  timeouts: { compile: 30_000, run: 30_000 },
+  cpu_times: { compile: 30_000, run: 30_000 },
+  memory_limits: { compile: 256_000_000, run: 256_000_000 },
+  max_process_count: 64,
+  max_open_files: 2048,
+  max_file_size: 10_000_000,
+  output_max_size: 1024,
+};
+
+describe('sandboxed workspace commands', () => {
+  test('requires an exact high-entropy runner capability', () => {
+    const token = 'a'.repeat(32);
+    expect(hasWorkspaceCommandToken(token, token)).toBe(true);
+    expect(hasWorkspaceCommandToken(token, `${token}x`)).toBe(false);
+    expect(hasWorkspaceCommandToken(token, undefined)).toBe(false);
+    expect(hasWorkspaceCommandToken('short', 'short')).toBe(false);
+  });
+
+  test('passes command and canonical cwd as arguments to NsJail', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'workspace-command-'));
+    try {
+      await mkdir(join(root, 'src'));
+      let captured: Parameters<NonNullable<WorkspaceCommandExecutionOptions['executeNsJail']>>[0] | undefined;
+      const response = await executeWorkspaceCommand({
+        command: 'printf ok',
+        cwd: 'src',
+        timeoutMs: 1234,
+        maxOutputBytes: 64,
+      }, {
+        workspaceRoot: root,
+        runtime,
+        executeNsJail: async (options) => {
+          captured = options;
+          return {
+            stdout: 'ok', stderr: '', code: 0, signal: null, output: 'ok',
+            memory: null, message: null, status: null, cpu_time: null, wall_time: 1,
+          };
+        },
+      });
+
+      expect(captured?.command).toEqual([
+        '/bin/bash', '--noprofile', '--norc', '-c',
+        'cd -- "$1" && exec /bin/bash --noprofile --norc -c "$2"',
+        'librechat-code', '/mnt/data/src', 'printf ok',
+      ]);
+      expect(captured?.submissionDir).toBe(await realpath(root));
+      expect(captured?.timeout).toBe(1234);
+      expect(captured?.outputMaxSize).toBe(64);
+      expect(response).toEqual({
+        exitCode: 0,
+        stdout: 'ok',
+        stderr: '',
+        truncated: false,
+        timedOut: false,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects a cwd symlink that escapes the mounted workspace', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'workspace-command-'));
+    try {
+      const root = join(parent, 'root');
+      await mkdir(root);
+      await symlink(parent, join(root, 'escape'));
+      await expect(executeWorkspaceCommand({
+        command: 'pwd',
+        cwd: 'escape',
+      }, { workspaceRoot: root, runtime, executeNsJail: async () => { throw new Error('must not run'); } }))
+        .rejects.toBeInstanceOf(WorkspaceCommandRequestError);
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects malformed requests before starting NsJail', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'workspace-command-'));
+    try {
+      for (const body of [
+        { command: '' },
+        { command: 'pwd', cwd: '../outside' },
+        { command: 'pwd', timeoutMs: 300_001 },
+        { command: 'pwd', unexpected: true },
+      ]) {
+        await expect(executeWorkspaceCommand(body, {
+          workspaceRoot: root,
+          runtime,
+          executeNsJail: async () => { throw new Error('must not run'); },
+        })).rejects.toBeInstanceOf(WorkspaceCommandRequestError);
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('bounds aggregate UTF-8 output and maps timeout state', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'workspace-command-'));
+    try {
+      const response = await executeWorkspaceCommand({
+        command: 'run',
+        maxOutputBytes: 5,
+      }, {
+        workspaceRoot: root,
+        runtime,
+        executeNsJail: async () => ({
+          stdout: '€€', stderr: 'tail', code: null, signal: 'SIGKILL', output: '',
+          memory: null, message: 'Time limit exceeded', status: 'TO', cpu_time: null, wall_time: 1,
+        }),
+      });
+      expect(Buffer.byteLength(response.stdout) + Buffer.byteLength(response.stderr)).toBeLessThanOrEqual(5);
+      expect(response).toEqual({
+        exitCode: null,
+        signal: 'SIGKILL',
+        stdout: '€',
+        stderr: 'ta',
+        truncated: true,
+        timedOut: true,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/api/src/workspace-command.ts
+++ b/api/src/workspace-command.ts
@@ -1,0 +1,200 @@
+import * as path from 'node:path';
+import * as fsp from 'node:fs/promises';
+import { timingSafeEqual } from 'node:crypto';
+
+import { aggregateBashExtras } from './job';
+import { execute, type NsJailResult } from './nsjail';
+import { getLatestRuntimeMatchingLanguageVersion } from './runtime';
+import type { Runtime } from './runtime';
+
+const COMMAND_MAX_BYTES = 32 * 1024;
+const COMMAND_MAX_TIMEOUT_MS = 5 * 60_000;
+const COMMAND_MAX_OUTPUT_BYTES = 1024 * 1024;
+const REQUEST_KEYS = new Set([
+  'command',
+  'cwd',
+  'timeoutMs',
+  'maxOutputBytes',
+]);
+
+export interface WorkspaceCommandBody {
+  command: string;
+  cwd?: string;
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+}
+
+export interface WorkspaceCommandResponse {
+  exitCode: number | null;
+  signal?: string;
+  stdout: string;
+  stderr: string;
+  truncated: boolean;
+  timedOut: boolean;
+}
+
+export class WorkspaceCommandRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WorkspaceCommandRequestError';
+  }
+}
+
+export interface WorkspaceCommandExecutionOptions {
+  workspaceRoot: string;
+  executeNsJail?: typeof execute;
+  runtime?: Runtime;
+}
+
+function safePortablePath(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= 4096 &&
+    value !== '..' &&
+    !value.startsWith('/') &&
+    !value.includes('\\') &&
+    !value.includes('\0') &&
+    !value.split('/').some((segment) => segment === '..') &&
+    Buffer.from(value).toString('utf8') === value
+  );
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+function integerInRange(value: unknown, minimum: number, maximum: number): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= minimum && Number(value) <= maximum;
+}
+
+export function hasWorkspaceCommandToken(
+  expected: string,
+  supplied: string | undefined,
+): boolean {
+  const expectedBytes = Buffer.from(expected);
+  const suppliedBytes = Buffer.from(supplied ?? '');
+  return (
+    expectedBytes.length >= 32 &&
+    suppliedBytes.length === expectedBytes.length &&
+    timingSafeEqual(suppliedBytes, expectedBytes)
+  );
+}
+
+function validateBody(value: unknown): WorkspaceCommandBody {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new WorkspaceCommandRequestError('Command request must be an object');
+  }
+  const body = value as Record<string, unknown>;
+  if (Object.keys(body).some((key) => !REQUEST_KEYS.has(key))) {
+    throw new WorkspaceCommandRequestError('Command request contains unexpected fields');
+  }
+  if (
+    typeof body.command !== 'string' ||
+    body.command.trim().length === 0 ||
+    body.command.includes('\0') ||
+    Buffer.from(body.command).toString('utf8') !== body.command ||
+    Buffer.byteLength(body.command) > COMMAND_MAX_BYTES
+  ) {
+    throw new WorkspaceCommandRequestError('Command is invalid or exceeds its size limit');
+  }
+  if (body.cwd !== undefined && (typeof body.cwd !== 'string' || !safePortablePath(body.cwd))) {
+    throw new WorkspaceCommandRequestError('Command working directory is invalid');
+  }
+  if (
+    body.timeoutMs !== undefined &&
+    !integerInRange(body.timeoutMs, 1, COMMAND_MAX_TIMEOUT_MS)
+  ) {
+    throw new WorkspaceCommandRequestError('Command timeout is invalid');
+  }
+  if (
+    body.maxOutputBytes !== undefined &&
+    !integerInRange(body.maxOutputBytes, 1, COMMAND_MAX_OUTPUT_BYTES)
+  ) {
+    throw new WorkspaceCommandRequestError('Command output limit is invalid');
+  }
+  return body as unknown as WorkspaceCommandBody;
+}
+
+function takeUtf8(value: string, budget: number): { value: string; bytes: number; truncated: boolean } {
+  const encoded = Buffer.from(value);
+  if (encoded.byteLength <= budget) {
+    return { value, bytes: encoded.byteLength, truncated: false };
+  }
+  let end = budget;
+  while (end > 0 && (encoded[end] & 0xc0) === 0x80) end -= 1;
+  const bounded = encoded.subarray(0, end).toString('utf8');
+  return { value: bounded, bytes: Buffer.byteLength(bounded), truncated: true };
+}
+
+function boundedResult(result: NsJailResult, maxOutputBytes: number): WorkspaceCommandResponse {
+  const stdout = takeUtf8(result.stdout, maxOutputBytes);
+  const stderr = takeUtf8(result.stderr, maxOutputBytes - stdout.bytes);
+  const timedOut = result.status === 'TO' || /time limit/i.test(result.message ?? '');
+  return {
+    exitCode: result.signal || timedOut ? null : (result.code ?? 1),
+    ...(result.signal ? { signal: result.signal } : {}),
+    stdout: stdout.value,
+    stderr: stderr.value,
+    truncated: stdout.truncated || stderr.truncated || result.status === 'OL',
+    timedOut,
+  };
+}
+
+export async function executeWorkspaceCommand(
+  rawBody: unknown,
+  options: WorkspaceCommandExecutionOptions,
+): Promise<WorkspaceCommandResponse> {
+  const body = validateBody(rawBody);
+  if (
+    !path.isAbsolute(options.workspaceRoot) ||
+    path.parse(options.workspaceRoot).root === options.workspaceRoot
+  ) {
+    throw new WorkspaceCommandRequestError('Configured workspace is unavailable');
+  }
+  const workspaceRoot = await fsp.realpath(options.workspaceRoot);
+  const rootStat = await fsp.stat(workspaceRoot);
+  if (!rootStat.isDirectory()) {
+    throw new WorkspaceCommandRequestError('Configured workspace is unavailable');
+  }
+  const cwd = await fsp.realpath(path.resolve(workspaceRoot, body.cwd ?? '.'))
+    .catch(() => { throw new WorkspaceCommandRequestError('Command working directory is unavailable'); });
+  if (!isWithin(workspaceRoot, cwd) || !(await fsp.stat(cwd)).isDirectory()) {
+    throw new WorkspaceCommandRequestError('Command working directory is unavailable');
+  }
+  const runtime = options.runtime ?? getLatestRuntimeMatchingLanguageVersion('bash', '*');
+  if (!runtime) throw new Error('Bash runtime is unavailable');
+  const envVars = {
+    ...runtime.env_vars,
+    HOME: '/mnt/data',
+    SANDBOX_LANGUAGE: 'bash',
+  };
+  const extraPkgdirs = aggregateBashExtras(runtime.pkgdir, envVars);
+  const relativeCwd = path.relative(workspaceRoot, cwd).split(path.sep).join('/');
+  const result = await (options.executeNsJail ?? execute)({
+    command: [
+      '/bin/bash',
+      '--noprofile',
+      '--norc',
+      '-c',
+      'cd -- "$1" && exec /bin/bash --noprofile --norc -c "$2"',
+      'librechat-code',
+      relativeCwd ? `/mnt/data/${relativeCwd}` : '/mnt/data',
+      body.command,
+    ],
+    envVars,
+    submissionDir: workspaceRoot,
+    pkgdir: runtime.pkgdir,
+    timeout: body.timeoutMs ?? 30_000,
+    memoryLimit: runtime.memory_limits.run,
+    outputMaxSize: body.maxOutputBytes ?? 256 * 1024,
+    extraPkgdirs,
+    identity: {
+      slot: 0,
+      uid: rootStat.uid,
+      gid: rootStat.gid,
+      perJobUid: true,
+    },
+  });
+  return boundedResult(result, body.maxOutputBytes ?? 256 * 1024);
+}

--- a/docs/remote-bridge/README.md
+++ b/docs/remote-bridge/README.md
@@ -149,6 +149,16 @@ validates bounded results, and treats an unknown command failure as an uncertain
 mutation. The built-in CLI remains command-disabled until its supported NsJail
 adapter can safely map a registered directory without changing host ownership.
 
+The supported `docker-nsjail` adapter enables that mapping only with
+`--allow-workspace-commands` (or
+`LIBRECHAT_CODE_ALLOW_WORKSPACE_COMMANDS=true`) and a registered worker/default
+directory. It mounts only the canonical workspace, keeps the runner port
+unpublished, authenticates its dedicated command route with an ephemeral
+container capability, and runs Bash inside the existing NsJail profile. Direct
+endpoint mode is rejected. This deployment permission does not replace the
+per-call approval decision: LibreChat must apply its configurable tool-approval
+hooks before dispatching `execute_command`.
+
 Stateful deployments must also set `LIBRECHAT_CODE_STATEFUL_WORKSPACE=true`
 and route the CLI's `{runtimeSessionId}` endpoint template to an isolated,
 persistent local runner per session. A single sandbox endpoint is stateless and

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -77,7 +77,7 @@ the same capability and seccomp policy as `docker-compose.mac.yml`:
 docker build --target local-oci-runtime \
   -t librechat-code-runtime:local -f api/Dockerfile .
 
-LIBRECHAT_CODE_RUNTIME_SUPERVISOR=docker-macos-nsjail \
+LIBRECHAT_CODE_RUNTIME_SUPERVISOR=docker-nsjail \
 LIBRECHAT_CODE_RUNTIME_IMAGE=librechat-code-runtime:local \
 LIBRECHAT_CODE_DOCKER_SECCOMP_PROFILE=./seccomp/nsjail.json \
 LIBRECHAT_CODE_DOCKER_PACKAGES_PATH=./data/pkgs \
@@ -230,6 +230,26 @@ does not include a shell fallback. Invalid responses and unknown sandbox errors
 are reported as potentially committed mutations so the worker's durable
 quarantine remains armed. A concrete runtime adapter must prove its mount and
 identity behavior before the CLI can enable this composition.
+
+The built-in Docker/NsJail adapter can be enabled explicitly for one registered
+directory:
+
+```bash
+LIBRECHAT_CODE_RUNTIME_SUPERVISOR=docker-nsjail \
+LIBRECHAT_CODE_RUNTIME_IMAGE=librechat-code-runtime:local \
+LIBRECHAT_CODE_DOCKER_SECCOMP_PROFILE=./seccomp/nsjail.json \
+LIBRECHAT_CODE_DOCKER_PACKAGES_PATH=./data/pkgs \
+librechat-code run --worker-dir /path/to/workspace --allow-workspace-commands
+```
+
+`docker-macos-nsjail` remains accepted as a compatibility alias. The worker
+bind-mounts only that canonical directory into an unexposed runtime
+container and submits commands to a private, capability-authenticated runner
+route. The runner maps the mounted directory owner into NsJail without chowning
+the directory, disables network access by default, rejects an escaping `cwd`,
+and bounds command, time, stdout, and stderr. The endpoint supervisor cannot
+enable this feature. This operator switch controls availability; LibreChat tool
+approval hooks remain the user-facing allow/deny boundary for each invocation.
 
 Reads reject absolute paths, traversal, escaping symlinks, non-regular files,
 and files larger than 1 MiB. The opened file is checked against its canonical

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -26,6 +26,10 @@
     "./workspace": {
       "types": "./dist/workspace.d.ts",
       "import": "./dist/workspace.js"
+    },
+    "./workspace-runtime": {
+      "types": "./dist/workspace-runtime.d.ts",
+      "import": "./dist/workspace-runtime.js"
     }
   },
   "bin": {

--- a/packages/code/src/cli.test.ts
+++ b/packages/code/src/cli.test.ts
@@ -67,7 +67,7 @@ test('CLI rejects an unknown runtime supervisor before entering the run loop', (
   assert.notEqual(result.status, 0);
   assert.match(
     result.stderr,
-    /LIBRECHAT_CODE_RUNTIME_SUPERVISOR must be endpoint, docker, or docker-macos-nsjail/,
+    /LIBRECHAT_CODE_RUNTIME_SUPERVISOR must be endpoint, docker, docker-nsjail, or docker-macos-nsjail/,
   );
 });
 
@@ -102,7 +102,7 @@ test('CLI requires the macOS NsJail seccomp profile', () => {
         LIBRECHAT_CODE_URL: 'https://code.example/v1',
         LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
         LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
-        LIBRECHAT_CODE_RUNTIME_SUPERVISOR: 'docker-macos-nsjail',
+        LIBRECHAT_CODE_RUNTIME_SUPERVISOR: 'docker-nsjail',
         LIBRECHAT_CODE_RUNTIME_IMAGE: 'example/runtime:latest',
       },
     },

--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -21,7 +21,13 @@ import {
 } from './storage.js';
 import { BridgeWorker } from './worker.js';
 import { DockerRuntimeSupervisor, EndpointRuntimeSupervisor } from './runtime.js';
-import { LocalWorkspaceTools } from './workspace.js';
+import {
+  LocalWorkspaceTools,
+  SandboxWorkspaceTools,
+} from './workspace.js';
+import { RuntimeWorkspaceCommandSandbox } from './workspace-runtime.js';
+import type { RuntimeSupervisor } from './runtime.js';
+import type { WorkspaceToolExecutor } from './workspace.js';
 import {
   BRIDGE_WORKSPACE_NAME_MAX_LENGTH,
   BridgeProtocolError,
@@ -201,12 +207,15 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
   if (
     runtimeMode !== 'endpoint' &&
     runtimeMode !== 'docker' &&
+    runtimeMode !== 'docker-nsjail' &&
     runtimeMode !== 'docker-macos-nsjail'
   ) {
     throw new Error(
-      'LIBRECHAT_CODE_RUNTIME_SUPERVISOR must be endpoint, docker, or docker-macos-nsjail',
+      'LIBRECHAT_CODE_RUNTIME_SUPERVISOR must be endpoint, docker, docker-nsjail, or docker-macos-nsjail',
     );
   }
+  const nsjailDockerMode =
+    runtimeMode === 'docker-nsjail' || runtimeMode === 'docker-macos-nsjail';
   const sandboxEndpoint =
     process.env.LIBRECHAT_CODE_SANDBOX_ENDPOINT ??
     'http://127.0.0.1:2000/api/v2';
@@ -229,7 +238,7 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
   const fileRelayUpstream =
     process.env.LIBRECHAT_CODE_FILE_RELAY_UPSTREAM?.trim();
   const fileRelayEnabled =
-    runtimeMode === 'docker-macos-nsjail' &&
+    nsjailDockerMode &&
     runtimeSessionId == null &&
     (fileRelayUpstream?.length ?? 0) > 0;
   const workspaceId =
@@ -252,6 +261,11 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
     runtimeSessionId == null &&
     (args.includes('--allow-workspace-writes') ||
       process.env.LIBRECHAT_CODE_ALLOW_WORKSPACE_WRITES?.trim().toLowerCase() ===
+        'true');
+  const allowWorkspaceCommands =
+    runtimeSessionId == null &&
+    (args.includes('--allow-workspace-commands') ||
+      process.env.LIBRECHAT_CODE_ALLOW_WORKSPACE_COMMANDS?.trim().toLowerCase() ===
         'true');
   if (explicitWorkerDirectory && useDefaultWorkspace) {
     throw new Error(
@@ -283,14 +297,14 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
     }
   }
   const mutationQuarantinePath =
-    allowWorkspaceWrites && canonicalWorkerDirectory
+    (allowWorkspaceWrites || allowWorkspaceCommands) && canonicalWorkerDirectory
       ? workspaceQuarantinePath({
           codeApiUrl,
           workerId,
           workspaceRoot: canonicalWorkerDirectory,
         })
       : undefined;
-  const workspaceTools = workerDirectory
+  let workspaceTools: WorkspaceToolExecutor | undefined = workerDirectory
     ? await LocalWorkspaceTools.create({
         workspaces: [
           {
@@ -307,19 +321,9 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
         ],
       })
     : undefined;
-  const capabilities = {
-    statefulWorkspace,
-    sandboxProfile:
-      process.env.LIBRECHAT_CODE_SANDBOX_PROFILE ??
-      (runtimeMode.startsWith('docker') ? 'oci-docker' : 'nsjail'),
-    runtimes: list(process.env.LIBRECHAT_CODE_RUNTIMES),
-    policyDigest: createHash('sha256').update(policy).digest('hex'),
-    ...(fileRelayEnabled ? { requiresReadyConfirmation: true } : {}),
-    ...(workspaceTools ? { workspaceTools: workspaceTools.capabilities } : {}),
-  };
-  if (!isValidBridgeWorkerCapabilities(capabilities)) {
+  if (allowWorkspaceCommands && (!canonicalWorkerDirectory || !nsjailDockerMode)) {
     throw new Error(
-      'LIBRECHAT_CODE_SANDBOX_PROFILE or LIBRECHAT_CODE_RUNTIMES is invalid',
+      'Workspace commands require a registered directory and the docker-nsjail runtime supervisor',
     );
   }
   const controller = new AbortController();
@@ -332,8 +336,8 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
         ? required('LIBRECHAT_CODE_RUNTIME_IMAGE')
         : process.env.LIBRECHAT_CODE_RUNTIME_IMAGE?.trim()
       : undefined;
-  const macLaunchProfile =
-    runtimeMode === 'docker-macos-nsjail' && runtimeSessionId == null
+  const nsjailLaunchProfile =
+    nsjailDockerMode && runtimeSessionId == null
       ? (() => {
           const seccompProfile = resolve(
             required('LIBRECHAT_CODE_DOCKER_SECCOMP_PROFILE'),
@@ -392,6 +396,105 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
   const fileRelayProfile = await fileRelaySupervisor?.prepare(
     controller.signal,
   );
+  const workspaceMount =
+    allowWorkspaceCommands && canonicalWorkerDirectory
+      ? {
+          source: canonicalWorkerDirectory,
+          target: '/mnt/workspace',
+        }
+      : undefined;
+  const workspaceCommandToken = allowWorkspaceCommands
+    ? createHmac(
+        'sha256',
+        pairedIdentity?.privateKey ??
+          required('LIBRECHAT_CODE_WORKER_TOKEN', configuredToken),
+      )
+        .update(`librechat-code-workspace-command-v1\0${canonicalWorkerDirectory}`)
+        .digest('base64url')
+    : undefined;
+  const runtimeSupervisor: RuntimeSupervisor =
+    runtimeMode !== 'endpoint'
+      ? new DockerRuntimeSupervisor({
+          image: runtimeImage,
+          ...(nsjailDockerMode && runtimeSessionId == null
+            ? (() => {
+                const { seccompProfile, packagesPath, profileRevision } =
+                  nsjailLaunchProfile!;
+                return {
+                  capabilities: MACOS_NSJAIL_CAPABILITIES,
+                  securityOptions: [`seccomp=${seccompProfile}`],
+                  profileRevision,
+                  restartStoppedContainers: false,
+                  ...(fileRelayProfile ? { network: fileRelayProfile.network } : {}),
+                  bindMounts: [
+                    { source: packagesPath, target: '/pkgs', readOnly: true },
+                    ...(workspaceMount ? [workspaceMount] : []),
+                  ],
+                  httpClient: 'bun' as const,
+                  environment: {
+                    SANDBOX_USE_CGROUPV2: 'false',
+                    SANDBOX_REMOVE_UMOUNT_AFTER_STARTUP: 'false',
+                    ...(workspaceMount
+                      ? {
+                          SANDBOX_EXTERNAL_WORKSPACE_ENABLED: 'true',
+                          SANDBOX_EXTERNAL_WORKSPACE_ROOT: workspaceMount.target,
+                          SANDBOX_EXTERNAL_WORKSPACE_TOKEN: workspaceCommandToken!,
+                        }
+                      : {}),
+                    ...(fileRelayProfile
+                      ? {
+                          EGRESS_GATEWAY_URL: fileRelayProfile.url,
+                          SANDBOX_PRIME_CONCURRENCY: String(fileRelayLimits!.maxConcurrentRequests),
+                          SANDBOX_UPLOAD_CONCURRENCY: String(fileRelayLimits!.maxConcurrentRequests),
+                          SANDBOX_FILE_RELAY_TOKEN: fileRelayProfile.token,
+                          SANDBOX_REQUIRE_EGRESS_MANIFEST: 'true',
+                          SANDBOX_EXECUTION_MANIFEST_PUBLIC_KEY: executionManifestPublicKey!,
+                        }
+                      : {}),
+                  },
+                };
+              })()
+            : workspaceMount
+              ? {
+                  bindMounts: [workspaceMount],
+                  environment: {
+                    SANDBOX_EXTERNAL_WORKSPACE_ENABLED: 'true',
+                    SANDBOX_EXTERNAL_WORKSPACE_ROOT: workspaceMount.target,
+                    SANDBOX_EXTERNAL_WORKSPACE_TOKEN: workspaceCommandToken!,
+                  },
+                }
+              : {}),
+        })
+      : new EndpointRuntimeSupervisor({
+          endpoint: sandboxEndpoint,
+          statefulWorkspace,
+        });
+  if (allowWorkspaceCommands && workspaceTools) {
+    workspaceTools = new SandboxWorkspaceTools({
+      workspaceTools,
+      commandWorkspaces: [workspaceId],
+      commandSandbox: new RuntimeWorkspaceCommandSandbox({
+        runtimeSupervisor,
+        workerId,
+        incarnationId,
+      }),
+    });
+  }
+  const capabilities = {
+    statefulWorkspace,
+    sandboxProfile:
+      process.env.LIBRECHAT_CODE_SANDBOX_PROFILE ??
+      (runtimeMode.startsWith('docker') ? 'oci-docker' : 'nsjail'),
+    runtimes: list(process.env.LIBRECHAT_CODE_RUNTIMES),
+    policyDigest: createHash('sha256').update(policy).digest('hex'),
+    ...(fileRelayEnabled ? { requiresReadyConfirmation: true } : {}),
+    ...(workspaceTools ? { workspaceTools: workspaceTools.capabilities } : {}),
+  };
+  if (!isValidBridgeWorkerCapabilities(capabilities)) {
+    throw new Error(
+      'LIBRECHAT_CODE_SANDBOX_PROFILE or LIBRECHAT_CODE_RUNTIMES is invalid',
+    );
+  }
   try {
     const worker = new BridgeWorker({
       codeApiUrl,
@@ -399,57 +502,7 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
       identity: workerIdentity,
       workerId,
       incarnationId,
-      runtimeSupervisor:
-        runtimeMode !== 'endpoint'
-          ? new DockerRuntimeSupervisor({
-              image: runtimeImage,
-              ...(runtimeMode === 'docker-macos-nsjail' && runtimeSessionId == null
-                ? (() => {
-                    const { seccompProfile, packagesPath, profileRevision } =
-                      macLaunchProfile!;
-                    return {
-                      capabilities: MACOS_NSJAIL_CAPABILITIES,
-                      securityOptions: [`seccomp=${seccompProfile}`],
-                      profileRevision,
-                      restartStoppedContainers: false,
-                      ...(fileRelayProfile
-                        ? { network: fileRelayProfile.network }
-                        : {}),
-                      bindMounts: [
-                        {
-                          source: packagesPath,
-                          target: '/pkgs',
-                          readOnly: true,
-                        },
-                      ],
-                      httpClient: 'bun',
-                      environment: {
-                        SANDBOX_USE_CGROUPV2: 'false',
-                        SANDBOX_REMOVE_UMOUNT_AFTER_STARTUP: 'false',
-                        ...(fileRelayProfile
-                          ? {
-                              EGRESS_GATEWAY_URL: fileRelayProfile.url,
-                              SANDBOX_PRIME_CONCURRENCY: String(
-                                fileRelayLimits!.maxConcurrentRequests,
-                              ),
-                              SANDBOX_UPLOAD_CONCURRENCY: String(
-                                fileRelayLimits!.maxConcurrentRequests,
-                              ),
-                              SANDBOX_FILE_RELAY_TOKEN: fileRelayProfile.token,
-                              SANDBOX_REQUIRE_EGRESS_MANIFEST: 'true',
-                              SANDBOX_EXECUTION_MANIFEST_PUBLIC_KEY:
-                                executionManifestPublicKey!,
-                            }
-                          : {}),
-                      },
-                    };
-                  })()
-                : {}),
-            })
-          : new EndpointRuntimeSupervisor({
-              endpoint: sandboxEndpoint,
-              statefulWorkspace,
-            }),
+      runtimeSupervisor,
       capabilities,
       workspaceTools,
       workspaceMutationQuarantine: mutationQuarantinePath

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -4,4 +4,5 @@ export * from './pairing.js';
 export * from './storage.js';
 export * from './runtime.js';
 export * from './workspace.js';
+export * from './workspace-runtime.js';
 export * from './worker.js';

--- a/packages/code/src/runtime.test.ts
+++ b/packages/code/src/runtime.test.ts
@@ -110,6 +110,48 @@ test('docker runtime supervisor creates a networkless stateful runtime and execu
   assert.ok(health?.includes('--max-time'));
 });
 
+test('docker runtime supervisor permits only its fixed workspace command route', async () => {
+  const calls: string[][] = [];
+  const supervisor = new DockerRuntimeSupervisor({
+    image: 'runner:latest',
+    environment: {
+      SANDBOX_EXTERNAL_WORKSPACE_TOKEN: 'private-workspace-capability',
+    },
+    client: {
+      async run(args) {
+        calls.push(args);
+        if (args[0] === 'container') throw new Error('No such container');
+        if (args[0] === 'run') return 'container';
+        if (args.some((value) => value.includes('/api/v2/health'))) return '200';
+        if (args.some((value) => value.includes('/api/v2/workspace/execute'))) {
+          const script = args.find((value) => value.includes("const b=await Bun.stdin.text"));
+          const marker = script?.match(/\\n([0-9a-f]{64})/)?.[1];
+          return `{"exitCode":0}\n${marker}200`;
+        }
+        return '';
+      },
+    },
+    httpClient: 'bun',
+  });
+  const lease = await supervisor.acquire(assignment('workspace-route'));
+  const response = await lease.execute?.({
+    body: '{"command":"pwd"}',
+    headers: { 'Content-Type': 'application/json' },
+    path: '/api/v2/workspace/execute',
+  });
+  assert.equal(response?.status, 200);
+  assert.ok(calls.some((args) => args.includes('http://127.0.0.1:2000/api/v2/workspace/execute')));
+  const execution = calls.find((args) =>
+    args.includes('http://127.0.0.1:2000/api/v2/workspace/execute'),
+  );
+  assert.equal(execution?.includes('curl'), false);
+  assert.equal(JSON.stringify(execution).includes('private-workspace-capability'), false);
+  assert.equal(
+    execution?.some((value) => value.includes('X-LibreChat-Workspace-Token')),
+    true,
+  );
+});
+
 test('docker runtime supervisor preserves the legacy profile digest for the default network', async () => {
   const image = 'example/code-runtime:latest';
   const legacyDigest = createHash('sha256')

--- a/packages/code/src/runtime.ts
+++ b/packages/code/src/runtime.ts
@@ -15,6 +15,8 @@ export interface RuntimeLease {
 export interface RuntimeExecutionRequest {
   body: string;
   headers: Record<string, string>;
+  /** Fixed runner route; omitted for ordinary code execution. */
+  path?: '/api/v2/execute' | '/api/v2/workspace/execute';
   signal?: AbortSignal;
 }
 
@@ -434,16 +436,19 @@ export class DockerRuntimeSupervisor implements RuntimeSupervisor {
       throw new Error('Runtime request headers cannot contain line breaks');
     }
     const marker = randomBytes(32).toString('hex');
-    const executeUrl = `http://127.0.0.1:${this.runnerPort}/api/v2/execute`;
+    const executeUrl = `http://127.0.0.1:${this.runnerPort}${request.path ?? '/api/v2/execute'}`;
+    const httpClient = request.path === '/api/v2/workspace/execute'
+      ? 'bun'
+      : this.httpClient;
     const output = await this.client.run(
-      this.httpClient === 'bun'
+      httpClient === 'bun'
         ? [
             'exec',
             '--interactive',
             name,
             'bun',
             '-e',
-            `const b=await Bun.stdin.text();const r=await fetch(process.argv.at(-2),{method:'POST',headers:JSON.parse(process.argv.at(-1)),body:b});process.stdout.write(await r.text());process.stdout.write('\\n${marker}'+r.status);`,
+            `const b=await Bun.stdin.text();const h=JSON.parse(process.argv.at(-1));if(process.argv.at(-2).endsWith('/workspace/execute')){const t=process.env.SANDBOX_EXTERNAL_WORKSPACE_TOKEN;if(!t)throw new Error('workspace capability unavailable');h['X-LibreChat-Workspace-Token']=t;}const r=await fetch(process.argv.at(-2),{method:'POST',headers:h,body:b});process.stdout.write(await r.text());process.stdout.write('\\n${marker}'+r.status);`,
             executeUrl,
             JSON.stringify(request.headers),
           ]

--- a/packages/code/src/workspace-cli.test.ts
+++ b/packages/code/src/workspace-cli.test.ts
@@ -62,6 +62,55 @@ test('CLI trims an environment-configured worker directory', async (t) => {
   assert.doesNotMatch(result.stderr, /invalid workspace registration/i);
 });
 
+test('CLI refuses workspace commands without its Docker sandbox profile', async (t) => {
+  const workspaceRoot = await mkdtemp(
+    join(tmpdir(), 'librechat-code-command-workspace-'),
+  );
+  t.after(() => rm(workspaceRoot, { recursive: true, force: true }));
+  const endpoint = spawnSync(
+    process.execPath,
+    [
+      fileURLToPath(new URL('./cli.js', import.meta.url)),
+      'run',
+      '--worker-dir',
+      workspaceRoot,
+      '--allow-workspace-commands',
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        LIBRECHAT_CODE_URL: 'http://127.0.0.1:1/v1',
+        LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
+        LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
+      },
+    },
+  );
+  assert.notEqual(endpoint.status, 0);
+  assert.match(endpoint.stderr, /require.*docker-nsjail runtime supervisor/i);
+
+  const noWorkspace = spawnSync(
+    process.execPath,
+    [
+      fileURLToPath(new URL('./cli.js', import.meta.url)),
+      'run',
+      '--allow-workspace-commands',
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        LIBRECHAT_CODE_URL: 'http://127.0.0.1:1/v1',
+        LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
+        LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
+        LIBRECHAT_CODE_RUNTIME_SUPERVISOR: 'docker',
+      },
+    },
+  );
+  assert.notEqual(noWorkspace.status, 0);
+  assert.match(noWorkspace.stderr, /require.*registered directory/i);
+});
+
 test('CLI advertises explicitly enabled writes without exposing the workspace root', async (t) => {
   const root = await mkdtemp(join(tmpdir(), 'librechat-code-cli-'));
   const workspaceRoot = join(root, '   ');

--- a/packages/code/src/workspace-runtime.test.ts
+++ b/packages/code/src/workspace-runtime.test.ts
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { RuntimeWorkspaceCommandSandbox } from './workspace-runtime.js';
+import { WorkspaceToolError } from './workspace.js';
+
+import type { RuntimeSupervisor } from './runtime.js';
+
+const request = {
+  protocolVersion: 1 as const,
+  operation: 'execute_command' as const,
+  workspaceId: 'primary',
+  command: 'pwd',
+  cwd: 'src',
+  timeoutMs: 1234,
+  maxOutputBytes: 64,
+};
+
+test('executes a command through a stable stateful runtime session', async () => {
+  const requests: object[] = [];
+  const assignments: object[] = [];
+  const supervisor: RuntimeSupervisor = {
+    async acquire(assignment) {
+      assignments.push(assignment);
+      return {
+        sessionId: assignment.runtimeSessionId,
+        async execute(runtimeRequest) {
+          requests.push(runtimeRequest);
+          return {
+            status: 200,
+            body: JSON.stringify({
+              exitCode: 0,
+              stdout: '/mnt/data/src\n',
+              stderr: '',
+              truncated: false,
+              timedOut: false,
+            }),
+          };
+        },
+      };
+    },
+    async reset() {},
+    async quarantine() { throw new Error('must not quarantine'); },
+  };
+  const sandbox = new RuntimeWorkspaceCommandSandbox({
+    runtimeSupervisor: supervisor,
+    workerId: 'worker-1',
+    incarnationId: 'incarnation-1',
+  });
+
+  assert.equal(sandbox.mutationFailuresAreAtomic, true);
+  assert.deepEqual(await sandbox.execute(request), {
+    protocolVersion: 1,
+    operation: 'execute_command',
+    workspaceId: 'primary',
+    exitCode: 0,
+    stdout: '/mnt/data/src\n',
+    stderr: '',
+    truncated: false,
+    timedOut: false,
+  });
+  const assignment = assignments[0] as { runtimeSessionId?: string };
+  assert.match(assignment.runtimeSessionId ?? '', /^workspace-[0-9a-f]{40}$/);
+  assert.deepEqual(requests, [{
+    path: '/api/v2/workspace/execute',
+    body: JSON.stringify({
+      command: 'pwd', cwd: 'src', timeoutMs: 1234, maxOutputBytes: 64,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Runtime-Session-Id': assignment.runtimeSessionId,
+    },
+    signal: undefined,
+  }]);
+});
+
+test('quarantines the runtime and hides malformed sandbox responses', async () => {
+  const quarantined: string[] = [];
+  const supervisor: RuntimeSupervisor = {
+    async acquire(assignment) {
+      return {
+        sessionId: assignment.runtimeSessionId,
+        async execute() {
+          return { status: 200, body: '{"stdout":"host secret"}' };
+        },
+      };
+    },
+    async reset() {},
+    async quarantine(sessionId) { quarantined.push(sessionId); },
+  };
+  const sandbox = new RuntimeWorkspaceCommandSandbox({
+    runtimeSupervisor: supervisor,
+    workerId: 'worker-1',
+    incarnationId: 'incarnation-1',
+  });
+
+  await assert.rejects(
+    sandbox.execute(request),
+    (error: unknown) =>
+      error instanceof WorkspaceToolError &&
+      error.code === 'COMMAND_UNAVAILABLE' &&
+      error.mutationMayHaveCommitted === true &&
+      !error.message.includes('host secret'),
+  );
+  assert.equal(quarantined.length, 1);
+});
+
+test('keeps definite pre-execution request rejections clean', async () => {
+  let quarantined = false;
+  const supervisor: RuntimeSupervisor = {
+    async acquire(assignment) {
+      return {
+        sessionId: assignment.runtimeSessionId,
+        async execute() {
+          return { status: 400, body: '{"message":"Command working directory is unavailable"}' };
+        },
+      };
+    },
+    async reset() {},
+    async quarantine() { quarantined = true; },
+  };
+  const sandbox = new RuntimeWorkspaceCommandSandbox({
+    runtimeSupervisor: supervisor,
+    workerId: 'worker-1',
+    incarnationId: 'incarnation-1',
+  });
+
+  await assert.rejects(
+    sandbox.execute(request),
+    (error: unknown) =>
+      error instanceof WorkspaceToolError &&
+      error.code === 'INVALID_REQUEST' &&
+      error.mutationMayHaveCommitted === false &&
+      !error.message.includes('working directory'),
+  );
+  assert.equal(quarantined, false);
+});
+
+test('refuses a runtime lease that is not bound to the requested workspace', async () => {
+  let quarantined = false;
+  const supervisor: RuntimeSupervisor = {
+    async acquire() { return { sessionId: 'wrong', async execute() { throw new Error(); } }; },
+    async reset() {},
+    async quarantine() { quarantined = true; },
+  };
+  const sandbox = new RuntimeWorkspaceCommandSandbox({
+    runtimeSupervisor: supervisor,
+    workerId: 'worker-1',
+    incarnationId: 'incarnation-1',
+  });
+  await assert.rejects(sandbox.execute(request), /unavailable/i);
+  assert.equal(quarantined, true);
+});

--- a/packages/code/src/workspace-runtime.ts
+++ b/packages/code/src/workspace-runtime.ts
@@ -1,0 +1,143 @@
+import { createHash } from 'node:crypto';
+
+import { BRIDGE_PROTOCOL_VERSION, isWorkspaceToolResult } from './protocol.js';
+import { WorkspaceToolError } from './workspace.js';
+
+import type {
+  BridgeAssignment,
+  WorkspaceExecuteCommandRequest,
+  WorkspaceExecuteCommandResult,
+} from './protocol.js';
+import type { RuntimeSupervisor } from './runtime.js';
+import type { WorkspaceCommandSandbox } from './workspace.js';
+
+const RESPONSE_KEYS = new Set([
+  'exitCode',
+  'signal',
+  'stdout',
+  'stderr',
+  'truncated',
+  'timedOut',
+]);
+
+export interface RuntimeWorkspaceCommandSandboxOptions {
+  runtimeSupervisor: RuntimeSupervisor;
+  workerId: string;
+  incarnationId: string;
+}
+
+function runtimeSessionId(workerId: string, workspaceId: string): string {
+  return `workspace-${createHash('sha256')
+    .update(`${workerId}\0${workspaceId}`)
+    .digest('hex')
+    .slice(0, 40)}`;
+}
+
+function commandAssignment(
+  options: RuntimeWorkspaceCommandSandboxOptions,
+  request: WorkspaceExecuteCommandRequest,
+  sessionId: string,
+): BridgeAssignment {
+  return {
+    protocolVersion: BRIDGE_PROTOCOL_VERSION,
+    assignmentId: `workspace-command-${createHash('sha256')
+      .update(request.command)
+      .digest('hex')
+      .slice(0, 24)}`,
+    workerId: options.workerId,
+    incarnationId: options.incarnationId,
+    generation: 1,
+    leaseToken: 'local-workspace-command',
+    expiresAt: new Date(Date.now() + (request.timeoutMs ?? 30_000)).toISOString(),
+    runtimeSessionId: sessionId,
+    executionKind: 'workspace_tool',
+    request,
+  };
+}
+
+function parseResponse(
+  request: WorkspaceExecuteCommandRequest,
+  value: unknown,
+): WorkspaceExecuteCommandResult {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('invalid sandbox response');
+  }
+  const result = value as Record<string, unknown>;
+  if (Object.keys(result).some((key) => !RESPONSE_KEYS.has(key))) {
+    throw new Error('invalid sandbox response');
+  }
+  const candidate = {
+    protocolVersion: BRIDGE_PROTOCOL_VERSION,
+    operation: 'execute_command',
+    workspaceId: request.workspaceId,
+    exitCode: result.exitCode as number | null,
+    ...(result.signal !== undefined ? { signal: result.signal as string } : {}),
+    stdout: result.stdout as string,
+    stderr: result.stderr as string,
+    truncated: result.truncated as boolean,
+    timedOut: result.timedOut as boolean,
+  };
+  if (!isWorkspaceToolResult(request, candidate)) {
+    throw new Error('invalid sandbox response');
+  }
+  return candidate;
+}
+
+/** Runs workspace commands only through a stateful sandbox runner route. */
+export class RuntimeWorkspaceCommandSandbox implements WorkspaceCommandSandbox {
+  readonly mutationFailuresAreAtomic = true as const;
+
+  constructor(private readonly options: RuntimeWorkspaceCommandSandboxOptions) {}
+
+  async execute(
+    request: WorkspaceExecuteCommandRequest,
+    signal?: AbortSignal,
+  ): Promise<WorkspaceExecuteCommandResult> {
+    const sessionId = runtimeSessionId(this.options.workerId, request.workspaceId);
+    try {
+      const lease = await this.options.runtimeSupervisor.acquire(
+        commandAssignment(this.options, request, sessionId),
+        signal,
+      );
+      if (!lease.execute || lease.sessionId !== sessionId) {
+        throw new Error('runtime does not provide isolated command execution');
+      }
+      const response = await lease.execute({
+        path: '/api/v2/workspace/execute',
+        body: JSON.stringify({
+          command: request.command,
+          ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+          ...(request.timeoutMs !== undefined ? { timeoutMs: request.timeoutMs } : {}),
+          ...(request.maxOutputBytes !== undefined
+            ? { maxOutputBytes: request.maxOutputBytes }
+            : {}),
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Runtime-Session-Id': sessionId,
+        },
+        signal,
+      });
+      if (response.status < 200 || response.status >= 300) {
+        if (response.status >= 400 && response.status < 500) {
+          throw new WorkspaceToolError(
+            'Sandboxed command request was rejected',
+            response.status === 400 ? 'INVALID_REQUEST' : 'COMMAND_UNAVAILABLE',
+          );
+        }
+        throw new Error(`sandbox rejected command with HTTP ${response.status}`);
+      }
+      return parseResponse(request, JSON.parse(response.body) as unknown);
+    } catch (error) {
+      if (error instanceof WorkspaceToolError) throw error;
+      await this.options.runtimeSupervisor
+        .quarantine(sessionId, 'Sandboxed workspace command failed', error)
+        .catch(() => undefined);
+      throw new WorkspaceToolError(
+        'Sandboxed command execution unavailable',
+        'COMMAND_UNAVAILABLE',
+        true,
+      );
+    }
+  }
+}

--- a/packages/code/src/workspace-worker.test.ts
+++ b/packages/code/src/workspace-worker.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import { BridgeProtocolError } from './protocol.js';
 import { BridgeWorker, BridgeWorkspaceQuarantinedError } from './worker.js';
-import { WorkspaceToolError } from './workspace.js';
+import { SandboxWorkspaceTools, WorkspaceToolError } from './workspace.js';
 
 const incarnationId = 'incarnation-00000001';
 
@@ -1050,6 +1050,71 @@ test('worker clears quarantine after an atomic executor rejection is settled', a
       workspaceId: 'primary',
       path: 'missing/outside.txt',
       content: 'blocked',
+    },
+  });
+  assert.deepEqual(lifecycle, ['arm', 'execute', 'settle', 'clear']);
+});
+
+test('worker clears quarantine after a composed command is cleanly rejected', async () => {
+  const lifecycle: string[] = [];
+  const baseCapabilities = {
+    protocolVersion: 1 as const,
+    operations: ['read_file' as const],
+    workspaces: [{ id: 'primary', operations: ['read_file' as const] }],
+  };
+  const workspaceTools = new SandboxWorkspaceTools({
+    workspaceTools: {
+      capabilities: baseCapabilities,
+      mutationFailuresAreAtomic: true,
+      async execute() { throw new Error('base executor must not run'); },
+    },
+    commandWorkspaces: ['primary'],
+    commandSandbox: {
+      mutationFailuresAreAtomic: true,
+      async execute() {
+        lifecycle.push('execute');
+        throw new WorkspaceToolError('Sandboxed command request was rejected', 'INVALID_REQUEST');
+      },
+    },
+  });
+  const worker = new BridgeWorker({
+    codeApiUrl: 'https://code.example/v1',
+    token: 'worker-secret',
+    workerId: 'vm-1',
+    incarnationId,
+    sandboxEndpoint: 'http://127.0.0.1:2000/api/v2',
+    capabilities: {
+      statefulWorkspace: true,
+      sandboxProfile: 'nsjail',
+      runtimes: ['bash'],
+      workspaceTools: workspaceTools.capabilities,
+    },
+    workspaceTools,
+    workspaceMutationQuarantine: mutationQuarantine(
+      () => lifecycle.push('quarantine'),
+      () => lifecycle.push('arm'),
+      () => lifecycle.push('clear'),
+    ),
+    fetchImpl: async () => {
+      lifecycle.push('settle');
+      return Response.json({ protocolVersion: 1, accepted: true });
+    },
+  });
+
+  await worker.executeAndSettle({
+    protocolVersion: 1,
+    assignmentId: 'assignment-command-clean-rejection',
+    workerId: 'vm-1',
+    incarnationId,
+    generation: 4,
+    leaseToken: 'lease-token-that-is-long-enough-for-testing',
+    expiresAt: new Date(Date.now() + 5_000).toISOString(),
+    executionKind: 'workspace_tool',
+    request: {
+      protocolVersion: 1,
+      operation: 'execute_command',
+      workspaceId: 'primary',
+      command: 'pwd',
     },
   });
   assert.deepEqual(lifecycle, ['arm', 'execute', 'settle', 'clear']);

--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -1565,6 +1565,7 @@ test('composes sandboxed commands without exposing them on unconfigured workspac
     workspaceTools: local,
     commandWorkspaces: ['sandboxed'],
     commandSandbox: {
+      mutationFailuresAreAtomic: true,
       async execute(request) {
         requests.push(request);
         return {
@@ -1581,6 +1582,7 @@ test('composes sandboxed commands without exposing them on unconfigured workspac
     },
   });
 
+  assert.equal(tools.mutationFailuresAreAtomic, true);
   assert.deepEqual(tools.capabilities.operations, [
     'read_file',
     'search_text',
@@ -1645,6 +1647,7 @@ test('fails closed on invalid or failed sandbox command results', async (t) => {
   for (const execute of [
     async () => ({ ...request, exitCode: 0, stdout: 'ok', stderr: '' }),
     async () => { throw new Error('container details'); },
+    async () => { throw new WorkspaceToolError('untrusted clean claim', 'COMMAND_UNAVAILABLE'); },
   ]) {
     const tools = new SandboxWorkspaceTools({
       workspaceTools: local,
@@ -1659,6 +1662,7 @@ test('fails closed on invalid or failed sandbox command results', async (t) => {
         error.mutationMayHaveCommitted === true &&
         !error.message.includes('container details'),
     );
+    assert.equal(tools.mutationFailuresAreAtomic, undefined);
   }
 });
 

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -91,6 +91,11 @@ export interface WorkspaceToolExecutor {
  * confinement; this package deliberately never falls back to a host shell.
  */
 export interface WorkspaceCommandSandbox {
+  /**
+   * True only when every thrown WorkspaceToolError proves no command-side
+   * mutation committed unless mutationMayHaveCommitted is explicitly set.
+   */
+  mutationFailuresAreAtomic?: true;
   execute(
     request: WorkspaceExecuteCommandRequest,
     signal?: AbortSignal,
@@ -1448,16 +1453,18 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
   }
 }
 
-/**
- * Composes ordinary workspace tools with an explicitly supplied sandboxed
- * command boundary. Command failures are intentionally not declared atomic:
- * callers must retain their durable mutation quarantine until settlement.
- */
+/** Composes ordinary workspace tools with an explicitly supplied sandboxed command boundary. */
 export class SandboxWorkspaceTools implements WorkspaceToolExecutor {
   readonly capabilities: BridgeWorkspaceToolCapabilities;
+  readonly mutationFailuresAreAtomic?: true;
   private readonly commandWorkspaces: ReadonlySet<string>;
 
   constructor(private readonly options: SandboxWorkspaceToolsOptions) {
+    this.mutationFailuresAreAtomic =
+      options.workspaceTools.mutationFailuresAreAtomic === true &&
+      options.commandSandbox.mutationFailuresAreAtomic === true
+        ? true
+        : undefined;
     const base = options.workspaceTools.capabilities;
     const registeredIds = new Set(base.workspaces.map(({ id }) => id));
     const commandWorkspaces = new Set(options.commandWorkspaces);
@@ -1516,7 +1523,15 @@ export class SandboxWorkspaceTools implements WorkspaceToolExecutor {
     try {
       result = await this.options.commandSandbox.execute(request, signal);
     } catch (error) {
-      if (error instanceof WorkspaceToolError) throw error;
+      if (error instanceof WorkspaceToolError) {
+        if (
+          this.options.commandSandbox.mutationFailuresAreAtomic === true ||
+          error.mutationMayHaveCommitted
+        ) {
+          throw error;
+        }
+        throw new WorkspaceToolError(error.message, error.code, true);
+      }
       throw new WorkspaceToolError(
         'Sandboxed command execution unavailable',
         'COMMAND_UNAVAILABLE',


### PR DESCRIPTION
## Summary

I connected BYOM workspace commands to the supported Docker/NsJail runtime while keeping the selected directory local, stateful, network-disabled, and inaccessible through a host-shell fallback. This PR depends on #98.

- Add a capability-authenticated `/api/v2/workspace/execute` runner route that is hidden unless the external-workspace profile is enabled.
- Resolve and fence the requested working directory beneath one canonical mounted workspace.
- Map the mounted directory owner into NsJail without changing host ownership.
- Apply the existing NsJail namespace, seccomp, process, memory, filesystem, and network controls to Bash commands.
- Bound command source, timeout, aggregate UTF-8 output, exit, signal, and timeout results.
- Add a stateful runtime adapter that derives a stable per-worker/workspace session and quarantines malformed or ambiguous runtime failures.
- Add `--allow-workspace-commands` and `LIBRECHAT_CODE_ALLOW_WORKSPACE_COMMANDS=true` as explicit Docker-only operator gates.
- Mount only the selected canonical workspace and share a private derived capability with its unexposed runner container.
- Preserve the durable mutation quarantine and document LibreChat approval hooks as the separate per-call decision boundary.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Documentation update

## Testing

- Ran `npm test` in `packages/code`: 211 passed, 1 platform-specific skip.
- Ran focused API workspace-command, session-binding, and NsJail tests: 36 passed.
- Ran focused Code API workspace/bridge tests: 19 passed.
- Built the API bundle and the real `local-oci-runtime` image.
- Ran a direct macOS/OrbStack NsJail smoke: two commands persisted `state.txt`; `/dev/tcp/1.1.1.1/80` was denied.
- Ran live outbound E2E with Code API on 23125 and Redis on 26395: two `/v1/workspace-tools/execute` calls traversed Redis and the CLI worker into NsJail, persisted `e2e.txt`, and produced `outbound-firstsecond`; network access remained denied.

### **Test Configuration**:

- macOS arm64
- OrbStack Linux VM
- Docker `local-oci-runtime` image
- NsJail seccomp profile
- Networkless runtime container
- Minimal Bash 5.2 runtime package fixture

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.