### PR TITLE
🈳 feat: Create Workspace Files Only When Paths Are Vacant

### DIFF
--- a/docs/remote-bridge/README.md
+++ b/docs/remote-bridge/README.md
@@ -137,27 +137,42 @@ listings, and later tool results necessarily cross the outbound bridge to Code
 API and the model.
 Treat them as explicit tool outputs, apply the same retention and audit policy
 as chat content, and do not register a directory containing secrets. The
-default operations are read-only. The bridge protocol reserves a bounded
-`execute_command` operation, but the local filesystem executor and CLI do not
-advertise it. A later layer must bind it to a sandboxed process boundary and
-LibreChat's tool-approval hooks before it becomes dispatchable.
+default operations are read-only. Operators can explicitly add bounded
+`execute_command` support with `--allow-workspace-commands` (or
+`LIBRECHAT_CODE_ALLOW_WORKSPACE_COMMANDS=true`). The CLI prepares its sandbox
+before registration, so Code API cannot dispatch commands to an unavailable
+boundary. LibreChat's tool-approval hooks remain the per-call decision point.
 
 The package exposes `SandboxWorkspaceTools` for composing that boundary without
-ever invoking a host shell. It requires an explicit sandbox implementation and
-an allowlist of workspace IDs, preserves per-workspace operation restrictions,
-validates bounded results, and treats an unknown command failure as an uncertain
-mutation. The built-in CLI remains command-disabled until its supported NsJail
-adapter can safely map a registered directory without changing host ownership.
+ever invoking an unsandboxed host shell. It requires an explicit sandbox
+implementation and an allowlist of workspace IDs, preserves per-workspace
+operation restrictions, validates bounded results, and treats an unknown
+command failure as an uncertain mutation.
 
-The supported `docker-nsjail` adapter enables that mapping only with
+Native SRT is the MVP and default command backend on a user's chosen laptop or
+VM. It uses Seatbelt on macOS, bubblewrap/seccomp on Linux, and the SRT
+restricted-account helper on Windows. It confines writes to the registered
+workspace, denies reads of the worker home and control files, strips worker
+credentials, and denies network egress by default. Startup fails closed when
+the platform dependencies are unavailable; there is no unsandboxed fallback.
+Use `LIBRECHAT_CODE_COMMAND_ALLOWED_DOMAINS` for an explicit comma-separated
+egress allowlist.
+Linux hosts must provide Bash at `/bin/bash`, `bubblewrap`, `socat`, and
+`ripgrep`; macOS uses system facilities. Windows requires SRT's one-time
+restricted-account setup.
+
+The optional `docker-nsjail` adapter enables a stronger container boundary with
 `--allow-workspace-commands` (or
 `LIBRECHAT_CODE_ALLOW_WORKSPACE_COMMANDS=true`) and a registered worker/default
 directory. It mounts only the canonical workspace, keeps the runner port
 unpublished, authenticates its dedicated command route with an ephemeral
 container capability, and runs Bash inside the existing NsJail profile. Direct
-endpoint mode is rejected. This deployment permission does not replace the
-per-call approval decision: LibreChat must apply its configurable tool-approval
-hooks before dispatching `execute_command`.
+endpoint mode cannot be used as the `runtime` command backend, but endpoint
+runtime supervision can coexist with native SRT commands. Set
+`LIBRECHAT_CODE_COMMAND_SANDBOX=runtime` to select Docker/NsJail explicitly.
+This deployment permission does not replace the per-call approval decision:
+LibreChat must apply its configurable tool-approval hooks before dispatching
+`execute_command`.
 
 Stateful deployments must also set `LIBRECHAT_CODE_STATEFUL_WORKSPACE=true`
 and route the CLI's `{runtimeSessionId}` endpoint template to an isolated,

--- a/packages/code/Dockerfile
+++ b/packages/code/Dockerfile
@@ -7,11 +7,13 @@ RUN npm run build
 
 FROM node:24-alpine
 ENV NODE_ENV=production
-RUN apk add --no-cache ripgrep \
+RUN apk add --no-cache bash bubblewrap ripgrep socat \
   && addgroup -S librechat-code \
   && adduser -S librechat-code -G librechat-code
 WORKDIR /app
 COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/package-lock.json ./package-lock.json
+RUN npm ci --omit=dev
 COPY --from=build /app/dist ./dist
 USER librechat-code
 ENTRYPOINT ["node", "dist/cli.js"]

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -3,9 +3,11 @@
 Provider-neutral protocol and worker CLI for attaching a stateful, sandboxed
 code environment to LibreChat Code API.
 
-The CLI owns the runtime-supervisor seam. The bundled endpoint adapter connects
-to an already-running loopback Code Interpreter sandbox; future adapters create
-and isolate the runtime themselves. It connects outbound to Code API,
+The CLI owns the runtime-supervisor seam. Native workspace commands use
+Anthropic's open-source Sandbox Runtime (SRT) on the worker machine. The
+bundled endpoint adapter can also connect to an already-running loopback Code
+Interpreter sandbox, while the optional Docker adapter provides a stronger
+container/NsJail profile. The worker connects outbound to Code API,
 long-polls for assignments, sends them to the local runtime, and returns fenced
 results. The VM does not need an inbound public port.
 
@@ -37,7 +39,61 @@ Use `--identity <path>` while pairing and
 `LIBRECHAT_CODE_IDENTITY_FILE=<path>` while running to override the identity
 file location.
 
-## Docker runtime supervisor (programmatic adapter)
+## Native BYOM sandbox (default)
+
+The MVP command sandbox runs directly on the user's chosen laptop or VM. It
+does not require Docker. Enable commands for an existing project or for a new
+application-owned directory:
+
+```bash
+librechat-code run --worker-dir /path/to/project --allow-workspace-commands
+
+# Git is optional; this creates and reuses an empty workspace.
+librechat-code run --default-workspace --allow-workspace-commands
+```
+
+`native-srt` is the default command sandbox unless a Docker/NsJail runtime was
+selected. It uses `@anthropic-ai/sandbox-runtime`: Seatbelt on macOS,
+bubblewrap plus seccomp on Linux, and the SRT restricted-account helper on
+Windows. Startup fails before worker registration when the platform or its
+dependencies are unavailable. There is no unsandboxed command fallback.
+
+The bridge worker remains outside the sandbox so it can maintain its outbound
+Code API connection. Each command and its descendants run inside SRT with:
+
+- write access restricted to the one canonical registered workspace;
+- read access denied to the worker's home directory except for that workspace;
+- paired identity and mutation-quarantine files explicitly denied;
+- `LIBRECHAT_CODE_*` and nonessential inherited environment variables removed;
+- network egress denied by default, local binding denied, and Unix sockets
+  denied; and
+- bounded time and aggregate output, with best-effort process-group termination
+  on cancellation, timeout, and completion.
+
+SRT restrictions remain inherited by descendants. Windows additionally uses a
+kill-on-close Job Object. Native macOS does not provide an equivalent hard
+process-lifetime boundary: a deliberately daemonized descendant can outlive
+the command while remaining confined to the approved workspace and network
+policy. This matches the personal-machine SRT trust model; use the Docker/NsJail
+backend or a dedicated VM boundary when hard teardown of adversarial process
+trees is required.
+
+Linux hosts need Bash at `/bin/bash`, `bubblewrap`, `socat`, and `ripgrep`; macOS uses system
+facilities. Follow SRT's one-time restricted-account setup when using Windows.
+An operator may allow explicit egress destinations with the comma-separated
+`LIBRECHAT_CODE_COMMAND_ALLOWED_DOMAINS` setting. Treat that as a security
+policy: an allowed destination can receive workspace data. The normalized
+allowlist is included in the worker policy digest. Tool approval hooks remain
+the user-facing allow/deny boundary for each invocation.
+
+Select the backend explicitly when desired:
+
+```bash
+LIBRECHAT_CODE_COMMAND_SANDBOX=native-srt librechat-code run \
+  --worker-dir /path/to/project --allow-workspace-commands
+```
+
+## Docker runtime supervisor (optional hardened adapter)
 
 `DockerRuntimeSupervisor` is the first self-contained local OCI adapter. It
 owns one named container per runtime session, does not publish the runner port,
@@ -158,7 +214,9 @@ librechat-code run
 
 Optional environment variables:
 
-- `LIBRECHAT_CODE_SANDBOX_PROFILE`: capability label; defaults to `nsjail`.
+- `LIBRECHAT_CODE_SANDBOX_PROFILE`: capability label; defaults to
+  `anthropic-srt` for native workspace commands, `oci-docker` for Docker, and
+  the existing `nsjail` label otherwise.
 - `LIBRECHAT_CODE_RUNTIMES`: comma-separated capability labels.
 - `LIBRECHAT_CODE_POLICY`: local policy description hashed into the worker's
   registration; defaults to `default-deny`.
@@ -219,8 +277,9 @@ capabilities; absolute host paths remain local to the worker process.
 The protocol also defines a bounded `execute_command` request and result for a
 sandbox-backed executor. Commands are treated as workspace mutations and cannot
 be advertised without durable quarantine storage. `LocalWorkspaceTools` never
-runs them in the worker host process; the CLI does not advertise command support
-until a sandbox runtime executor is configured.
+runs them directly in the trusted worker process; the CLI does not advertise
+command support until its selected SRT or Docker/NsJail sandbox has passed
+startup checks.
 
 `SandboxWorkspaceTools` is the composition boundary for that runtime. It adds
 `execute_command` only to workspace IDs explicitly backed by a
@@ -228,8 +287,8 @@ until a sandbox runtime executor is configured.
 executor, and validates the sandbox's complete result before returning it. It
 does not include a shell fallback. Invalid responses and unknown sandbox errors
 are reported as potentially committed mutations so the worker's durable
-quarantine remains armed. A concrete runtime adapter must prove its mount and
-identity behavior before the CLI can enable this composition.
+quarantine remains armed. The concrete adapter must pass its platform and
+identity checks before the CLI can enable this composition.
 
 The built-in Docker/NsJail adapter can be enabled explicitly for one registered
 directory:
@@ -239,6 +298,7 @@ LIBRECHAT_CODE_RUNTIME_SUPERVISOR=docker-nsjail \
 LIBRECHAT_CODE_RUNTIME_IMAGE=librechat-code-runtime:local \
 LIBRECHAT_CODE_DOCKER_SECCOMP_PROFILE=./seccomp/nsjail.json \
 LIBRECHAT_CODE_DOCKER_PACKAGES_PATH=./data/pkgs \
+LIBRECHAT_CODE_COMMAND_SANDBOX=runtime \
 librechat-code run --worker-dir /path/to/workspace --allow-workspace-commands
 ```
 
@@ -247,9 +307,11 @@ bind-mounts only that canonical directory into an unexposed runtime
 container and submits commands to a private, capability-authenticated runner
 route. The runner maps the mounted directory owner into NsJail without chowning
 the directory, disables network access by default, rejects an escaping `cwd`,
-and bounds command, time, stdout, and stderr. The endpoint supervisor cannot
-enable this feature. This operator switch controls availability; LibreChat tool
-approval hooks remain the user-facing allow/deny boundary for each invocation.
+and bounds command, time, stdout, and stderr. The endpoint supervisor cannot be
+used as the `runtime` command backend, but it can coexist with the default
+native SRT command backend. This operator switch controls availability;
+LibreChat tool approval hooks remain the user-facing allow/deny boundary for
+each invocation.
 
 Reads reject absolute paths, traversal, escaping symlinks, non-regular files,
 and files larger than 1 MiB. The opened file is checked against its canonical

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -271,6 +271,9 @@ names and exposes bounded `read_file`, literal `search_text`, and deterministic
 can explicitly add confined `write_file` and exact-match `edit_file` operations
 with `--allow-workspace-writes` or
 `LIBRECHAT_CODE_ALLOW_WORKSPACE_WRITES=true`.
+`write_file` preserves its overwrite behavior by default; callers can set
+`overwrite: false` to require an atomic create that returns `EDIT_CONFLICT` if
+the target already exists.
 Only IDs, names, protocol version, and supported operations appear in worker
 capabilities; absolute host paths remain local to the worker process.
 

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -273,9 +273,11 @@ with `--allow-workspace-writes` or
 `LIBRECHAT_CODE_ALLOW_WORKSPACE_WRITES=true`.
 `write_file` preserves its overwrite behavior by default; callers can set
 `overwrite: false` to require an atomic create that returns `EDIT_CONFLICT` if
-the target already exists.
-Only IDs, names, protocol version, and supported operations appear in worker
-capabilities; absolute host paths remain local to the worker process.
+the target already exists. Code API dispatches that mode only after the worker
+and server negotiate `create` in `writeFileModes`.
+Only IDs, names, protocol version, supported operations, and negotiated write
+modes appear in worker capabilities; absolute host paths remain local to the
+worker process.
 
 The protocol also defines a bounded `execute_command` request and result for a
 sandbox-backed executor. Commands are treated as workspace mutations and cannot

--- a/packages/code/package-lock.json
+++ b/packages/code/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@librechat/code",
       "version": "0.1.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@anthropic-ai/sandbox-runtime": "0.0.75"
+      },
       "bin": {
         "librechat-code": "dist/cli.js"
       },
@@ -16,8 +19,32 @@
         "typescript": "^5.5.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.11"
       }
+    },
+    "node_modules/@anthropic-ai/sandbox-runtime": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sandbox-runtime/-/sandbox-runtime-0.0.75.tgz",
+      "integrity": "sha512-oqAKi6QtkT2DpLwFoDCDD757zw2i6ftpLTyV8rNSV9QWF53q2m1JxEs0RYXv2CIXtCoje4RGYQylagn15RKmww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@pondwader/socks5-server": "^1.0.10",
+        "commander": "^12.1.0",
+        "node-forge": "^1.4.0",
+        "zod": "^3.24.1"
+      },
+      "bin": {
+        "srt": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@pondwader/socks5-server": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@pondwader/socks5-server/-/socks5-server-1.0.10.tgz",
+      "integrity": "sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.20.1",
@@ -27,6 +54,24 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/typescript": {
@@ -49,6 +94,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -30,6 +30,10 @@
     "./workspace-runtime": {
       "types": "./dist/workspace-runtime.d.ts",
       "import": "./dist/workspace-runtime.js"
+    },
+    "./native-sandbox": {
+      "types": "./dist/native-sandbox.d.ts",
+      "import": "./dist/native-sandbox.js"
     }
   },
   "bin": {
@@ -49,6 +53,9 @@
     "typescript": "^5.5.4"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20.11"
+  },
+  "dependencies": {
+    "@anthropic-ai/sandbox-runtime": "0.0.75"
   }
 }

--- a/packages/code/src/cli.test.ts
+++ b/packages/code/src/cli.test.ts
@@ -71,6 +71,29 @@ test('CLI rejects an unknown runtime supervisor before entering the run loop', (
   );
 });
 
+test('CLI rejects an unknown command sandbox before entering the run loop', () => {
+  const result = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL('./cli.js', import.meta.url))],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        LIBRECHAT_CODE_URL: 'https://code.example/v1',
+        LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
+        LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
+        LIBRECHAT_CODE_COMMAND_SANDBOX: 'host-shell',
+      },
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /LIBRECHAT_CODE_COMMAND_SANDBOX must be native-srt or runtime/,
+  );
+});
+
 test('CLI requires a runtime image for Docker supervision', () => {
   const result = spawnSync(
     process.execPath,

--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -20,12 +20,13 @@ import {
   saveWorkspaceMutationQuarantine,
 } from './storage.js';
 import { BridgeWorker } from './worker.js';
-import { DockerRuntimeSupervisor, EndpointRuntimeSupervisor } from './runtime.js';
 import {
   LocalWorkspaceTools,
   SandboxWorkspaceTools,
 } from './workspace.js';
+import { DockerRuntimeSupervisor, EndpointRuntimeSupervisor } from './runtime.js';
 import { RuntimeWorkspaceCommandSandbox } from './workspace-runtime.js';
+import { NativeSrtWorkspaceCommandSandbox } from './native-sandbox.js';
 import type { RuntimeSupervisor } from './runtime.js';
 import type { WorkspaceToolExecutor } from './workspace.js';
 import {
@@ -267,6 +268,18 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
     (args.includes('--allow-workspace-commands') ||
       process.env.LIBRECHAT_CODE_ALLOW_WORKSPACE_COMMANDS?.trim().toLowerCase() ===
         'true');
+  const commandSandboxMode =
+    option(args, '--command-sandbox') ??
+    process.env.LIBRECHAT_CODE_COMMAND_SANDBOX?.trim().toLowerCase() ??
+    (nsjailDockerMode ? 'runtime' : 'native-srt');
+  if (commandSandboxMode !== 'native-srt' && commandSandboxMode !== 'runtime') {
+    throw new Error(
+      'LIBRECHAT_CODE_COMMAND_SANDBOX must be native-srt or runtime',
+    );
+  }
+  const commandAllowedDomains = [
+    ...new Set(list(process.env.LIBRECHAT_CODE_COMMAND_ALLOWED_DOMAINS)),
+  ].sort();
   if (explicitWorkerDirectory && useDefaultWorkspace) {
     throw new Error(
       '--worker-dir and --default-workspace cannot be used together',
@@ -321,9 +334,16 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
         ],
       })
     : undefined;
-  if (allowWorkspaceCommands && (!canonicalWorkerDirectory || !nsjailDockerMode)) {
+  if (allowWorkspaceCommands && !canonicalWorkerDirectory) {
+    throw new Error('Workspace commands require a registered directory');
+  }
+  if (
+    allowWorkspaceCommands &&
+    commandSandboxMode === 'runtime' &&
+    !nsjailDockerMode
+  ) {
     throw new Error(
-      'Workspace commands require a registered directory and the docker-nsjail runtime supervisor',
+      'The runtime command sandbox requires the docker-nsjail runtime supervisor',
     );
   }
   const controller = new AbortController();
@@ -397,21 +417,26 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
     controller.signal,
   );
   const workspaceMount =
-    allowWorkspaceCommands && canonicalWorkerDirectory
+    allowWorkspaceCommands &&
+    commandSandboxMode === 'runtime' &&
+    canonicalWorkerDirectory
       ? {
           source: canonicalWorkerDirectory,
           target: '/mnt/workspace',
         }
       : undefined;
-  const workspaceCommandToken = allowWorkspaceCommands
-    ? createHmac(
-        'sha256',
-        pairedIdentity?.privateKey ??
-          required('LIBRECHAT_CODE_WORKER_TOKEN', configuredToken),
-      )
-        .update(`librechat-code-workspace-command-v1\0${canonicalWorkerDirectory}`)
-        .digest('base64url')
-    : undefined;
+  const workspaceCommandToken =
+    allowWorkspaceCommands && commandSandboxMode === 'runtime'
+      ? createHmac(
+          'sha256',
+          pairedIdentity?.privateKey ??
+            required('LIBRECHAT_CODE_WORKER_TOKEN', configuredToken),
+        )
+          .update(
+            `librechat-code-workspace-command-v1\0${canonicalWorkerDirectory}`,
+          )
+          .digest('base64url')
+      : undefined;
   const runtimeSupervisor: RuntimeSupervisor =
     runtimeMode !== 'endpoint'
       ? new DockerRuntimeSupervisor({
@@ -469,31 +494,61 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
           endpoint: sandboxEndpoint,
           statefulWorkspace,
         });
+  const nativeCommandSandbox =
+    allowWorkspaceCommands && commandSandboxMode === 'native-srt'
+      ? new NativeSrtWorkspaceCommandSandbox({
+          workspaceRoot: canonicalWorkerDirectory!,
+          protectedPaths: [identityPath, mutationQuarantinePath].filter(
+            (path): path is string => path != null,
+          ),
+          allowedDomains: commandAllowedDomains,
+        })
+      : undefined;
   if (allowWorkspaceCommands && workspaceTools) {
     workspaceTools = new SandboxWorkspaceTools({
       workspaceTools,
       commandWorkspaces: [workspaceId],
-      commandSandbox: new RuntimeWorkspaceCommandSandbox({
-        runtimeSupervisor,
-        workerId,
-        incarnationId,
-      }),
+      commandSandbox:
+        nativeCommandSandbox ??
+        new RuntimeWorkspaceCommandSandbox({
+          runtimeSupervisor,
+          workerId,
+          incarnationId,
+        }),
     });
   }
   const capabilities = {
     statefulWorkspace,
     sandboxProfile:
       process.env.LIBRECHAT_CODE_SANDBOX_PROFILE ??
-      (runtimeMode.startsWith('docker') ? 'oci-docker' : 'nsjail'),
+      (allowWorkspaceCommands && commandSandboxMode === 'native-srt'
+        ? 'anthropic-srt'
+        : runtimeMode.startsWith('docker')
+          ? 'oci-docker'
+          : 'nsjail'),
     runtimes: list(process.env.LIBRECHAT_CODE_RUNTIMES),
-    policyDigest: createHash('sha256').update(policy).digest('hex'),
+    policyDigest: createHash('sha256')
+      .update(policy)
+      .update(
+        allowWorkspaceCommands && commandSandboxMode === 'native-srt'
+          ? `\0native-srt\0${commandAllowedDomains.join('\0')}`
+          : '',
+      )
+      .digest('hex'),
     ...(fileRelayEnabled ? { requiresReadyConfirmation: true } : {}),
     ...(workspaceTools ? { workspaceTools: workspaceTools.capabilities } : {}),
   };
   if (!isValidBridgeWorkerCapabilities(capabilities)) {
+    await fileRelaySupervisor?.stop().catch(() => undefined);
     throw new Error(
       'LIBRECHAT_CODE_SANDBOX_PROFILE or LIBRECHAT_CODE_RUNTIMES is invalid',
     );
+  }
+  try {
+    await nativeCommandSandbox?.prepare();
+  } catch (error) {
+    await fileRelaySupervisor?.stop().catch(() => undefined);
+    throw error;
   }
   try {
     const worker = new BridgeWorker({
@@ -587,7 +642,11 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
     }
     await worker.run(controller.signal);
   } finally {
-    await fileRelaySupervisor?.stop();
+    try {
+      await nativeCommandSandbox?.close();
+    } finally {
+      await fileRelaySupervisor?.stop();
+    }
   }
 }
 

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -5,4 +5,5 @@ export * from './storage.js';
 export * from './runtime.js';
 export * from './workspace.js';
 export * from './workspace-runtime.js';
+export * from './native-sandbox.js';
 export * from './worker.js';

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -1,0 +1,320 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import {
+  access,
+  mkdtemp,
+  mkdir,
+  realpath,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import test from 'node:test';
+
+import type { SandboxRuntimeConfig } from '@anthropic-ai/sandbox-runtime';
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+
+import { NativeSrtWorkspaceCommandSandbox } from './native-sandbox.js';
+import { WorkspaceToolError } from './workspace.js';
+
+const request = {
+  protocolVersion: 1 as const,
+  operation: 'execute_command' as const,
+  workspaceId: 'primary',
+  command: 'printf hello',
+  timeoutMs: 1_000,
+  maxOutputBytes: 64,
+};
+
+function fakeManager(options: { dependencyErrors?: string[] } = {}) {
+  let config: SandboxRuntimeConfig | undefined;
+  let reset = false;
+  const manager = {
+    isSupportedPlatform: () => true,
+    async checkDependenciesAsync() {
+      return { warnings: [], errors: options.dependencyErrors ?? [] };
+    },
+    async initialize(value: SandboxRuntimeConfig) {
+      config = value;
+    },
+    async wrapWithSandboxArgv(command: string) {
+      return {
+        argv: ['/bin/bash', '-c', command],
+        env: { PATH: process.env.PATH },
+      };
+    },
+    annotateStderrWithSandboxFailures(_commandId: string, stderr: string) {
+      return stderr;
+    },
+    cleanupAfterCommand() {},
+    async reset() {
+      reset = true;
+    },
+  };
+  return {
+    manager,
+    get config() {
+      return config;
+    },
+    get reset() {
+      return reset;
+    },
+  };
+}
+
+test('initializes SRT with a default-deny network and scrubbed worker credentials', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  const identity = join(tmpdir(), 'librechat-code-identity.json');
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const fake = fakeManager();
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    protectedPaths: [identity],
+    environment: {
+      PATH: '/usr/bin',
+      Path: '/windows/system32',
+      LANG: 'en_US.UTF-8',
+      lc_api_token: 'lowercase-secret',
+      LIBRECHAT_CODE_WORKER_TOKEN: 'secret',
+      AWS_SECRET_ACCESS_KEY: 'secret',
+    },
+    manager: fake.manager,
+  });
+
+  await sandbox.prepare();
+  const canonicalRoot = await realpath(root);
+  const canonicalIdentity = await realpath(identity).catch(async () =>
+    join(await realpath(tmpdir()), 'librechat-code-identity.json'),
+  );
+  const canonicalHome = await realpath(homedir());
+  assert.deepEqual(fake.config?.network.allowedDomains, []);
+  assert.equal(fake.config?.network.strictAllowlist, true);
+  assert.equal(fake.config?.network.allowAllUnixSockets, false);
+  assert.deepEqual(fake.config?.filesystem.allowRead, [canonicalRoot]);
+  assert.deepEqual(fake.config?.filesystem.allowWrite, [canonicalRoot]);
+  assert.ok(fake.config?.filesystem.denyRead.includes(canonicalHome));
+  assert.ok(fake.config?.filesystem.denyWrite.includes(canonicalIdentity));
+  const denied = fake.config?.credentials?.envVars?.map(({ name }) => name);
+  assert.ok(denied?.includes('LIBRECHAT_CODE_WORKER_TOKEN'));
+  assert.ok(denied?.includes('AWS_SECRET_ACCESS_KEY'));
+  assert.ok(!denied?.includes('PATH'));
+  assert.ok(denied?.includes('Path'));
+  assert.ok(denied?.includes('lc_api_token'));
+  await sandbox.close();
+  assert.equal(fake.reset, true);
+});
+
+test('filters environment names case-insensitively only on Windows', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const fake = fakeManager();
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    platform: 'win32',
+    environment: {
+      PATH: '/usr/bin',
+      Path: 'C:\\Windows\\System32',
+      LC_API_TOKEN: 'secret',
+      librechat_code_worker_token: 'secret',
+    },
+    manager: fake.manager,
+  });
+
+  await sandbox.prepare();
+  const denied = fake.config?.credentials?.envVars?.map(({ name }) => name);
+  assert.ok(!denied?.includes('PATH'));
+  assert.ok(!denied?.includes('Path'));
+  assert.ok(!denied?.includes('LC_API_TOKEN'));
+  assert.ok(denied?.includes('librechat_code_worker_token'));
+});
+
+test('fails closed when the configured POSIX shell is unavailable', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    platform: 'linux',
+    shellPath: join(root, 'missing-bash'),
+    manager: fakeManager().manager,
+  });
+
+  await assert.rejects(
+    sandbox.prepare(),
+    (error: unknown) =>
+      error instanceof WorkspaceToolError &&
+      error.code === 'COMMAND_UNAVAILABLE' &&
+      /shell is unavailable/i.test(error.message),
+  );
+});
+
+test('fails closed when SRT dependencies are unavailable', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const fake = fakeManager({ dependencyErrors: ['bubblewrap missing'] });
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fake.manager,
+  });
+
+  await assert.rejects(
+    sandbox.prepare(),
+    (error: unknown) =>
+      error instanceof WorkspaceToolError &&
+      error.code === 'COMMAND_UNAVAILABLE' &&
+      /bubblewrap missing/.test(error.message),
+  );
+});
+
+test('refuses workspace roots that expose worker home or control files', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  const controlDirectory = join(root, '.control');
+  await mkdir(controlDirectory);
+  const controlFile = join(controlDirectory, 'identity.json');
+  await writeFile(controlFile, '{}');
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  await assert.rejects(
+    new NativeSrtWorkspaceCommandSandbox({
+      workspaceRoot: homedir(),
+      manager: fakeManager().manager,
+    }).prepare(),
+    /cannot contain the worker home directory/i,
+  );
+  await assert.rejects(
+    new NativeSrtWorkspaceCommandSandbox({
+      workspaceRoot: root,
+      protectedPaths: [controlFile],
+      manager: fakeManager().manager,
+    }).prepare(),
+    /cannot contain worker control files/i,
+  );
+});
+
+test('executes in the canonical workspace and bounds aggregate output', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  await mkdir(join(root, 'src'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fakeManager().manager,
+  });
+
+  assert.equal(sandbox.mutationFailuresAreAtomic, true);
+  assert.deepEqual(
+    await sandbox.execute({
+      ...request,
+      command: "printf '1234567890'; printf 'abcdefghij' >&2",
+      cwd: 'src',
+      maxOutputBytes: 12,
+    }),
+    {
+      protocolVersion: 1,
+      operation: 'execute_command',
+      workspaceId: 'primary',
+      exitCode: 0,
+      stdout: '1234567890',
+      stderr: 'ab',
+      truncated: true,
+      timedOut: false,
+    },
+  );
+});
+
+test('rejects an escaping or unavailable command working directory', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fakeManager().manager,
+  });
+
+  await assert.rejects(
+    sandbox.execute({ ...request, cwd: '..' }),
+    (error: unknown) =>
+      error instanceof WorkspaceToolError && error.code === 'INVALID_REQUEST',
+  );
+});
+
+test('terminates detached command descendants before returning', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fakeManager().manager,
+  });
+
+  const result = await sandbox.execute({
+    ...request,
+    command: '(sleep 0.2; printf late > late.txt) >/dev/null 2>&1 &',
+  });
+  assert.equal(result.exitCode, 0);
+  await new Promise((resolve) => setTimeout(resolve, 350));
+  await assert.rejects(access(join(root, 'late.txt')));
+});
+
+test('reports cancellation after command start as a potentially committed mutation', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fakeManager().manager,
+  });
+  const controller = new AbortController();
+  const execution = sandbox.execute(
+    { ...request, command: 'sleep 30' },
+    controller.signal,
+  );
+  setTimeout(() => controller.abort(), 25);
+
+  await assert.rejects(
+    execution,
+    (error: unknown) =>
+      error instanceof WorkspaceToolError &&
+      error.code === 'EXECUTION_ABORTED' &&
+      error.mutationMayHaveCommitted === true,
+  );
+});
+
+test('closes stdin immediately when the command protocol provides no input', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fakeManager().manager,
+  });
+
+  const result = await sandbox.execute({
+    ...request,
+    command: 'cat',
+    timeoutMs: 250,
+  });
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.timedOut, false);
+});
+
+test('maps platform-native exit statuses into the bridge protocol range', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const spawnCommand = () => {
+    const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+    Object.assign(child, {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      pid: undefined,
+      kill: () => true,
+    });
+    queueMicrotask(() => child.emit('close', 300, null));
+    return child;
+  };
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fakeManager().manager,
+    spawnCommand,
+  });
+
+  const result = await sandbox.execute(request);
+  assert.equal(result.exitCode, 1);
+});

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -1,0 +1,481 @@
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from 'node:path';
+import { constants as fsConstants } from 'node:fs';
+import { access, realpath, stat } from 'node:fs/promises';
+
+import { SandboxManager } from '@anthropic-ai/sandbox-runtime';
+
+import {
+  BRIDGE_PROTOCOL_VERSION,
+  BRIDGE_WORKSPACE_COMMAND_DEFAULT_OUTPUT_BYTES,
+  BRIDGE_WORKSPACE_COMMAND_DEFAULT_TIMEOUT_MS,
+  isWorkspaceToolRequest,
+} from './protocol.js';
+import { WorkspaceToolError } from './workspace.js';
+
+import type {
+  ChildProcessWithoutNullStreams,
+  SpawnOptionsWithoutStdio,
+} from 'node:child_process';
+import type { SandboxRuntimeConfig } from '@anthropic-ai/sandbox-runtime';
+import type {
+  WorkspaceExecuteCommandRequest,
+  WorkspaceExecuteCommandResult,
+} from './protocol.js';
+import type { WorkspaceCommandSandbox } from './workspace.js';
+
+const SAFE_CHILD_ENV_NAMES = new Set([
+  'COLORTERM',
+  'HOME',
+  'LANG',
+  'LC_ALL',
+  'LOGNAME',
+  'NO_COLOR',
+  'PATH',
+  'SHELL',
+  'TERM',
+  'TMPDIR',
+  'USER',
+]);
+
+interface NativeSandboxManager {
+  isSupportedPlatform(): boolean;
+  checkDependenciesAsync(): Promise<{ warnings: string[]; errors: string[] }>;
+  initialize(config: SandboxRuntimeConfig): Promise<void>;
+  wrapWithSandboxArgv(
+    command: string,
+    binShell?: string,
+    customConfig?: Partial<SandboxRuntimeConfig>,
+    abortSignal?: AbortSignal,
+    cwd?: string,
+    options?: { commandId?: string; commandText?: string },
+  ): Promise<{ argv: string[]; env: NodeJS.ProcessEnv }>;
+  annotateStderrWithSandboxFailures(commandId: string, stderr: string): string;
+  cleanupAfterCommand(): void;
+  reset(): Promise<void>;
+}
+
+type SpawnCommand = (
+  command: string,
+  args: readonly string[],
+  options: SpawnOptionsWithoutStdio,
+) => ChildProcessWithoutNullStreams;
+
+export interface NativeSrtWorkspaceCommandSandboxOptions {
+  workspaceRoot: string;
+  /** Trusted worker files that must never become workspace-readable or writable. */
+  protectedPaths?: string[];
+  allowedDomains?: string[];
+  environment?: NodeJS.ProcessEnv;
+  manager?: NativeSandboxManager;
+  spawnCommand?: SpawnCommand;
+  homeDirectory?: string;
+  platform?: NodeJS.Platform;
+  /** Trusted shell path used by SRT on POSIX hosts. */
+  shellPath?: string;
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const path = relative(root, candidate);
+  return (
+    path === '' ||
+    (!path.startsWith(`..${sep}`) && path !== '..' && !isAbsolute(path))
+  );
+}
+
+async function canonicalPath(path: string): Promise<string> {
+  const absolute = resolve(path);
+  let cursor = absolute;
+  const missingSegments: string[] = [];
+  for (;;) {
+    try {
+      return join(await realpath(cursor), ...missingSegments);
+    } catch {
+      const parent = dirname(cursor);
+      if (parent === cursor)
+        throw new Error(`Cannot canonicalize protected path: ${path}`);
+      missingSegments.unshift(basename(cursor));
+      cursor = parent;
+    }
+  }
+}
+
+function boundedUtf8(buffer: Buffer, budget: number): string {
+  let end = Math.min(buffer.byteLength, budget);
+  while (end > 0) {
+    const value = buffer.subarray(0, end).toString('utf8');
+    if (Buffer.byteLength(value) <= budget) return value;
+    end -= 1;
+  }
+  return '';
+}
+
+function safeEnvironmentNames(
+  environment: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): string[] {
+  return Object.keys(environment)
+    .filter((name) => {
+      const normalized = platform === 'win32' ? name.toUpperCase() : name;
+      return (
+        normalized.startsWith('LIBRECHAT_CODE_') ||
+        (!SAFE_CHILD_ENV_NAMES.has(normalized) && !normalized.startsWith('LC_'))
+      );
+    })
+    .sort();
+}
+
+export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox {
+  readonly mutationFailuresAreAtomic = true as const;
+  private readonly manager: NativeSandboxManager;
+  private readonly spawnCommand: SpawnCommand;
+  private readonly environment: NodeJS.ProcessEnv;
+  private readonly platform: NodeJS.Platform;
+  private initialized?: Promise<void>;
+  private canonicalRoot?: string;
+
+  constructor(
+    private readonly options: NativeSrtWorkspaceCommandSandboxOptions,
+  ) {
+    this.manager = options.manager ?? SandboxManager;
+    this.spawnCommand = options.spawnCommand ?? spawn;
+    this.environment = { ...(options.environment ?? process.env) };
+    this.platform = options.platform ?? process.platform;
+  }
+
+  /** Fail closed before the worker advertises command execution. */
+  async prepare(): Promise<void> {
+    await this.initialize();
+  }
+
+  private async initialize(): Promise<void> {
+    if (this.initialized) return this.initialized;
+    this.initialized = this.initializeOnce().catch(async (error) => {
+      await this.manager.reset().catch(() => undefined);
+      this.initialized = undefined;
+      throw error;
+    });
+    return this.initialized;
+  }
+
+  private async initializeOnce(): Promise<void> {
+    if (!this.manager.isSupportedPlatform()) {
+      throw new WorkspaceToolError(
+        'Native sandbox is unsupported on this platform',
+        'COMMAND_UNAVAILABLE',
+      );
+    }
+    const root = await realpath(this.options.workspaceRoot);
+    if (!(await stat(root)).isDirectory()) {
+      throw new WorkspaceToolError(
+        'Native sandbox workspace is unavailable',
+        'COMMAND_UNAVAILABLE',
+      );
+    }
+    const home = await canonicalPath(this.options.homeDirectory ?? homedir());
+    if (isWithin(root, home)) {
+      throw new WorkspaceToolError(
+        'Native sandbox workspace cannot contain the worker home directory',
+        'REGISTRATION_INVALID',
+      );
+    }
+    const protectedPaths = await Promise.all(
+      (this.options.protectedPaths ?? []).map(canonicalPath),
+    );
+    if (protectedPaths.some((path) => isWithin(root, path))) {
+      throw new WorkspaceToolError(
+        'Native sandbox workspace cannot contain worker control files',
+        'REGISTRATION_INVALID',
+      );
+    }
+    const dependencies = await this.manager.checkDependenciesAsync();
+    if (dependencies.errors.length > 0) {
+      throw new WorkspaceToolError(
+        `Native sandbox dependencies are unavailable: ${dependencies.errors.join('; ')}`,
+        'COMMAND_UNAVAILABLE',
+      );
+    }
+    if (this.platform !== 'win32') {
+      try {
+        await access(this.options.shellPath ?? '/bin/bash', fsConstants.X_OK);
+      } catch {
+        throw new WorkspaceToolError(
+          `Native sandbox shell is unavailable: ${this.options.shellPath ?? '/bin/bash'}`,
+          'COMMAND_UNAVAILABLE',
+        );
+      }
+    }
+    const config: SandboxRuntimeConfig = {
+      network: {
+        allowedDomains: [...(this.options.allowedDomains ?? [])],
+        deniedDomains: [],
+        strictAllowlist: true,
+        allowAllUnixSockets: false,
+        allowLocalBinding: false,
+      },
+      filesystem: {
+        denyRead: [home],
+        allowRead: [root],
+        allowWrite: [root],
+        denyWrite: protectedPaths,
+        allowGitConfig: false,
+      },
+      credentials: {
+        files: protectedPaths.map((path) => ({
+          path,
+          mode: 'deny' as const,
+        })),
+        envVars: safeEnvironmentNames(this.environment, this.platform).map((name) => ({
+          name,
+          mode: 'deny' as const,
+        })),
+      },
+      allowAppleEvents: false,
+      enableWeakerNestedSandbox: false,
+      enableWeakerNetworkIsolation: false,
+      git: { safeDirectories: [root] },
+    };
+    await this.manager.initialize(config);
+    this.canonicalRoot = root;
+  }
+
+  async execute(
+    request: WorkspaceExecuteCommandRequest,
+    signal?: AbortSignal,
+  ): Promise<WorkspaceExecuteCommandResult> {
+    if (
+      !isWorkspaceToolRequest(request) ||
+      request.operation !== 'execute_command'
+    ) {
+      throw new WorkspaceToolError(
+        'Invalid native sandbox command',
+        'INVALID_REQUEST',
+      );
+    }
+    if (signal?.aborted) {
+      throw new WorkspaceToolError(
+        'Workspace command execution aborted',
+        'EXECUTION_ABORTED',
+      );
+    }
+    await this.initialize();
+    const root = this.canonicalRoot!;
+    let cwd: string;
+    try {
+      cwd = await realpath(resolve(root, request.cwd ?? '.'));
+      if (!isWithin(root, cwd) || !(await stat(cwd)).isDirectory())
+        throw new Error('invalid cwd');
+    } catch {
+      throw new WorkspaceToolError(
+        'Command working directory is unavailable',
+        'INVALID_PATH',
+      );
+    }
+    const commandId = `librechat-code-${randomUUID()}`;
+    let wrapped: Awaited<
+      ReturnType<NativeSandboxManager['wrapWithSandboxArgv']>
+    >;
+    try {
+      wrapped = await this.manager.wrapWithSandboxArgv(
+        request.command,
+        this.platform === 'win32'
+          ? undefined
+          : this.options.shellPath ?? '/bin/bash',
+        undefined,
+        signal,
+        cwd,
+        { commandId, commandText: request.command },
+      );
+    } catch (error) {
+      if (signal?.aborted) {
+        throw new WorkspaceToolError(
+          'Workspace command execution aborted',
+          'EXECUTION_ABORTED',
+        );
+      }
+      throw new WorkspaceToolError(
+        'Native sandbox command could not start',
+        'COMMAND_UNAVAILABLE',
+      );
+    }
+    if (signal?.aborted) {
+      throw new WorkspaceToolError(
+        'Workspace command execution aborted',
+        'EXECUTION_ABORTED',
+      );
+    }
+    return await this.runWrapped(request, wrapped, cwd, commandId, signal);
+  }
+
+  private async runWrapped(
+    request: WorkspaceExecuteCommandRequest,
+    wrapped: { argv: string[]; env: NodeJS.ProcessEnv },
+    cwd: string,
+    commandId: string,
+    signal?: AbortSignal,
+  ): Promise<WorkspaceExecuteCommandResult> {
+    const outputLimit =
+      request.maxOutputBytes ?? BRIDGE_WORKSPACE_COMMAND_DEFAULT_OUTPUT_BYTES;
+    const timeoutMs =
+      request.timeoutMs ?? BRIDGE_WORKSPACE_COMMAND_DEFAULT_TIMEOUT_MS;
+    return await new Promise<WorkspaceExecuteCommandResult>(
+      (resolvePromise, reject) => {
+        let child: ChildProcessWithoutNullStreams;
+        try {
+          child = this.spawnCommand(wrapped.argv[0], wrapped.argv.slice(1), {
+            cwd,
+            env: wrapped.env,
+            detached: this.platform !== 'win32',
+            shell: false,
+            windowsHide: true,
+          });
+          child.stdin.end();
+        } catch {
+          reject(
+            new WorkspaceToolError(
+              'Native sandbox command could not start',
+              'COMMAND_UNAVAILABLE',
+            ),
+          );
+          return;
+        }
+        let settled = false;
+        let timedOut = false;
+        let outputBytes = 0;
+        let truncated = false;
+        const stdout: Buffer[] = [];
+        const stderr: Buffer[] = [];
+        const append = (target: Buffer[], chunk: Buffer): void => {
+          const remaining = outputLimit - outputBytes;
+          if (remaining <= 0) {
+            truncated = true;
+            return;
+          }
+          const accepted = chunk.subarray(0, remaining);
+          target.push(accepted);
+          outputBytes += accepted.byteLength;
+          if (accepted.byteLength !== chunk.byteLength) truncated = true;
+        };
+        child.stdout.on('data', (chunk: Buffer) => append(stdout, chunk));
+        child.stderr.on('data', (chunk: Buffer) => append(stderr, chunk));
+        const abort = (): void => {
+          if (settled) return;
+          this.killCommandTree(child);
+        };
+        signal?.addEventListener('abort', abort, { once: true });
+        if (signal?.aborted) abort();
+        const timer = setTimeout(() => {
+          if (settled) return;
+          timedOut = true;
+          this.killCommandTree(child);
+        }, timeoutMs);
+        const cleanup = (): void => {
+          clearTimeout(timer);
+          signal?.removeEventListener('abort', abort);
+          try {
+            this.manager.cleanupAfterCommand();
+          } catch {
+            // Cleanup is retried by close(); command settlement must still finish.
+          }
+        };
+        child.once('error', () => {
+          if (settled) return;
+          settled = true;
+          const mayHaveStarted = child.pid != null;
+          this.killCommandTree(child);
+          cleanup();
+          reject(
+            new WorkspaceToolError(
+              'Native sandbox command could not start',
+              'COMMAND_UNAVAILABLE',
+              mayHaveStarted,
+            ),
+          );
+        });
+        child.once('close', (code, childSignal) => {
+          if (settled) return;
+          settled = true;
+          this.killCommandTree(child);
+          cleanup();
+          if (signal?.aborted) {
+            reject(
+              new WorkspaceToolError(
+                'Workspace command execution aborted',
+                'EXECUTION_ABORTED',
+                true,
+              ),
+            );
+            return;
+          }
+          const stdoutValue = boundedUtf8(Buffer.concat(stdout), outputLimit);
+          const stderrBudget = Math.max(
+            0,
+            outputLimit - Buffer.byteLength(stdoutValue),
+          );
+          const rawStderr = Buffer.concat(stderr).toString('utf8');
+          let annotatedStderr = rawStderr;
+          try {
+            annotatedStderr = this.manager.annotateStderrWithSandboxFailures(
+              commandId,
+              rawStderr,
+            );
+          } catch {
+            // Preserve the bounded child error if optional violation annotation fails.
+          }
+          const stderrValue = boundedUtf8(
+            Buffer.from(annotatedStderr),
+            stderrBudget,
+          );
+          resolvePromise({
+            protocolVersion: BRIDGE_PROTOCOL_VERSION,
+            operation: 'execute_command',
+            workspaceId: request.workspaceId,
+            exitCode:
+              timedOut || childSignal ? null : this.protocolExitCode(code),
+            ...(childSignal ? { signal: childSignal } : {}),
+            stdout: stdoutValue,
+            stderr: stderrValue,
+            truncated:
+              truncated || Buffer.byteLength(annotatedStderr) > stderrBudget,
+            timedOut,
+          });
+        });
+      },
+    );
+  }
+
+  private killCommandTree(child: ChildProcessWithoutNullStreams): void {
+    try {
+      if (this.platform !== 'win32' && child.pid != null) {
+        process.kill(-child.pid, 'SIGKILL');
+      } else {
+        child.kill('SIGKILL');
+      }
+    } catch {
+      // The command group has already exited.
+    }
+  }
+
+  private protocolExitCode(code: number | null): number {
+    return Number.isSafeInteger(code) && code != null && code >= 0 && code <= 255
+      ? code
+      : 1;
+  }
+
+  async close(): Promise<void> {
+    if (!this.initialized) return;
+    await this.manager.reset();
+    this.initialized = undefined;
+    this.canonicalRoot = undefined;
+  }
+}

--- a/packages/code/src/protocol.test.ts
+++ b/packages/code/src/protocol.test.ts
@@ -75,6 +75,27 @@ test('bridge worker capabilities accept only bounded public workspace descriptor
       ...valid,
       workspaceTools: {
         ...valid.workspaceTools,
+        operations: ['read_file', 'write_file'],
+        writeFileModes: ['replace', 'create'],
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    isValidBridgeWorkerCapabilities({
+      ...valid,
+      workspaceTools: {
+        ...valid.workspaceTools,
+        writeFileModes: ['create'],
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    isValidBridgeWorkerCapabilities({
+      ...valid,
+      workspaceTools: {
+        ...valid.workspaceTools,
         workspaces: [{ id: 'primary', root: '/Users/operator/private' }],
       },
     }),

--- a/packages/code/src/protocol.test.ts
+++ b/packages/code/src/protocol.test.ts
@@ -156,8 +156,13 @@ test('workspace mutations accept bounded UTF-8 requests and exact result shapes'
     workspaceId: 'primary',
     path: 'notes.txt',
     content: 'hello',
+    overwrite: false,
   };
   assert.equal(isWorkspaceToolRequest(writeRequest), true);
+  assert.equal(
+    isWorkspaceToolRequest({ ...writeRequest, overwrite: 'false' }),
+    false,
+  );
   assert.equal(
     isWorkspaceToolRequest({
       ...writeRequest,
@@ -175,6 +180,17 @@ test('workspace mutations accept bounded UTF-8 requests and exact result shapes'
       bytesWritten: 5,
     }),
     true,
+  );
+  assert.equal(
+    isWorkspaceToolResult(writeRequest, {
+      protocolVersion: 1,
+      operation: 'write_file',
+      workspaceId: 'primary',
+      path: 'notes.txt',
+      created: false,
+      bytesWritten: 5,
+    }),
+    false,
   );
 
   const editRequest = {

--- a/packages/code/src/protocol.ts
+++ b/packages/code/src/protocol.ts
@@ -30,6 +30,8 @@ export type BridgeWorkspaceToolOperation =
   | 'edit_file'
   | 'execute_command';
 
+export type WorkspaceWriteFileMode = 'replace' | 'create';
+
 export interface BridgeWorkspaceDescriptor {
   id: string;
   name?: string;
@@ -41,6 +43,8 @@ export interface BridgeWorkspaceToolCapabilities {
   protocolVersion: BridgeProtocolVersion;
   operations: BridgeWorkspaceToolOperation[];
   workspaces: BridgeWorkspaceDescriptor[];
+  /** Omitted by legacy workers, which only accept replacement writes. */
+  writeFileModes?: WorkspaceWriteFileMode[];
 }
 
 export interface WorkspaceReadFileRequest {
@@ -314,6 +318,8 @@ export interface BridgeWorkerRegistrationResponse {
   leaseTtlMs: number;
   /** Operations this Code API can dispatch after the worker advertises them. */
   supportedWorkspaceToolOperations?: BridgeWorkspaceToolOperation[];
+  /** Write modes this Code API can safely route to a capability-aware worker. */
+  supportedWorkspaceWriteFileModes?: WorkspaceWriteFileMode[];
 }
 
 export interface BridgePairingRedemption {
@@ -781,6 +787,21 @@ export function isValidBridgeWorkspaceToolCapabilities(
     !Array.isArray(capabilities.workspaces) ||
     capabilities.workspaces.length < 1 ||
     capabilities.workspaces.length > BRIDGE_WORKSPACE_MAX_COUNT
+  ) {
+    return false;
+  }
+
+  if (
+    capabilities.writeFileModes !== undefined &&
+    (!Array.isArray(capabilities.writeFileModes) ||
+      capabilities.writeFileModes.length < 1 ||
+      capabilities.writeFileModes.length > 2 ||
+      !capabilities.operations.includes('write_file') ||
+      !capabilities.writeFileModes.every(
+        (mode) => mode === 'replace' || mode === 'create',
+      ) ||
+      new Set(capabilities.writeFileModes).size !==
+        capabilities.writeFileModes.length)
   ) {
     return false;
   }

--- a/packages/code/src/protocol.ts
+++ b/packages/code/src/protocol.ts
@@ -110,6 +110,8 @@ export interface WorkspaceWriteFileRequest {
   workspaceId: string;
   path: string;
   content: string;
+  /** False requires an atomic create and refuses to replace an existing file. */
+  overwrite?: boolean;
 }
 
 export interface WorkspaceWriteFileResult {
@@ -208,6 +210,7 @@ const WORKSPACE_WRITE_REQUEST_KEYS = new Set([
   'workspaceId',
   'path',
   'content',
+  'overwrite',
 ]);
 const WORKSPACE_EDIT_REQUEST_KEYS = new Set([
   'protocolVersion',
@@ -557,7 +560,9 @@ export function isWorkspaceToolRequest(
       typeof request.content === 'string' &&
       Buffer.from(request.content).toString('utf8') === request.content &&
       new TextEncoder().encode(request.content).byteLength <=
-        BRIDGE_WORKSPACE_WRITE_MAX_BYTES
+        BRIDGE_WORKSPACE_WRITE_MAX_BYTES &&
+      (request.overwrite === undefined ||
+        typeof request.overwrite === 'boolean')
     );
   }
   if (request.operation === 'edit_file') {
@@ -681,6 +686,7 @@ export function isWorkspaceToolResult(
       hasOnlyKeys(result, WORKSPACE_WRITE_RESULT_KEYS) &&
       result.path === request.path &&
       typeof result.created === 'boolean' &&
+      (request.overwrite !== false || result.created === true) &&
       Number.isSafeInteger(result.bytesWritten) &&
       Number(result.bytesWritten) ===
         new TextEncoder().encode(request.content).byteLength

--- a/packages/code/src/worker.ts
+++ b/packages/code/src/worker.ts
@@ -137,6 +137,10 @@ function workspaceCapabilitiesMatch(
     advertised.operations.every(
       (operation, index) => operation === executor.operations[index],
     ) &&
+    advertised.writeFileModes?.length === executor.writeFileModes?.length &&
+    (advertised.writeFileModes?.every(
+      (mode, index) => mode === executor.writeFileModes?.[index],
+    ) ?? executor.writeFileModes == null) &&
     advertised.workspaces.length === executor.workspaces.length &&
     advertised.workspaces.every(
       (workspace, index) =>
@@ -191,10 +195,12 @@ function registrationCompatibleCapabilities(
     const { workspaceTools: _workspaceTools, ...compatible } = capabilities;
     return compatible;
   }
+  const { writeFileModes: _writeFileModes, ...compatibleWorkspaceTools } =
+    workspaceTools;
   return {
     ...capabilities,
     workspaceTools: {
-      ...workspaceTools,
+      ...compatibleWorkspaceTools,
       operations,
       workspaces,
     },
@@ -222,12 +228,19 @@ function supportedWorkspaceCapabilities(
       : [{ ...workspace, operations: workspaceOperations }];
   });
   if (workspaces.length === 0) return undefined;
+  const writeFileModes = desired.writeFileModes?.filter((mode) =>
+    registration.supportedWorkspaceWriteFileModes?.includes(mode),
+  );
+  const { writeFileModes: _writeFileModes, ...compatibleDesired } = desired;
   return {
     ...capabilities,
     workspaceTools: {
-      ...desired,
+      ...compatibleDesired,
       operations,
       workspaces,
+      ...(operations.includes('write_file') && writeFileModes?.length
+        ? { writeFileModes }
+        : {}),
     },
   };
 }
@@ -874,6 +887,18 @@ export class BridgeWorker {
           throw new BridgeProtocolError(
             'Workspace tool operation is not advertised for workspace',
           );
+        }
+        if (
+          workspaceRequest.operation === 'write_file' &&
+          workspaceRequest.overwrite !== undefined
+        ) {
+          const mode =
+            workspaceRequest.overwrite === false ? 'create' : 'replace';
+          if (!advertised.writeFileModes?.includes(mode)) {
+            throw new BridgeProtocolError(
+              'Workspace write mode is not advertised',
+            );
+          }
         }
         const isMutation =
           workspaceRequest.operation === 'write_file' ||

--- a/packages/code/src/workspace-cli.test.ts
+++ b/packages/code/src/workspace-cli.test.ts
@@ -62,7 +62,7 @@ test('CLI trims an environment-configured worker directory', async (t) => {
   assert.doesNotMatch(result.stderr, /invalid workspace registration/i);
 });
 
-test('CLI refuses workspace commands without its Docker sandbox profile', async (t) => {
+test('CLI supports native SRT by default and validates explicit runtime mode', async (t) => {
   const workspaceRoot = await mkdtemp(
     join(tmpdir(), 'librechat-code-command-workspace-'),
   );
@@ -83,11 +83,15 @@ test('CLI refuses workspace commands without its Docker sandbox profile', async 
         LIBRECHAT_CODE_URL: 'http://127.0.0.1:1/v1',
         LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
         LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
+        LIBRECHAT_CODE_COMMAND_SANDBOX: 'runtime',
       },
     },
   );
   assert.notEqual(endpoint.status, 0);
-  assert.match(endpoint.stderr, /require.*docker-nsjail runtime supervisor/i);
+  assert.match(
+    endpoint.stderr,
+    /runtime command sandbox requires.*docker-nsjail/i,
+  );
 
   const noWorkspace = spawnSync(
     process.execPath,
@@ -198,6 +202,10 @@ test('CLI advertises explicitly enabled writes without exposing the workspace ro
   child.kill();
   await once(child, 'exit');
 
+  assert.equal(
+    (body.capabilities as Record<string, unknown>).sandboxProfile,
+    'nsjail',
+  );
   assert.deepEqual(
     (body.capabilities as Record<string, unknown>).workspaceTools,
     {

--- a/packages/code/src/workspace-worker.test.ts
+++ b/packages/code/src/workspace-worker.test.ts
@@ -220,6 +220,7 @@ test('worker promotes only operations understood by an older Code API', async ()
   const registrations: Array<{
     operations: string[];
     workspaces: Array<Record<string, unknown>>;
+    writeFileModes?: string[];
   }> = [];
   const workspaceCapabilities = {
     protocolVersion: 1 as const,
@@ -230,6 +231,7 @@ test('worker promotes only operations understood by an older Code API', async ()
       'write_file' as const,
       'edit_file' as const,
     ],
+    writeFileModes: ['replace' as const, 'create' as const],
     workspaces: [
       {
         id: 'primary',
@@ -268,6 +270,7 @@ test('worker promotes only operations understood by an older Code API', async ()
           workspaceTools: {
             operations: string[];
             workspaces: Array<Record<string, unknown>>;
+            writeFileModes?: string[];
           };
         };
       };
@@ -312,6 +315,7 @@ test('worker retains per-workspace restrictions during partial mutation promotio
   const registrations: Array<{
     operations: string[];
     workspaces: Array<Record<string, unknown>>;
+    writeFileModes?: string[];
   }> = [];
   const workspaceCapabilities = {
     protocolVersion: 1 as const,
@@ -322,6 +326,7 @@ test('worker retains per-workspace restrictions during partial mutation promotio
       'write_file' as const,
       'edit_file' as const,
     ],
+    writeFileModes: ['replace' as const, 'create' as const],
     workspaces: [
       {
         id: 'readonly',
@@ -368,6 +373,7 @@ test('worker retains per-workspace restrictions during partial mutation promotio
           workspaceTools: {
             operations: string[];
             workspaces: Array<Record<string, unknown>>;
+            writeFileModes?: string[];
           };
         };
       };
@@ -384,6 +390,7 @@ test('worker retains per-workspace restrictions during partial mutation promotio
           'list_files',
           'write_file',
         ],
+        supportedWorkspaceWriteFileModes: ['replace', 'create'],
       });
     },
   });
@@ -393,6 +400,7 @@ test('worker retains per-workspace restrictions during partial mutation promotio
   assert.deepEqual(registrations[1], {
     protocolVersion: 1,
     operations: ['read_file', 'search_text', 'list_files', 'write_file'],
+    writeFileModes: ['replace', 'create'],
     workspaces: [
       {
         id: 'readonly',
@@ -409,6 +417,72 @@ test('worker retains per-workspace restrictions during partial mutation promotio
       },
     ],
   });
+});
+
+test('worker omits write modes not negotiated by an older Code API', async () => {
+  const registrations: Array<Record<string, unknown>> = [];
+  const workspaceCapabilities = {
+    protocolVersion: 1 as const,
+    operations: ['read_file' as const, 'write_file' as const],
+    writeFileModes: ['replace' as const, 'create' as const],
+    workspaces: [
+      {
+        id: 'primary',
+        operations: ['read_file' as const, 'write_file' as const],
+      },
+    ],
+  };
+  const worker = new BridgeWorker({
+    codeApiUrl: 'https://code.example/v1',
+    token: 'worker-secret',
+    workerId: 'vm-1',
+    incarnationId,
+    sandboxEndpoint: 'http://127.0.0.1:2000/api/v2',
+    capabilities: {
+      statefulWorkspace: true,
+      sandboxProfile: 'nsjail',
+      runtimes: ['bash'],
+      workspaceTools: workspaceCapabilities,
+    },
+    workspaceTools: {
+      capabilities: workspaceCapabilities,
+      async execute() {
+        throw new Error('not executed');
+      },
+    },
+    workspaceMutationQuarantine: mutationQuarantine(),
+    fetchImpl: async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        capabilities: { workspaceTools?: Record<string, unknown> };
+      };
+      registrations.push(body.capabilities.workspaceTools ?? {});
+      return Response.json({
+        protocolVersion: 1,
+        workerId: 'vm-1',
+        incarnationId,
+        registeredAt: new Date().toISOString(),
+        leaseTtlMs: 60_000,
+        supportedWorkspaceToolOperations: ['read_file', 'write_file'],
+      });
+    },
+  });
+
+  await worker.register();
+
+  assert.deepEqual(registrations, [
+    {
+      protocolVersion: 1,
+      operations: ['read_file'],
+      workspaces: [{ id: 'primary' }],
+    },
+    {
+      protocolVersion: 1,
+      operations: ['read_file', 'write_file'],
+      workspaces: [
+        { id: 'primary', operations: ['read_file', 'write_file'] },
+      ],
+    },
+  ]);
 });
 
 test('worker retains per-workspace restrictions during read-only promotion', async () => {

--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -820,6 +820,7 @@ test('writable workspaces create, replace, and exactly edit files', async (t) =>
         ],
       },
     ],
+    writeFileModes: ['replace', 'create'],
   });
   await tools.execute({
     protocolVersion: 1,
@@ -957,6 +958,42 @@ test('workspace mutations sync the containing directory after replacement', asyn
     newText: 'after',
   });
   assert.equal(syncCalls, 5);
+});
+
+test('atomic creates remove staging before syncing the directory', async (t) => {
+  if (process.platform === 'win32') {
+    t.skip('Directory fsync is unavailable on Windows');
+    return;
+  }
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-workspace-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const tools = await LocalWorkspaceTools.create({
+    workspaces: [{ id: 'primary', root, writable: true }],
+  });
+  const probe = await open(root, 'r');
+  const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+    sync(): Promise<void>;
+  };
+  await probe.close();
+  const originalSync = fileHandlePrototype.sync;
+  let syncCalls = 0;
+  t.mock.method(fileHandlePrototype, 'sync', async function (this: FileHandle) {
+    syncCalls += 1;
+    if (syncCalls === 2) {
+      assert.deepEqual(await readdir(root), ['created.txt']);
+    }
+    await originalSync.call(this);
+  });
+
+  await tools.execute({
+    protocolVersion: 1,
+    operation: 'write_file',
+    workspaceId: 'primary',
+    path: 'created.txt',
+    content: 'durable create',
+    overwrite: false,
+  });
+  assert.equal(syncCalls, 2);
 });
 
 test('workspace mutations report uncertain commit when directory sync fails', async (t) => {
@@ -1661,6 +1698,7 @@ test('composes sandboxed commands without exposing them on unconfigured workspac
     'edit_file',
     'execute_command',
   ]);
+  assert.deepEqual(tools.capabilities.writeFileModes, ['replace', 'create']);
   assert.deepEqual(
     tools.capabilities.workspaces.find(({ id }) => id === 'sandboxed')?.operations,
     tools.capabilities.operations,

--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -847,6 +847,76 @@ test('writable workspaces create, replace, and exactly edit files', async (t) =>
   assert.equal(await readFile(join(root, 'notes.txt'), 'utf8'), 'hello BYOM');
 });
 
+test('workspace writes can require an atomic create without replacement', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-workspace-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeFile(join(root, 'existing.txt'), 'preserve me');
+  const tools = await LocalWorkspaceTools.create({
+    workspaces: [{ id: 'primary', root, writable: true }],
+  });
+
+  await assert.rejects(
+    tools.execute({
+      protocolVersion: 1,
+      operation: 'write_file',
+      workspaceId: 'primary',
+      path: 'existing.txt',
+      content: 'replace me',
+      overwrite: false,
+    }),
+    (error: unknown) =>
+      error instanceof WorkspaceToolError && error.code === 'EDIT_CONFLICT',
+  );
+  assert.equal(await readFile(join(root, 'existing.txt'), 'utf8'), 'preserve me');
+
+  const created = await tools.execute({
+    protocolVersion: 1,
+    operation: 'write_file',
+    workspaceId: 'primary',
+    path: 'created.txt',
+    content: 'new file',
+    overwrite: false,
+  });
+  assert.deepEqual(created, {
+    protocolVersion: 1,
+    operation: 'write_file',
+    workspaceId: 'primary',
+    path: 'created.txt',
+    created: true,
+    bytesWritten: 8,
+  });
+  assert.equal(await readFile(join(root, 'created.txt'), 'utf8'), 'new file');
+
+  const competingWrites = await Promise.allSettled([
+    tools.execute({
+      protocolVersion: 1,
+      operation: 'write_file',
+      workspaceId: 'primary',
+      path: 'raced.txt',
+      content: 'first',
+      overwrite: false,
+    }),
+    tools.execute({
+      protocolVersion: 1,
+      operation: 'write_file',
+      workspaceId: 'primary',
+      path: 'raced.txt',
+      content: 'second',
+      overwrite: false,
+    }),
+  ]);
+  assert.equal(
+    competingWrites.filter((result) => result.status === 'fulfilled').length,
+    1,
+  );
+  const rejected = competingWrites.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected',
+  );
+  assert.ok(rejected?.reason instanceof WorkspaceToolError);
+  assert.equal(rejected.reason.code, 'EDIT_CONFLICT');
+  assert.match(await readFile(join(root, 'raced.txt'), 'utf8'), /^(first|second)$/);
+});
+
 test('workspace mutations sync the containing directory after replacement', async (t) => {
   if (process.platform === 'win32') {
     t.skip('Directory fsync is unavailable on Windows');

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -513,6 +513,7 @@ async function atomicWriteConfinedFile(
   );
   const installTarget = resolve(canonicalParent, basename(candidate));
   let handle: FileHandle | undefined;
+  let temporaryNeedsCleanup = true;
   let staged: { dev: bigint | number; ino: bigint | number; content: Buffer };
   try {
     handle = await open(
@@ -595,11 +596,13 @@ async function atomicWriteConfinedFile(
         staged,
         signal,
       );
+      temporaryNeedsCleanup = false;
       return { created: false };
     }
     throwIfAborted(signal);
     if (allowOverwrite) {
       await rename(temporary, installTarget);
+      temporaryNeedsCleanup = false;
     } else {
       try {
         await link(temporary, installTarget);
@@ -612,6 +615,16 @@ async function atomicWriteConfinedFile(
         }
         throw error;
       }
+      try {
+        await unlink(temporary);
+        temporaryNeedsCleanup = false;
+      } catch {
+        throw new WorkspaceToolError(
+          'Workspace create cleanup could not be confirmed',
+          'WRITE_UNAVAILABLE',
+          true,
+        );
+      }
     }
     await confirmInstalledMutation(root, installTarget, staged);
     return { created: existing == null };
@@ -623,7 +636,9 @@ async function atomicWriteConfinedFile(
     );
   } finally {
     await handle?.close().catch(() => undefined);
-    await unlink(temporary).catch(() => undefined);
+    if (temporaryNeedsCleanup) {
+      await unlink(temporary).catch(() => undefined);
+    }
   }
 }
 
@@ -1321,11 +1336,13 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
     private readonly roots: ReadonlyMap<string, WorkspaceRoot>,
     operations: BridgeWorkspaceToolCapabilities['operations'],
     workspaces: BridgeWorkspaceDescriptor[],
+    writeFileModes?: BridgeWorkspaceToolCapabilities['writeFileModes'],
   ) {
     this.capabilities = {
       protocolVersion: BRIDGE_PROTOCOL_VERSION,
       operations,
       workspaces,
+      ...(writeFileModes != null ? { writeFileModes } : {}),
     };
   }
 
@@ -1358,6 +1375,7 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
       protocolVersion: BRIDGE_PROTOCOL_VERSION,
       operations,
       workspaces,
+      ...(anyWritable ? { writeFileModes: ['replace', 'create'] } : {}),
     };
     if (!isValidBridgeWorkspaceToolCapabilities(capabilities)) {
       throw new WorkspaceToolError(
@@ -1381,7 +1399,12 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
         writable: workspace.writable === true,
       });
     }
-    return new LocalWorkspaceTools(roots, operations, workspaces);
+    return new LocalWorkspaceTools(
+      roots,
+      operations,
+      workspaces,
+      capabilities.writeFileModes,
+    );
   }
 
   async execute(
@@ -1505,6 +1528,9 @@ export class SandboxWorkspaceTools implements WorkspaceToolExecutor {
     this.capabilities = {
       protocolVersion: BRIDGE_PROTOCOL_VERSION,
       operations: [...new Set([...base.operations, 'execute_command' as const])],
+      ...(base.writeFileModes != null
+        ? { writeFileModes: base.writeFileModes }
+        : {}),
       workspaces: base.workspaces.map((workspace) => ({
         ...workspace,
         operations: [

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { constants } from 'node:fs';
-import { lstat, open, realpath, rename, stat, unlink } from 'node:fs/promises';
+import { link, lstat, open, realpath, rename, stat, unlink } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 
 import type { FileHandle } from 'node:fs/promises';
@@ -455,6 +455,7 @@ async function atomicWriteConfinedFile(
   content: Buffer,
   signal?: AbortSignal,
   expected?: { dev: bigint | number; ino: bigint | number; content: Buffer },
+  allowOverwrite = true,
 ): Promise<{ created: boolean }> {
   throwIfAborted(signal);
   if (content.byteLength > BRIDGE_WORKSPACE_WRITE_MAX_BYTES) {
@@ -487,6 +488,12 @@ async function atomicWriteConfinedFile(
   }
   if (existing?.isSymbolicLink() || (existing != null && !existing.isFile())) {
     throw new WorkspaceToolError('Invalid workspace path', 'INVALID_PATH');
+  }
+  if (!allowOverwrite && existing != null) {
+    throw new WorkspaceToolError(
+      'Workspace file already exists',
+      'EDIT_CONFLICT',
+    );
   }
   if (
     expected != null &&
@@ -591,7 +598,21 @@ async function atomicWriteConfinedFile(
       return { created: false };
     }
     throwIfAborted(signal);
-    await rename(temporary, installTarget);
+    if (allowOverwrite) {
+      await rename(temporary, installTarget);
+    } else {
+      try {
+        await link(temporary, installTarget);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          throw new WorkspaceToolError(
+            'Workspace file already exists',
+            'EDIT_CONFLICT',
+          );
+        }
+        throw error;
+      }
+    }
     await confirmInstalledMutation(root, installTarget, staged);
     return { created: existing == null };
   } catch (error) {
@@ -617,6 +638,8 @@ async function writeWorkspaceFile(
     request.path,
     content,
     signal,
+    undefined,
+    request.overwrite !== false,
   );
   return {
     protocolVersion: BRIDGE_PROTOCOL_VERSION,

--- a/service/src/bridge/router.test.ts
+++ b/service/src/bridge/router.test.ts
@@ -287,6 +287,7 @@ describe('paired bridge HTTP API', () => {
         'edit_file',
         'execute_command',
       ],
+      supportedWorkspaceWriteFileModes: ['replace', 'create'],
     });
 
     const crossDeploymentRevoke = await fetch(

--- a/service/src/bridge/router.ts
+++ b/service/src/bridge/router.ts
@@ -387,6 +387,7 @@ router.post(
           'edit_file',
           'execute_command',
         ],
+        supportedWorkspaceWriteFileModes: ['replace', 'create'],
       });
     } catch (error) {
       if (error instanceof BridgeStoreError) {

--- a/service/src/bridge/store.ts
+++ b/service/src/bridge/store.ts
@@ -76,13 +76,18 @@ function supportsWorkspaceTool(
   const workspace = capabilities?.workspaces.find(
     (candidate) => candidate.id === request.workspaceId,
   );
-  return (
+  const supportsOperation =
     capabilities != null &&
     capabilities.operations.includes(request.operation) &&
     workspace != null &&
     (workspace.operations == null ||
-      workspace.operations.includes(request.operation))
-  );
+      workspace.operations.includes(request.operation));
+  if (!supportsOperation || request.operation !== 'write_file') {
+    return supportsOperation;
+  }
+  if (request.overwrite === undefined) return true;
+  const mode = request.overwrite === false ? 'create' : 'replace';
+  return capabilities?.writeFileModes?.includes(mode) === true;
 }
 
 function workerKey(workerId: string): string {

--- a/service/src/bridge/workspace-store.test.ts
+++ b/service/src/bridge/workspace-store.test.ts
@@ -143,6 +143,41 @@ test('rejects an operation omitted from the selected workspace capability', asyn
   expect(await redis.keys('codeapi:bridge:v1:assignment:*')).toHaveLength(0);
 });
 
+test('rejects create-only writes from workers without the negotiated mode', async () => {
+  await store.register({
+    protocolVersion: BRIDGE_PROTOCOL_VERSION,
+    workerId: 'workspace-worker',
+    incarnationId,
+    capabilities: {
+      statefulWorkspace: true,
+      sandboxProfile: 'nsjail',
+      runtimes: ['bash'],
+      workspaceTools: {
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        operations: ['write_file'],
+        workspaces: [{ id: 'primary' }],
+      },
+    },
+  });
+
+  await expect(
+    store.dispatchWorkspaceTool({
+      workerId: 'workspace-worker',
+      request: {
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        operation: 'write_file',
+        workspaceId: 'primary',
+        path: 'notes.txt',
+        content: 'create me',
+        overwrite: false,
+      },
+      deadlineAtMs: Date.now() + 1_000,
+      signal: new AbortController().signal,
+    }),
+  ).rejects.toMatchObject({ code: 'WORKER_MISMATCH' });
+  expect(await redis.keys('codeapi:bridge:v1:assignment:*')).toHaveLength(0);
+});
+
 test('rejects a fulfilled workspace settlement that violates the result contract', async () => {
   await store.register({
     protocolVersion: BRIDGE_PROTOCOL_VERSION,


### PR DESCRIPTION
## Summary

I added a backwards-compatible create-only mode to the BYOM workspace write protocol so LibreChat can safely honor `create_file` without a read-then-write race.

- Add the optional `overwrite` field to workspace write requests while preserving overwrite behavior for existing callers.
- Install create-only files atomically with a hard-link operation and return `EDIT_CONFLICT` if another writer wins the target path.
- Validate that create-only results report a newly created file.
- Cover existing-target preservation and concurrent-create races.
- Document the create-only protocol behavior.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- Ran `npm test` in `packages/code`: 226 passed, 1 filesystem-dependent test skipped, 0 failed.
- Ran `git diff --check`.

### **Test Configuration**:

- macOS
- Node.js package build through the repository test script

## Checklist

- [x] My code adheres to this projects style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes