### PR TITLE
🧺 feat: Commit Ordered Workspace Edit Batches Atomically

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -277,7 +277,8 @@ the target already exists. Code API dispatches that mode only after the worker
 and server negotiate `create` in `writeFileModes`.
 `edit_file` accepts either the legacy `oldText`/`newText` pair or an ordered
 `edits` array; every exact replacement is validated before the updated file is
-installed as one atomic mutation.
+installed as one atomic mutation. Code API dispatches the batch form only after
+the worker and server negotiate `batch` in `editFileModes`.
 Only IDs, names, protocol version, supported operations, and negotiated write
 modes appear in worker capabilities; absolute host paths remain local to the
 worker process.

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -275,6 +275,9 @@ with `--allow-workspace-writes` or
 `overwrite: false` to require an atomic create that returns `EDIT_CONFLICT` if
 the target already exists. Code API dispatches that mode only after the worker
 and server negotiate `create` in `writeFileModes`.
+`edit_file` accepts either the legacy `oldText`/`newText` pair or an ordered
+`edits` array; every exact replacement is validated before the updated file is
+installed as one atomic mutation.
 Only IDs, names, protocol version, supported operations, and negotiated write
 modes appear in worker capabilities; absolute host paths remain local to the
 worker process.

--- a/packages/code/src/protocol.test.ts
+++ b/packages/code/src/protocol.test.ts
@@ -235,6 +235,47 @@ test('workspace mutations accept bounded UTF-8 requests and exact result shapes'
     }),
     true,
   );
+  const batchEditRequest = {
+    protocolVersion: 1 as const,
+    operation: 'edit_file' as const,
+    workspaceId: 'primary',
+    path: 'notes.txt',
+    edits: [
+      { oldText: 'hello', newText: 'goodbye' },
+      { oldText: 'world', newText: 'BYOM' },
+    ],
+  };
+  assert.equal(isWorkspaceToolRequest(batchEditRequest), true);
+  assert.equal(
+    isWorkspaceToolRequest({ ...batchEditRequest, oldText: 'mixed' }),
+    false,
+  );
+  assert.equal(isWorkspaceToolRequest({ ...batchEditRequest, edits: [] }), false);
+  assert.equal(
+    isWorkspaceToolRequest({
+      ...batchEditRequest,
+      edits: Array.from({ length: 101 }, () => ({ oldText: 'a', newText: 'b' })),
+    }),
+    false,
+  );
+  assert.equal(
+    isWorkspaceToolRequest({
+      ...batchEditRequest,
+      edits: [{ oldText: 'a'.repeat(600_000), newText: 'b'.repeat(600_000) }],
+    }),
+    false,
+  );
+  assert.equal(
+    isWorkspaceToolResult(batchEditRequest, {
+      protocolVersion: 1,
+      operation: 'edit_file',
+      workspaceId: 'primary',
+      path: 'notes.txt',
+      replacements: 2,
+      bytesWritten: 12,
+    }),
+    true,
+  );
 });
 
 test('workspace commands require bounded sandbox inputs and outputs', () => {

--- a/packages/code/src/protocol.test.ts
+++ b/packages/code/src/protocol.test.ts
@@ -7,6 +7,37 @@ import {
   isWorkspaceToolRequest,
   isWorkspaceToolResult,
 } from './protocol.js';
+import type { WorkspaceEditFileRequest } from './protocol.js';
+
+const validSingleEditRequest: WorkspaceEditFileRequest = {
+  protocolVersion: 1,
+  operation: 'edit_file',
+  workspaceId: 'primary',
+  path: 'notes.txt',
+  oldText: 'before',
+  newText: 'after',
+};
+const validBatchEditRequest: WorkspaceEditFileRequest = {
+  protocolVersion: 1,
+  operation: 'edit_file',
+  workspaceId: 'primary',
+  path: 'notes.txt',
+  edits: [{ oldText: 'before', newText: 'after' }],
+};
+// @ts-expect-error An edit request must choose a complete single or batch form.
+const invalidEmptyEditRequest: WorkspaceEditFileRequest = {
+  protocolVersion: 1,
+  operation: 'edit_file',
+  workspaceId: 'primary',
+  path: 'notes.txt',
+};
+// @ts-expect-error Single and batch edit forms are mutually exclusive.
+const invalidMixedEditRequest: WorkspaceEditFileRequest = {
+  ...validSingleEditRequest,
+  edits: validBatchEditRequest.edits,
+};
+void invalidEmptyEditRequest;
+void invalidMixedEditRequest;
 
 test('bridgeWorkerPath encodes worker-controlled path segments', () => {
   assert.equal(
@@ -80,6 +111,27 @@ test('bridge worker capabilities accept only bounded public workspace descriptor
       },
     }),
     true,
+  );
+  assert.equal(
+    isValidBridgeWorkerCapabilities({
+      ...valid,
+      workspaceTools: {
+        ...valid.workspaceTools,
+        operations: ['read_file', 'edit_file'],
+        editFileModes: ['single', 'batch'],
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    isValidBridgeWorkerCapabilities({
+      ...valid,
+      workspaceTools: {
+        ...valid.workspaceTools,
+        editFileModes: ['batch'],
+      },
+    }),
+    false,
   );
   assert.equal(
     isValidBridgeWorkerCapabilities({

--- a/packages/code/src/protocol.ts
+++ b/packages/code/src/protocol.ts
@@ -32,6 +32,7 @@ export type BridgeWorkspaceToolOperation =
   | 'execute_command';
 
 export type WorkspaceWriteFileMode = 'replace' | 'create';
+export type WorkspaceEditFileMode = 'single' | 'batch';
 
 export interface BridgeWorkspaceDescriptor {
   id: string;
@@ -46,6 +47,8 @@ export interface BridgeWorkspaceToolCapabilities {
   workspaces: BridgeWorkspaceDescriptor[];
   /** Omitted by legacy workers, which only accept replacement writes. */
   writeFileModes?: WorkspaceWriteFileMode[];
+  /** Omitted by legacy workers, which only accept single exact replacements. */
+  editFileModes?: WorkspaceEditFileMode[];
 }
 
 export interface WorkspaceReadFileRequest {
@@ -128,18 +131,33 @@ export interface WorkspaceWriteFileResult {
   bytesWritten: number;
 }
 
-export interface WorkspaceEditFileRequest {
+interface WorkspaceEditFileRequestBase {
   protocolVersion: BridgeProtocolVersion;
   operation: 'edit_file';
   workspaceId: string;
   path: string;
-  /** Legacy single-edit form. Mutually exclusive with edits. */
-  oldText?: string;
-  /** Legacy single-edit form. Mutually exclusive with edits. */
-  newText?: string;
-  /** Ordered exact replacements applied atomically as one file mutation. */
-  edits?: WorkspaceTextEdit[];
 }
+
+export interface WorkspaceSingleEditFileRequest
+  extends WorkspaceEditFileRequestBase {
+  /** Legacy single-edit form. */
+  oldText: string;
+  /** Legacy single-edit form. */
+  newText: string;
+  edits?: never;
+}
+
+export interface WorkspaceBatchEditFileRequest
+  extends WorkspaceEditFileRequestBase {
+  /** Ordered exact replacements applied atomically as one file mutation. */
+  edits: WorkspaceTextEdit[];
+  oldText?: never;
+  newText?: never;
+}
+
+export type WorkspaceEditFileRequest =
+  | WorkspaceSingleEditFileRequest
+  | WorkspaceBatchEditFileRequest;
 
 export interface WorkspaceTextEdit {
   oldText: string;
@@ -332,6 +350,8 @@ export interface BridgeWorkerRegistrationResponse {
   supportedWorkspaceToolOperations?: BridgeWorkspaceToolOperation[];
   /** Write modes this Code API can safely route to a capability-aware worker. */
   supportedWorkspaceWriteFileModes?: WorkspaceWriteFileMode[];
+  /** Edit modes this Code API can safely route to a capability-aware worker. */
+  supportedWorkspaceEditFileModes?: WorkspaceEditFileMode[];
 }
 
 export interface BridgePairingRedemption {
@@ -856,6 +876,21 @@ export function isValidBridgeWorkspaceToolCapabilities(
       ) ||
       new Set(capabilities.writeFileModes).size !==
         capabilities.writeFileModes.length)
+  ) {
+    return false;
+  }
+
+  if (
+    capabilities.editFileModes !== undefined &&
+    (!Array.isArray(capabilities.editFileModes) ||
+      capabilities.editFileModes.length < 1 ||
+      capabilities.editFileModes.length > 2 ||
+      !capabilities.operations.includes('edit_file') ||
+      !capabilities.editFileModes.every(
+        (mode) => mode === 'single' || mode === 'batch',
+      ) ||
+      new Set(capabilities.editFileModes).size !==
+        capabilities.editFileModes.length)
   ) {
     return false;
   }

--- a/packages/code/src/protocol.ts
+++ b/packages/code/src/protocol.ts
@@ -9,6 +9,7 @@ export const BRIDGE_WORKSPACE_PATH_MAX_LENGTH = 4096;
 export const BRIDGE_WORKSPACE_QUERY_MAX_LENGTH = 4096;
 export const BRIDGE_WORKSPACE_READ_MAX_BYTES = 1024 * 1024;
 export const BRIDGE_WORKSPACE_WRITE_MAX_BYTES = 1024 * 1024;
+export const BRIDGE_WORKSPACE_EDIT_MAX_EDITS = 100;
 export const BRIDGE_WORKSPACE_READ_MAX_LINES = 500;
 export const BRIDGE_WORKSPACE_SEARCH_MAX_RESULTS = 200;
 export const BRIDGE_WORKSPACE_SEARCH_TEXT_MAX_LENGTH = 2000;
@@ -132,6 +133,15 @@ export interface WorkspaceEditFileRequest {
   operation: 'edit_file';
   workspaceId: string;
   path: string;
+  /** Legacy single-edit form. Mutually exclusive with edits. */
+  oldText?: string;
+  /** Legacy single-edit form. Mutually exclusive with edits. */
+  newText?: string;
+  /** Ordered exact replacements applied atomically as one file mutation. */
+  edits?: WorkspaceTextEdit[];
+}
+
+export interface WorkspaceTextEdit {
   oldText: string;
   newText: string;
 }
@@ -141,7 +151,7 @@ export interface WorkspaceEditFileResult {
   operation: 'edit_file';
   workspaceId: string;
   path: string;
-  replacements: 1;
+  replacements: number;
   bytesWritten: number;
 }
 
@@ -223,7 +233,9 @@ const WORKSPACE_EDIT_REQUEST_KEYS = new Set([
   'path',
   'oldText',
   'newText',
+  'edits',
 ]);
+const WORKSPACE_TEXT_EDIT_KEYS = new Set(['oldText', 'newText']);
 const WORKSPACE_COMMAND_REQUEST_KEYS = new Set([
   'protocolVersion',
   'operation',
@@ -496,6 +508,55 @@ function isWithinRequestedPath(candidate: string, requested?: string): boolean {
   );
 }
 
+function isValidWorkspaceEditRequest(request: Record<string, unknown>): boolean {
+  const hasBatch = request.edits !== undefined;
+  if (hasBatch && (request.oldText !== undefined || request.newText !== undefined)) {
+    return false;
+  }
+  const edits = hasBatch
+    ? request.edits
+    : [{ oldText: request.oldText, newText: request.newText }];
+  if (
+    !Array.isArray(edits) ||
+    edits.length < 1 ||
+    edits.length > BRIDGE_WORKSPACE_EDIT_MAX_EDITS
+  ) {
+    return false;
+  }
+  let totalBytes = 0;
+  for (const edit of edits) {
+    if (
+      typeof edit !== 'object' ||
+      edit === null ||
+      !hasOnlyKeys(edit as Record<string, unknown>, WORKSPACE_TEXT_EDIT_KEYS)
+    ) {
+      return false;
+    }
+    const candidate = edit as Record<string, unknown>;
+    if (
+      typeof candidate.oldText !== 'string' ||
+      candidate.oldText.length === 0 ||
+      Buffer.from(candidate.oldText).toString('utf8') !== candidate.oldText ||
+      typeof candidate.newText !== 'string' ||
+      Buffer.from(candidate.newText).toString('utf8') !== candidate.newText
+    ) {
+      return false;
+    }
+    const oldBytes = new TextEncoder().encode(candidate.oldText).byteLength;
+    const newBytes = new TextEncoder().encode(candidate.newText).byteLength;
+    totalBytes += oldBytes + newBytes;
+    if (
+      (hasBatch && totalBytes > BRIDGE_WORKSPACE_WRITE_MAX_BYTES) ||
+      (!hasBatch &&
+        (oldBytes > BRIDGE_WORKSPACE_WRITE_MAX_BYTES ||
+          newBytes > BRIDGE_WORKSPACE_WRITE_MAX_BYTES))
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function hasOnlyKeys(
   value: Record<string, unknown>,
   allowed: ReadonlySet<string>,
@@ -575,15 +636,7 @@ export function isWorkspaceToolRequest(
     return (
       hasOnlyKeys(request, WORKSPACE_EDIT_REQUEST_KEYS) &&
       isSafePortableRelativePath(request.path) &&
-      typeof request.oldText === 'string' &&
-      request.oldText.length > 0 &&
-      Buffer.from(request.oldText).toString('utf8') === request.oldText &&
-      new TextEncoder().encode(request.oldText).byteLength <=
-        BRIDGE_WORKSPACE_WRITE_MAX_BYTES &&
-      typeof request.newText === 'string' &&
-      Buffer.from(request.newText).toString('utf8') === request.newText &&
-      new TextEncoder().encode(request.newText).byteLength <=
-        BRIDGE_WORKSPACE_WRITE_MAX_BYTES
+      isValidWorkspaceEditRequest(request)
     );
   }
   if (request.operation === 'execute_command') {
@@ -700,10 +753,11 @@ export function isWorkspaceToolResult(
   }
 
   if (request.operation === 'edit_file') {
+    const replacements = request.edits?.length ?? 1;
     return (
       hasOnlyKeys(result, WORKSPACE_EDIT_RESULT_KEYS) &&
       result.path === request.path &&
-      result.replacements === 1 &&
+      result.replacements === replacements &&
       Number.isSafeInteger(result.bytesWritten) &&
       Number(result.bytesWritten) >= 0 &&
       Number(result.bytesWritten) <= BRIDGE_WORKSPACE_WRITE_MAX_BYTES

--- a/packages/code/src/worker.ts
+++ b/packages/code/src/worker.ts
@@ -141,6 +141,10 @@ function workspaceCapabilitiesMatch(
     (advertised.writeFileModes?.every(
       (mode, index) => mode === executor.writeFileModes?.[index],
     ) ?? executor.writeFileModes == null) &&
+    advertised.editFileModes?.length === executor.editFileModes?.length &&
+    (advertised.editFileModes?.every(
+      (mode, index) => mode === executor.editFileModes?.[index],
+    ) ?? executor.editFileModes == null) &&
     advertised.workspaces.length === executor.workspaces.length &&
     advertised.workspaces.every(
       (workspace, index) =>
@@ -195,8 +199,11 @@ function registrationCompatibleCapabilities(
     const { workspaceTools: _workspaceTools, ...compatible } = capabilities;
     return compatible;
   }
-  const { writeFileModes: _writeFileModes, ...compatibleWorkspaceTools } =
-    workspaceTools;
+  const {
+    writeFileModes: _writeFileModes,
+    editFileModes: _editFileModes,
+    ...compatibleWorkspaceTools
+  } = workspaceTools;
   return {
     ...capabilities,
     workspaceTools: {
@@ -231,7 +238,14 @@ function supportedWorkspaceCapabilities(
   const writeFileModes = desired.writeFileModes?.filter((mode) =>
     registration.supportedWorkspaceWriteFileModes?.includes(mode),
   );
-  const { writeFileModes: _writeFileModes, ...compatibleDesired } = desired;
+  const editFileModes = desired.editFileModes?.filter((mode) =>
+    registration.supportedWorkspaceEditFileModes?.includes(mode),
+  );
+  const {
+    writeFileModes: _writeFileModes,
+    editFileModes: _editFileModes,
+    ...compatibleDesired
+  } = desired;
   return {
     ...capabilities,
     workspaceTools: {
@@ -240,6 +254,9 @@ function supportedWorkspaceCapabilities(
       workspaces,
       ...(operations.includes('write_file') && writeFileModes?.length
         ? { writeFileModes }
+        : {}),
+      ...(operations.includes('edit_file') && editFileModes?.length
+        ? { editFileModes }
         : {}),
     },
   };
@@ -897,6 +914,18 @@ export class BridgeWorker {
           if (!advertised.writeFileModes?.includes(mode)) {
             throw new BridgeProtocolError(
               'Workspace write mode is not advertised',
+            );
+          }
+        }
+        if (workspaceRequest.operation === 'edit_file') {
+          const mode = workspaceRequest.edits === undefined ? 'single' : 'batch';
+          const modes = advertised.editFileModes;
+          if (
+            (modes == null && mode !== 'single') ||
+            (modes != null && !modes.includes(mode))
+          ) {
+            throw new BridgeProtocolError(
+              'Workspace edit mode is not advertised',
             );
           }
         }

--- a/packages/code/src/workspace-worker.test.ts
+++ b/packages/code/src/workspace-worker.test.ts
@@ -485,6 +485,72 @@ test('worker omits write modes not negotiated by an older Code API', async () =>
   ]);
 });
 
+test('worker omits batch edits not negotiated by an older Code API', async () => {
+  const registrations: Array<Record<string, unknown>> = [];
+  const workspaceCapabilities = {
+    protocolVersion: 1 as const,
+    operations: ['read_file' as const, 'edit_file' as const],
+    editFileModes: ['single' as const, 'batch' as const],
+    workspaces: [
+      {
+        id: 'primary',
+        operations: ['read_file' as const, 'edit_file' as const],
+      },
+    ],
+  };
+  const worker = new BridgeWorker({
+    codeApiUrl: 'https://code.example/v1',
+    token: 'worker-secret',
+    workerId: 'vm-1',
+    incarnationId,
+    sandboxEndpoint: 'http://127.0.0.1:2000/api/v2',
+    capabilities: {
+      statefulWorkspace: true,
+      sandboxProfile: 'nsjail',
+      runtimes: ['bash'],
+      workspaceTools: workspaceCapabilities,
+    },
+    workspaceTools: {
+      capabilities: workspaceCapabilities,
+      async execute() {
+        throw new Error('not executed');
+      },
+    },
+    workspaceMutationQuarantine: mutationQuarantine(),
+    fetchImpl: async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        capabilities: { workspaceTools?: Record<string, unknown> };
+      };
+      registrations.push(body.capabilities.workspaceTools ?? {});
+      return Response.json({
+        protocolVersion: 1,
+        workerId: 'vm-1',
+        incarnationId,
+        registeredAt: new Date().toISOString(),
+        leaseTtlMs: 60_000,
+        supportedWorkspaceToolOperations: ['read_file', 'edit_file'],
+      });
+    },
+  });
+
+  await worker.register();
+
+  assert.deepEqual(registrations, [
+    {
+      protocolVersion: 1,
+      operations: ['read_file'],
+      workspaces: [{ id: 'primary' }],
+    },
+    {
+      protocolVersion: 1,
+      operations: ['read_file', 'edit_file'],
+      workspaces: [
+        { id: 'primary', operations: ['read_file', 'edit_file'] },
+      ],
+    },
+  ]);
+});
+
 test('worker retains per-workspace restrictions during read-only promotion', async () => {
   const registrations: Array<{
     operations: string[];

--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -821,6 +821,7 @@ test('writable workspaces create, replace, and exactly edit files', async (t) =>
       },
     ],
     writeFileModes: ['replace', 'create'],
+    editFileModes: ['single', 'batch'],
   });
   await tools.execute({
     protocolVersion: 1,
@@ -1744,6 +1745,7 @@ test('composes sandboxed commands without exposing them on unconfigured workspac
     'execute_command',
   ]);
   assert.deepEqual(tools.capabilities.writeFileModes, ['replace', 'create']);
+  assert.deepEqual(tools.capabilities.editFileModes, ['single', 'batch']);
   assert.deepEqual(
     tools.capabilities.workspaces.find(({ id }) => id === 'sandboxed')?.operations,
     tools.capabilities.operations,

--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -918,6 +918,51 @@ test('workspace writes can require an atomic create without replacement', async 
   assert.match(await readFile(join(root, 'raced.txt'), 'utf8'), /^(first|second)$/);
 });
 
+test('workspace batch edits commit all replacements atomically', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-workspace-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeFile(join(root, 'batch.txt'), 'alpha beta gamma');
+  const tools = await LocalWorkspaceTools.create({
+    workspaces: [{ id: 'primary', root, writable: true }],
+  });
+
+  const result = await tools.execute({
+    protocolVersion: 1,
+    operation: 'edit_file',
+    workspaceId: 'primary',
+    path: 'batch.txt',
+    edits: [
+      { oldText: 'alpha', newText: 'one' },
+      { oldText: 'gamma', newText: 'three' },
+    ],
+  });
+  assert.deepEqual(result, {
+    protocolVersion: 1,
+    operation: 'edit_file',
+    workspaceId: 'primary',
+    path: 'batch.txt',
+    replacements: 2,
+    bytesWritten: 14,
+  });
+  assert.equal(await readFile(join(root, 'batch.txt'), 'utf8'), 'one beta three');
+
+  await assert.rejects(
+    tools.execute({
+      protocolVersion: 1,
+      operation: 'edit_file',
+      workspaceId: 'primary',
+      path: 'batch.txt',
+      edits: [
+        { oldText: 'one', newText: 'partial' },
+        { oldText: 'missing', newText: 'never' },
+      ],
+    }),
+    (error: unknown) =>
+      error instanceof WorkspaceToolError && error.code === 'EDIT_CONFLICT',
+  );
+  assert.equal(await readFile(join(root, 'batch.txt'), 'utf8'), 'one beta three');
+});
+
 test('workspace mutations sync the containing directory after replacement', async (t) => {
   if (process.platform === 'win32') {
     t.skip('Directory fsync is unavailable on Windows');

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -708,20 +708,26 @@ async function editWorkspaceFile(
         'INVALID_REQUEST',
       );
     }
-    const first = text.indexOf(request.oldText);
-    if (
-      first < 0 ||
-      text.indexOf(request.oldText, first + 1) >= 0
-    ) {
-      throw new WorkspaceToolError(
-        'Workspace edit must match exactly once',
-        'EDIT_CONFLICT',
-      );
+    const edits = request.edits ?? [
+      { oldText: request.oldText ?? '', newText: request.newText ?? '' },
+    ];
+    let updatedText = text;
+    for (const edit of edits) {
+      const first = updatedText.indexOf(edit.oldText);
+      if (
+        first < 0 ||
+        updatedText.indexOf(edit.oldText, first + 1) >= 0
+      ) {
+        throw new WorkspaceToolError(
+          'Workspace edit must match exactly once',
+          'EDIT_CONFLICT',
+        );
+      }
+      updatedText =
+        updatedText.slice(0, first) +
+        edit.newText +
+        updatedText.slice(first + edit.oldText.length);
     }
-    const updatedText =
-      text.slice(0, first) +
-      request.newText +
-      text.slice(first + request.oldText.length);
     const updatedBody = Buffer.from(updatedText, 'utf8');
     const updated = hasBom
       ? Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), updatedBody])
@@ -742,7 +748,7 @@ async function editWorkspaceFile(
       operation: 'edit_file',
       workspaceId: request.workspaceId,
       path: request.path,
-      replacements: 1,
+      replacements: edits.length,
       bytesWritten: updated.byteLength,
     };
   } catch (error) {

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -1343,12 +1343,14 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
     operations: BridgeWorkspaceToolCapabilities['operations'],
     workspaces: BridgeWorkspaceDescriptor[],
     writeFileModes?: BridgeWorkspaceToolCapabilities['writeFileModes'],
+    editFileModes?: BridgeWorkspaceToolCapabilities['editFileModes'],
   ) {
     this.capabilities = {
       protocolVersion: BRIDGE_PROTOCOL_VERSION,
       operations,
       workspaces,
       ...(writeFileModes != null ? { writeFileModes } : {}),
+      ...(editFileModes != null ? { editFileModes } : {}),
     };
   }
 
@@ -1382,6 +1384,7 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
       operations,
       workspaces,
       ...(anyWritable ? { writeFileModes: ['replace', 'create'] } : {}),
+      ...(anyWritable ? { editFileModes: ['single', 'batch'] } : {}),
     };
     if (!isValidBridgeWorkspaceToolCapabilities(capabilities)) {
       throw new WorkspaceToolError(
@@ -1410,6 +1413,7 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
       operations,
       workspaces,
       capabilities.writeFileModes,
+      capabilities.editFileModes,
     );
   }
 
@@ -1536,6 +1540,9 @@ export class SandboxWorkspaceTools implements WorkspaceToolExecutor {
       operations: [...new Set([...base.operations, 'execute_command' as const])],
       ...(base.writeFileModes != null
         ? { writeFileModes: base.writeFileModes }
+        : {}),
+      ...(base.editFileModes != null
+        ? { editFileModes: base.editFileModes }
         : {}),
       workspaces: base.workspaces.map((workspace) => ({
         ...workspace,

--- a/service/src/bridge/router.test.ts
+++ b/service/src/bridge/router.test.ts
@@ -288,6 +288,7 @@ describe('paired bridge HTTP API', () => {
         'execute_command',
       ],
       supportedWorkspaceWriteFileModes: ['replace', 'create'],
+      supportedWorkspaceEditFileModes: ['single', 'batch'],
     });
 
     const crossDeploymentRevoke = await fetch(

--- a/service/src/bridge/router.ts
+++ b/service/src/bridge/router.ts
@@ -388,6 +388,7 @@ router.post(
           'execute_command',
         ],
         supportedWorkspaceWriteFileModes: ['replace', 'create'],
+        supportedWorkspaceEditFileModes: ['single', 'batch'],
       });
     } catch (error) {
       if (error instanceof BridgeStoreError) {

--- a/service/src/bridge/store.ts
+++ b/service/src/bridge/store.ts
@@ -82,12 +82,20 @@ function supportsWorkspaceTool(
     workspace != null &&
     (workspace.operations == null ||
       workspace.operations.includes(request.operation));
-  if (!supportsOperation || request.operation !== 'write_file') {
+  if (!supportsOperation) {
     return supportsOperation;
   }
-  if (request.overwrite === undefined) return true;
-  const mode = request.overwrite === false ? 'create' : 'replace';
-  return capabilities?.writeFileModes?.includes(mode) === true;
+  if (request.operation === 'write_file') {
+    if (request.overwrite === undefined) return true;
+    const mode = request.overwrite === false ? 'create' : 'replace';
+    return capabilities?.writeFileModes?.includes(mode) === true;
+  }
+  if (request.operation === 'edit_file') {
+    const mode = request.edits === undefined ? 'single' : 'batch';
+    const modes = capabilities?.editFileModes;
+    return modes == null ? mode === 'single' : modes.includes(mode);
+  }
+  return true;
 }
 
 function workerKey(workerId: string): string {

--- a/service/src/bridge/workspace-store.test.ts
+++ b/service/src/bridge/workspace-store.test.ts
@@ -178,6 +178,40 @@ test('rejects create-only writes from workers without the negotiated mode', asyn
   expect(await redis.keys('codeapi:bridge:v1:assignment:*')).toHaveLength(0);
 });
 
+test('rejects batch edits from workers without the negotiated mode', async () => {
+  await store.register({
+    protocolVersion: BRIDGE_PROTOCOL_VERSION,
+    workerId: 'workspace-worker',
+    incarnationId,
+    capabilities: {
+      statefulWorkspace: true,
+      sandboxProfile: 'nsjail',
+      runtimes: ['bash'],
+      workspaceTools: {
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        operations: ['edit_file'],
+        workspaces: [{ id: 'primary' }],
+      },
+    },
+  });
+
+  await expect(
+    store.dispatchWorkspaceTool({
+      workerId: 'workspace-worker',
+      request: {
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        operation: 'edit_file',
+        workspaceId: 'primary',
+        path: 'notes.txt',
+        edits: [{ oldText: 'before', newText: 'after' }],
+      },
+      deadlineAtMs: Date.now() + 1_000,
+      signal: new AbortController().signal,
+    }),
+  ).rejects.toMatchObject({ code: 'WORKER_MISMATCH' });
+  expect(await redis.keys('codeapi:bridge:v1:assignment:*')).toHaveLength(0);
+});
+
 test('rejects a fulfilled workspace settlement that violates the result contract', async () => {
   await store.register({
     protocolVersion: BRIDGE_PROTOCOL_VERSION,


### PR DESCRIPTION
## Summary

I extended the BYOM workspace edit protocol with bounded ordered edit batches that commit as one atomic file mutation.

- Preserve the legacy single `oldText` and `newText` request form.
- Add a mutually exclusive `edits` array capped at 100 replacements and 1 MiB of aggregate edit text.
- Apply every exact replacement in memory before installing the updated file once.
- Reject a missing or ambiguous replacement without committing any earlier edit in the batch.
- Validate result replacement counts against the originating request.
- Document the atomic batch behavior.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- Ran `npm test` in `packages/code`: 227 passed, 1 filesystem-dependent test skipped, 0 failed.
- Covered batch bounds, mixed request-shape rejection, successful ordered replacement, and rollback when a later replacement conflicts.
- Ran `git diff --check`.

### **Test Configuration**:

- macOS
- Node.js package build through the repository test script

## Checklist

- [x] My code adheres to this projects style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes