### PR TITLE
🫆 feat: Fence Workspace Edits With Preview Revisions

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -279,6 +279,8 @@ and server negotiate `create` in `writeFileModes`.
 `edits` array; every exact replacement is validated before the updated file is
 installed as one atomic mutation. Code API dispatches the batch form only after
 the worker and server negotiate `batch` in `editFileModes`.
+Revision-fenced edits likewise require the negotiated
+`expected_base_sha256` entry in `editFileFeatures`.
 Only IDs, names, protocol version, supported operations, and negotiated write
 modes appear in worker capabilities; absolute host paths remain local to the
 worker process.

--- a/packages/code/src/protocol.test.ts
+++ b/packages/code/src/protocol.test.ts
@@ -340,6 +340,7 @@ test('workspace mutations accept bounded UTF-8 requests and exact result shapes'
       workspaceId: 'primary',
       path: 'notes.txt',
       content: 'goodbye BYOM',
+      hasUtf8Bom: false,
       baseSha256: 'a'.repeat(64),
       replacements: 2,
       bytesWritten: 12,

--- a/packages/code/src/protocol.test.ts
+++ b/packages/code/src/protocol.test.ts
@@ -7,7 +7,10 @@ import {
   isWorkspaceToolRequest,
   isWorkspaceToolResult,
 } from './protocol.js';
-import type { WorkspaceEditFileRequest } from './protocol.js';
+import type {
+  WorkspaceEditFileRequest,
+  WorkspacePreviewEditRequest,
+} from './protocol.js';
 
 const validSingleEditRequest: WorkspaceEditFileRequest = {
   protocolVersion: 1,
@@ -38,6 +41,26 @@ const invalidMixedEditRequest: WorkspaceEditFileRequest = {
 };
 void invalidEmptyEditRequest;
 void invalidMixedEditRequest;
+
+// @ts-expect-error A preview request must choose a complete single or batch form.
+const invalidEmptyPreviewRequest: WorkspacePreviewEditRequest = {
+  protocolVersion: 1,
+  operation: 'preview_edit',
+  workspaceId: 'primary',
+  path: 'notes.txt',
+};
+// @ts-expect-error Single and batch preview forms are mutually exclusive.
+const invalidMixedPreviewRequest: WorkspacePreviewEditRequest = {
+  protocolVersion: 1,
+  operation: 'preview_edit',
+  workspaceId: 'primary',
+  path: 'notes.txt',
+  oldText: 'before',
+  newText: 'after',
+  edits: [{ oldText: 'before', newText: 'after' }],
+};
+void invalidEmptyPreviewRequest;
+void invalidMixedPreviewRequest;
 
 test('bridgeWorkerPath encodes worker-controlled path segments', () => {
   assert.equal(
@@ -117,11 +140,33 @@ test('bridge worker capabilities accept only bounded public workspace descriptor
       ...valid,
       workspaceTools: {
         ...valid.workspaceTools,
-        operations: ['read_file', 'edit_file'],
+        operations: ['read_file', 'preview_edit'],
         editFileModes: ['single', 'batch'],
       },
     }),
     true,
+  );
+  assert.equal(
+    isValidBridgeWorkerCapabilities({
+      ...valid,
+      workspaceTools: {
+        ...valid.workspaceTools,
+        operations: ['read_file', 'edit_file'],
+        editFileModes: ['single', 'batch'],
+        editFileFeatures: ['expected_base_sha256'],
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    isValidBridgeWorkerCapabilities({
+      ...valid,
+      workspaceTools: {
+        ...valid.workspaceTools,
+        editFileFeatures: ['expected_base_sha256'],
+      },
+    }),
+    false,
   );
   assert.equal(
     isValidBridgeWorkerCapabilities({

--- a/packages/code/src/protocol.test.ts
+++ b/packages/code/src/protocol.test.ts
@@ -328,6 +328,38 @@ test('workspace mutations accept bounded UTF-8 requests and exact result shapes'
     }),
     true,
   );
+  const previewRequest = {
+    ...batchEditRequest,
+    operation: 'preview_edit' as const,
+  };
+  assert.equal(isWorkspaceToolRequest(previewRequest), true);
+  assert.equal(
+    isWorkspaceToolResult(previewRequest, {
+      protocolVersion: 1,
+      operation: 'preview_edit',
+      workspaceId: 'primary',
+      path: 'notes.txt',
+      content: 'goodbye BYOM',
+      baseSha256: 'a'.repeat(64),
+      replacements: 2,
+      bytesWritten: 12,
+    }),
+    true,
+  );
+  assert.equal(
+    isWorkspaceToolRequest({
+      ...editRequest,
+      expectedBaseSha256: 'b'.repeat(64),
+    }),
+    true,
+  );
+  assert.equal(
+    isWorkspaceToolRequest({
+      ...editRequest,
+      expectedBaseSha256: 'not-a-sha',
+    }),
+    false,
+  );
 });
 
 test('workspace commands require bounded sandbox inputs and outputs', () => {

--- a/packages/code/src/protocol.ts
+++ b/packages/code/src/protocol.ts
@@ -28,6 +28,7 @@ export type BridgeWorkspaceToolOperation =
   | 'search_text'
   | 'list_files'
   | 'write_file'
+  | 'preview_edit'
   | 'edit_file'
   | 'execute_command';
 
@@ -136,6 +137,8 @@ interface WorkspaceEditFileRequestBase {
   operation: 'edit_file';
   workspaceId: string;
   path: string;
+  /** Refuses the mutation unless current file bytes match this preview revision. */
+  expectedBaseSha256?: string;
 }
 
 export interface WorkspaceSingleEditFileRequest
@@ -173,6 +176,27 @@ export interface WorkspaceEditFileResult {
   bytesWritten: number;
 }
 
+export interface WorkspacePreviewEditRequest {
+  protocolVersion: BridgeProtocolVersion;
+  operation: 'preview_edit';
+  workspaceId: string;
+  path: string;
+  oldText?: string;
+  newText?: string;
+  edits?: WorkspaceTextEdit[];
+}
+
+export interface WorkspacePreviewEditResult {
+  protocolVersion: BridgeProtocolVersion;
+  operation: 'preview_edit';
+  workspaceId: string;
+  path: string;
+  content: string;
+  baseSha256: string;
+  replacements: number;
+  bytesWritten: number;
+}
+
 export interface WorkspaceExecuteCommandRequest {
   protocolVersion: BridgeProtocolVersion;
   operation: 'execute_command';
@@ -203,6 +227,7 @@ export type WorkspaceToolRequest =
   | WorkspaceSearchTextRequest
   | WorkspaceListFilesRequest
   | WorkspaceWriteFileRequest
+  | WorkspacePreviewEditRequest
   | WorkspaceEditFileRequest
   | WorkspaceExecuteCommandRequest;
 export type WorkspaceToolResult =
@@ -210,6 +235,7 @@ export type WorkspaceToolResult =
   | WorkspaceSearchTextResult
   | WorkspaceListFilesResult
   | WorkspaceWriteFileResult
+  | WorkspacePreviewEditResult
   | WorkspaceEditFileResult
   | WorkspaceExecuteCommandResult;
 
@@ -245,6 +271,16 @@ const WORKSPACE_WRITE_REQUEST_KEYS = new Set([
   'overwrite',
 ]);
 const WORKSPACE_EDIT_REQUEST_KEYS = new Set([
+  'protocolVersion',
+  'operation',
+  'workspaceId',
+  'path',
+  'oldText',
+  'newText',
+  'edits',
+  'expectedBaseSha256',
+]);
+const WORKSPACE_PREVIEW_EDIT_REQUEST_KEYS = new Set([
   'protocolVersion',
   'operation',
   'workspaceId',
@@ -301,6 +337,16 @@ const WORKSPACE_EDIT_RESULT_KEYS = new Set([
   'operation',
   'workspaceId',
   'path',
+  'replacements',
+  'bytesWritten',
+]);
+const WORKSPACE_PREVIEW_EDIT_RESULT_KEYS = new Set([
+  'protocolVersion',
+  'operation',
+  'workspaceId',
+  'path',
+  'content',
+  'baseSha256',
   'replacements',
   'bytesWritten',
 ]);
@@ -652,10 +698,20 @@ export function isWorkspaceToolRequest(
         typeof request.overwrite === 'boolean')
     );
   }
+  if (request.operation === 'preview_edit') {
+    return (
+      hasOnlyKeys(request, WORKSPACE_PREVIEW_EDIT_REQUEST_KEYS) &&
+      isSafePortableRelativePath(request.path) &&
+      isValidWorkspaceEditRequest(request)
+    );
+  }
   if (request.operation === 'edit_file') {
     return (
       hasOnlyKeys(request, WORKSPACE_EDIT_REQUEST_KEYS) &&
       isSafePortableRelativePath(request.path) &&
+      (request.expectedBaseSha256 === undefined ||
+        (typeof request.expectedBaseSha256 === 'string' &&
+          /^[a-f0-9]{64}$/.test(request.expectedBaseSha256))) &&
       isValidWorkspaceEditRequest(request)
     );
   }
@@ -784,6 +840,24 @@ export function isWorkspaceToolResult(
     );
   }
 
+  if (request.operation === 'preview_edit') {
+    const replacements = request.edits?.length ?? 1;
+    const content = typeof result.content === 'string' ? result.content : null;
+    return (
+      hasOnlyKeys(result, WORKSPACE_PREVIEW_EDIT_RESULT_KEYS) &&
+      result.path === request.path &&
+      content !== null &&
+      Buffer.from(content).toString('utf8') === content &&
+      typeof result.baseSha256 === 'string' &&
+      /^[a-f0-9]{64}$/.test(result.baseSha256) &&
+      result.replacements === replacements &&
+      Number.isSafeInteger(result.bytesWritten) &&
+      Number(result.bytesWritten) ===
+        new TextEncoder().encode(content).byteLength &&
+      Number(result.bytesWritten) <= BRIDGE_WORKSPACE_WRITE_MAX_BYTES
+    );
+  }
+
   if (request.operation === 'execute_command') {
     const stdout = typeof result.stdout === 'string' ? result.stdout : null;
     const stderr = typeof result.stderr === 'string' ? result.stderr : null;
@@ -847,13 +921,14 @@ export function isValidBridgeWorkspaceToolCapabilities(
     capabilities.protocolVersion !== BRIDGE_PROTOCOL_VERSION ||
     !Array.isArray(capabilities.operations) ||
     capabilities.operations.length < 1 ||
-    capabilities.operations.length > 6 ||
+    capabilities.operations.length > 7 ||
     !capabilities.operations.every(
       (operation) =>
         operation === 'read_file' ||
         operation === 'search_text' ||
         operation === 'list_files' ||
         operation === 'write_file' ||
+        operation === 'preview_edit' ||
         operation === 'edit_file' ||
         operation === 'execute_command',
     ) ||

--- a/packages/code/src/protocol.ts
+++ b/packages/code/src/protocol.ts
@@ -192,6 +192,7 @@ export interface WorkspacePreviewEditResult {
   workspaceId: string;
   path: string;
   content: string;
+  hasUtf8Bom: boolean;
   baseSha256: string;
   replacements: number;
   bytesWritten: number;
@@ -346,6 +347,7 @@ const WORKSPACE_PREVIEW_EDIT_RESULT_KEYS = new Set([
   'workspaceId',
   'path',
   'content',
+  'hasUtf8Bom',
   'baseSha256',
   'replacements',
   'bytesWritten',
@@ -848,12 +850,14 @@ export function isWorkspaceToolResult(
       result.path === request.path &&
       content !== null &&
       Buffer.from(content).toString('utf8') === content &&
+      typeof result.hasUtf8Bom === 'boolean' &&
       typeof result.baseSha256 === 'string' &&
       /^[a-f0-9]{64}$/.test(result.baseSha256) &&
       result.replacements === replacements &&
       Number.isSafeInteger(result.bytesWritten) &&
       Number(result.bytesWritten) ===
-        new TextEncoder().encode(content).byteLength &&
+        new TextEncoder().encode(content).byteLength +
+          (result.hasUtf8Bom ? 3 : 0) &&
       Number(result.bytesWritten) <= BRIDGE_WORKSPACE_WRITE_MAX_BYTES
     );
   }

--- a/packages/code/src/protocol.ts
+++ b/packages/code/src/protocol.ts
@@ -34,6 +34,7 @@ export type BridgeWorkspaceToolOperation =
 
 export type WorkspaceWriteFileMode = 'replace' | 'create';
 export type WorkspaceEditFileMode = 'single' | 'batch';
+export type WorkspaceEditFileFeature = 'expected_base_sha256';
 
 export interface BridgeWorkspaceDescriptor {
   id: string;
@@ -50,6 +51,8 @@ export interface BridgeWorkspaceToolCapabilities {
   writeFileModes?: WorkspaceWriteFileMode[];
   /** Omitted by legacy workers, which only accept single exact replacements. */
   editFileModes?: WorkspaceEditFileMode[];
+  /** Omitted by workers that cannot fence edits against a preview revision. */
+  editFileFeatures?: WorkspaceEditFileFeature[];
 }
 
 export interface WorkspaceReadFileRequest {
@@ -176,15 +179,30 @@ export interface WorkspaceEditFileResult {
   bytesWritten: number;
 }
 
-export interface WorkspacePreviewEditRequest {
+interface WorkspacePreviewEditRequestBase {
   protocolVersion: BridgeProtocolVersion;
   operation: 'preview_edit';
   workspaceId: string;
   path: string;
-  oldText?: string;
-  newText?: string;
-  edits?: WorkspaceTextEdit[];
 }
+
+export interface WorkspaceSinglePreviewEditRequest
+  extends WorkspacePreviewEditRequestBase {
+  oldText: string;
+  newText: string;
+  edits?: never;
+}
+
+export interface WorkspaceBatchPreviewEditRequest
+  extends WorkspacePreviewEditRequestBase {
+  edits: WorkspaceTextEdit[];
+  oldText?: never;
+  newText?: never;
+}
+
+export type WorkspacePreviewEditRequest =
+  | WorkspaceSinglePreviewEditRequest
+  | WorkspaceBatchPreviewEditRequest;
 
 export interface WorkspacePreviewEditResult {
   protocolVersion: BridgeProtocolVersion;
@@ -400,6 +418,8 @@ export interface BridgeWorkerRegistrationResponse {
   supportedWorkspaceWriteFileModes?: WorkspaceWriteFileMode[];
   /** Edit modes this Code API can safely route to a capability-aware worker. */
   supportedWorkspaceEditFileModes?: WorkspaceEditFileMode[];
+  /** Edit features this Code API can safely route to a capability-aware worker. */
+  supportedWorkspaceEditFileFeatures?: WorkspaceEditFileFeature[];
 }
 
 export interface BridgePairingRedemption {
@@ -964,12 +984,23 @@ export function isValidBridgeWorkspaceToolCapabilities(
     (!Array.isArray(capabilities.editFileModes) ||
       capabilities.editFileModes.length < 1 ||
       capabilities.editFileModes.length > 2 ||
-      !capabilities.operations.includes('edit_file') ||
+      (!capabilities.operations.includes('edit_file') &&
+        !capabilities.operations.includes('preview_edit')) ||
       !capabilities.editFileModes.every(
         (mode) => mode === 'single' || mode === 'batch',
       ) ||
       new Set(capabilities.editFileModes).size !==
         capabilities.editFileModes.length)
+  ) {
+    return false;
+  }
+
+  if (
+    capabilities.editFileFeatures !== undefined &&
+    (!Array.isArray(capabilities.editFileFeatures) ||
+      capabilities.editFileFeatures.length !== 1 ||
+      !capabilities.operations.includes('edit_file') ||
+      capabilities.editFileFeatures[0] !== 'expected_base_sha256')
   ) {
     return false;
   }

--- a/packages/code/src/worker.ts
+++ b/packages/code/src/worker.ts
@@ -145,6 +145,11 @@ function workspaceCapabilitiesMatch(
     (advertised.editFileModes?.every(
       (mode, index) => mode === executor.editFileModes?.[index],
     ) ?? executor.editFileModes == null) &&
+    advertised.editFileFeatures?.length ===
+      executor.editFileFeatures?.length &&
+    (advertised.editFileFeatures?.every(
+      (feature, index) => feature === executor.editFileFeatures?.[index],
+    ) ?? executor.editFileFeatures == null) &&
     advertised.workspaces.length === executor.workspaces.length &&
     advertised.workspaces.every(
       (workspace, index) =>
@@ -202,6 +207,7 @@ function registrationCompatibleCapabilities(
   const {
     writeFileModes: _writeFileModes,
     editFileModes: _editFileModes,
+    editFileFeatures: _editFileFeatures,
     ...compatibleWorkspaceTools
   } = workspaceTools;
   return {
@@ -224,6 +230,8 @@ function supportedWorkspaceCapabilities(
   const operations = desired.operations.filter((operation) =>
     supported.includes(operation),
   );
+  const supportsEditRequests =
+    operations.includes('edit_file') || operations.includes('preview_edit');
   if (operations.length === 0) return undefined;
   const workspaces = desired.workspaces.flatMap((workspace) => {
     if (workspace.operations == null) return [workspace];
@@ -241,9 +249,13 @@ function supportedWorkspaceCapabilities(
   const editFileModes = desired.editFileModes?.filter((mode) =>
     registration.supportedWorkspaceEditFileModes?.includes(mode),
   );
+  const editFileFeatures = desired.editFileFeatures?.filter((feature) =>
+    registration.supportedWorkspaceEditFileFeatures?.includes(feature),
+  );
   const {
     writeFileModes: _writeFileModes,
     editFileModes: _editFileModes,
+    editFileFeatures: _editFileFeatures,
     ...compatibleDesired
   } = desired;
   return {
@@ -255,8 +267,11 @@ function supportedWorkspaceCapabilities(
       ...(operations.includes('write_file') && writeFileModes?.length
         ? { writeFileModes }
         : {}),
-      ...(operations.includes('edit_file') && editFileModes?.length
+      ...(supportsEditRequests && editFileModes?.length
         ? { editFileModes }
+        : {}),
+      ...(operations.includes('edit_file') && editFileFeatures?.length
+        ? { editFileFeatures }
         : {}),
     },
   };
@@ -917,7 +932,10 @@ export class BridgeWorker {
             );
           }
         }
-        if (workspaceRequest.operation === 'edit_file') {
+        if (
+          workspaceRequest.operation === 'preview_edit' ||
+          workspaceRequest.operation === 'edit_file'
+        ) {
           const mode = workspaceRequest.edits === undefined ? 'single' : 'batch';
           const modes = advertised.editFileModes;
           if (
@@ -926,6 +944,15 @@ export class BridgeWorker {
           ) {
             throw new BridgeProtocolError(
               'Workspace edit mode is not advertised',
+            );
+          }
+          if (
+            workspaceRequest.operation === 'edit_file' &&
+            workspaceRequest.expectedBaseSha256 !== undefined &&
+            !advertised.editFileFeatures?.includes('expected_base_sha256')
+          ) {
+            throw new BridgeProtocolError(
+              'Workspace edit feature is not advertised',
             );
           }
         }

--- a/packages/code/src/worker.ts
+++ b/packages/code/src/worker.ts
@@ -19,6 +19,7 @@ import type {
   BridgeWorkerCapabilities,
   BridgeWorkerCredentialResponse,
   BridgeWorkerRegistrationResponse,
+  BridgeWorkspaceToolOperation,
 } from './protocol.js';
 import type { RuntimeLease, RuntimeSupervisor } from './runtime.js';
 import type { WorkspaceToolExecutor } from './workspace.js';
@@ -227,12 +228,50 @@ function supportedWorkspaceCapabilities(
   const desired = capabilities.workspaceTools;
   const supported = registration.supportedWorkspaceToolOperations;
   if (desired == null || !Array.isArray(supported)) return undefined;
-  const operations = desired.operations.filter((operation) =>
+  let operations = desired.operations.filter((operation) =>
     supported.includes(operation),
   );
-  const supportsEditRequests =
-    operations.includes('edit_file') || operations.includes('preview_edit');
   if (operations.length === 0) return undefined;
+  let writeFileModes: typeof desired.writeFileModes;
+  if (operations.includes('write_file')) {
+    const desiredModes = desired.writeFileModes ?? ['replace'];
+    const serverModes = registration.supportedWorkspaceWriteFileModes ?? [
+      'replace',
+    ];
+    const commonModes = desiredModes.filter((mode) =>
+      serverModes.includes(mode),
+    );
+    if (commonModes.length === 0) {
+      operations = operations.filter((operation) => operation !== 'write_file');
+    } else if (registration.supportedWorkspaceWriteFileModes != null) {
+      writeFileModes = commonModes;
+    }
+  }
+  const editOperations = new Set<BridgeWorkspaceToolOperation>([
+    'preview_edit',
+    'edit_file',
+  ]);
+  let editFileModes: typeof desired.editFileModes;
+  if (operations.some((operation) => editOperations.has(operation))) {
+    const desiredModes = desired.editFileModes ?? ['single'];
+    const serverModes = registration.supportedWorkspaceEditFileModes ?? [
+      'single',
+    ];
+    const commonModes = desiredModes.filter((mode) =>
+      serverModes.includes(mode),
+    );
+    if (commonModes.length === 0) {
+      operations = operations.filter(
+        (operation) => !editOperations.has(operation),
+      );
+    } else if (registration.supportedWorkspaceEditFileModes != null) {
+      editFileModes = commonModes;
+    }
+  }
+  if (operations.length === 0) return undefined;
+  const supportsEditRequests = operations.some((operation) =>
+    editOperations.has(operation),
+  );
   const workspaces = desired.workspaces.flatMap((workspace) => {
     if (workspace.operations == null) return [workspace];
     const workspaceOperations = workspace.operations.filter((operation) =>
@@ -243,12 +282,6 @@ function supportedWorkspaceCapabilities(
       : [{ ...workspace, operations: workspaceOperations }];
   });
   if (workspaces.length === 0) return undefined;
-  const writeFileModes = desired.writeFileModes?.filter((mode) =>
-    registration.supportedWorkspaceWriteFileModes?.includes(mode),
-  );
-  const editFileModes = desired.editFileModes?.filter((mode) =>
-    registration.supportedWorkspaceEditFileModes?.includes(mode),
-  );
   const editFileFeatures = desired.editFileFeatures?.filter((feature) =>
     registration.supportedWorkspaceEditFileFeatures?.includes(feature),
   );

--- a/packages/code/src/workspace-cli.test.ts
+++ b/packages/code/src/workspace-cli.test.ts
@@ -154,6 +154,9 @@ test('CLI advertises explicitly enabled writes without exposing the workspace ro
               'preview_edit',
               'edit_file',
             ],
+            supportedWorkspaceWriteFileModes: ['replace', 'create'],
+            supportedWorkspaceEditFileModes: ['single', 'batch'],
+            supportedWorkspaceEditFileFeatures: ['expected_base_sha256'],
           }),
         );
         return;
@@ -219,6 +222,9 @@ test('CLI advertises explicitly enabled writes without exposing the workspace ro
         'preview_edit',
         'edit_file',
       ],
+      writeFileModes: ['replace', 'create'],
+      editFileModes: ['single', 'batch'],
+      editFileFeatures: ['expected_base_sha256'],
       workspaces: [
         {
           id: 'root-workspace',

--- a/packages/code/src/workspace-cli.test.ts
+++ b/packages/code/src/workspace-cli.test.ts
@@ -151,6 +151,7 @@ test('CLI advertises explicitly enabled writes without exposing the workspace ro
               'search_text',
               'list_files',
               'write_file',
+              'preview_edit',
               'edit_file',
             ],
           }),
@@ -215,6 +216,7 @@ test('CLI advertises explicitly enabled writes without exposing the workspace ro
         'search_text',
         'list_files',
         'write_file',
+        'preview_edit',
         'edit_file',
       ],
       workspaces: [
@@ -226,6 +228,7 @@ test('CLI advertises explicitly enabled writes without exposing the workspace ro
             'search_text',
             'list_files',
             'write_file',
+            'preview_edit',
             'edit_file',
           ],
         },

--- a/packages/code/src/workspace-worker.test.ts
+++ b/packages/code/src/workspace-worker.test.ts
@@ -554,6 +554,85 @@ test('worker advertises only edit modes and features negotiated by Code API', as
   ]);
 });
 
+test('worker drops file operations when no request mode is compatible', async () => {
+  const registrations: Array<Record<string, unknown>> = [];
+  const workspaceCapabilities = {
+    protocolVersion: 1 as const,
+    operations: [
+      'read_file' as const,
+      'write_file' as const,
+      'preview_edit' as const,
+    ],
+    writeFileModes: ['create' as const],
+    editFileModes: ['batch' as const],
+    workspaces: [
+      {
+        id: 'primary',
+        operations: [
+          'read_file' as const,
+          'write_file' as const,
+          'preview_edit' as const,
+        ],
+      },
+    ],
+  };
+  const worker = new BridgeWorker({
+    codeApiUrl: 'https://code.example/v1',
+    token: 'worker-secret',
+    workerId: 'vm-1',
+    incarnationId,
+    sandboxEndpoint: 'http://127.0.0.1:2000/api/v2',
+    capabilities: {
+      statefulWorkspace: true,
+      sandboxProfile: 'nsjail',
+      runtimes: ['bash'],
+      workspaceTools: workspaceCapabilities,
+    },
+    workspaceTools: {
+      capabilities: workspaceCapabilities,
+      async execute() {
+        throw new Error('not executed');
+      },
+    },
+    workspaceMutationQuarantine: mutationQuarantine(),
+    fetchImpl: async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        capabilities: { workspaceTools?: Record<string, unknown> };
+      };
+      registrations.push(body.capabilities.workspaceTools ?? {});
+      return Response.json({
+        protocolVersion: 1,
+        workerId: 'vm-1',
+        incarnationId,
+        registeredAt: new Date().toISOString(),
+        leaseTtlMs: 60_000,
+        supportedWorkspaceToolOperations: [
+          'read_file',
+          'write_file',
+          'preview_edit',
+        ],
+        supportedWorkspaceWriteFileModes: ['replace'],
+        supportedWorkspaceEditFileModes: ['single'],
+      });
+    },
+  });
+
+  await worker.register();
+
+  assert.deepEqual(registrations, [
+    {
+      protocolVersion: 1,
+      operations: ['read_file'],
+      workspaces: [{ id: 'primary' }],
+    },
+    {
+      protocolVersion: 1,
+      operations: ['read_file'],
+      workspaces: [{ id: 'primary', operations: ['read_file'] }],
+    },
+  ]);
+});
+
 test('worker retains per-workspace restrictions during read-only promotion', async () => {
   const registrations: Array<{
     operations: string[];

--- a/packages/code/src/workspace-worker.test.ts
+++ b/packages/code/src/workspace-worker.test.ts
@@ -485,12 +485,13 @@ test('worker omits write modes not negotiated by an older Code API', async () =>
   ]);
 });
 
-test('worker omits batch edits not negotiated by an older Code API', async () => {
+test('worker advertises only edit modes and features negotiated by Code API', async () => {
   const registrations: Array<Record<string, unknown>> = [];
   const workspaceCapabilities = {
     protocolVersion: 1 as const,
     operations: ['read_file' as const, 'edit_file' as const],
     editFileModes: ['single' as const, 'batch' as const],
+    editFileFeatures: ['expected_base_sha256' as const],
     workspaces: [
       {
         id: 'primary',
@@ -529,6 +530,7 @@ test('worker omits batch edits not negotiated by an older Code API', async () =>
         registeredAt: new Date().toISOString(),
         leaseTtlMs: 60_000,
         supportedWorkspaceToolOperations: ['read_file', 'edit_file'],
+        supportedWorkspaceEditFileModes: ['single', 'batch'],
       });
     },
   });
@@ -544,6 +546,7 @@ test('worker omits batch edits not negotiated by an older Code API', async () =>
     {
       protocolVersion: 1,
       operations: ['read_file', 'edit_file'],
+      editFileModes: ['single', 'batch'],
       workspaces: [
         { id: 'primary', operations: ['read_file', 'edit_file'] },
       ],

--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -984,6 +984,7 @@ test('workspace edit previews are non-mutating and fence the commit revision', a
   });
   assert.equal(preview.operation, 'preview_edit');
   assert.equal(preview.content, 'prefix SECRET suffix');
+  assert.equal(preview.hasUtf8Bom, false);
   assert.match(preview.baseSha256, /^[a-f0-9]{64}$/);
   assert.equal(await readFile(join(root, 'preview.txt'), 'utf8'), 'prefix SEC suffix');
 
@@ -1002,6 +1003,29 @@ test('workspace edit previews are non-mutating and fence the commit revision', a
       error instanceof WorkspaceToolError && error.code === 'EDIT_CONFLICT',
   );
   assert.equal(await readFile(join(root, 'preview.txt'), 'utf8'), 'changed SEC suffix');
+});
+
+test('workspace edit previews strip a UTF-8 BOM while retaining its byte count', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-workspace-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeFile(join(root, 'bom.txt'), Buffer.from('\ufeffbefore', 'utf8'));
+  const tools = await LocalWorkspaceTools.create({
+    workspaces: [{ id: 'primary', root, writable: true }],
+  });
+
+  const preview = await tools.execute({
+    protocolVersion: 1,
+    operation: 'preview_edit',
+    workspaceId: 'primary',
+    path: 'bom.txt',
+    oldText: 'before',
+    newText: 'after',
+  });
+  assert.equal(preview.operation, 'preview_edit');
+  assert.equal(preview.content, 'after');
+  assert.equal(preview.hasUtf8Bom, true);
+  assert.equal(preview.bytesWritten, 8);
+  assert.equal(await readFile(join(root, 'bom.txt'), 'utf8'), '\ufeffbefore');
 });
 
 test('workspace mutations sync the containing directory after replacement', async (t) => {

--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -824,6 +824,7 @@ test('writable workspaces create, replace, and exactly edit files', async (t) =>
     ],
     writeFileModes: ['replace', 'create'],
     editFileModes: ['single', 'batch'],
+    editFileFeatures: ['expected_base_sha256'],
   });
   await tools.execute({
     protocolVersion: 1,
@@ -1811,6 +1812,9 @@ test('composes sandboxed commands without exposing them on unconfigured workspac
   ]);
   assert.deepEqual(tools.capabilities.writeFileModes, ['replace', 'create']);
   assert.deepEqual(tools.capabilities.editFileModes, ['single', 'batch']);
+  assert.deepEqual(tools.capabilities.editFileFeatures, [
+    'expected_base_sha256',
+  ]);
   assert.deepEqual(
     tools.capabilities.workspaces.find(({ id }) => id === 'sandboxed')?.operations,
     tools.capabilities.operations,

--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -805,6 +805,7 @@ test('writable workspaces create, replace, and exactly edit files', async (t) =>
       'search_text',
       'list_files',
       'write_file',
+      'preview_edit',
       'edit_file',
     ],
     workspaces: [
@@ -816,6 +817,7 @@ test('writable workspaces create, replace, and exactly edit files', async (t) =>
           'search_text',
           'list_files',
           'write_file',
+          'preview_edit',
           'edit_file',
         ],
       },
@@ -962,6 +964,44 @@ test('workspace batch edits commit all replacements atomically', async (t) => {
       error instanceof WorkspaceToolError && error.code === 'EDIT_CONFLICT',
   );
   assert.equal(await readFile(join(root, 'batch.txt'), 'utf8'), 'one beta three');
+});
+
+test('workspace edit previews are non-mutating and fence the commit revision', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-workspace-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeFile(join(root, 'preview.txt'), 'prefix SEC suffix');
+  const tools = await LocalWorkspaceTools.create({
+    workspaces: [{ id: 'primary', root, writable: true }],
+  });
+
+  const preview = await tools.execute({
+    protocolVersion: 1,
+    operation: 'preview_edit',
+    workspaceId: 'primary',
+    path: 'preview.txt',
+    oldText: ' suffix',
+    newText: 'RET suffix',
+  });
+  assert.equal(preview.operation, 'preview_edit');
+  assert.equal(preview.content, 'prefix SECRET suffix');
+  assert.match(preview.baseSha256, /^[a-f0-9]{64}$/);
+  assert.equal(await readFile(join(root, 'preview.txt'), 'utf8'), 'prefix SEC suffix');
+
+  await writeFile(join(root, 'preview.txt'), 'changed SEC suffix');
+  await assert.rejects(
+    tools.execute({
+      protocolVersion: 1,
+      operation: 'edit_file',
+      workspaceId: 'primary',
+      path: 'preview.txt',
+      oldText: ' suffix',
+      newText: 'RET suffix',
+      expectedBaseSha256: preview.baseSha256,
+    }),
+    (error: unknown) =>
+      error instanceof WorkspaceToolError && error.code === 'EDIT_CONFLICT',
+  );
+  assert.equal(await readFile(join(root, 'preview.txt'), 'utf8'), 'changed SEC suffix');
 });
 
 test('workspace mutations sync the containing directory after replacement', async (t) => {
@@ -1741,6 +1781,7 @@ test('composes sandboxed commands without exposing them on unconfigured workspac
     'search_text',
     'list_files',
     'write_file',
+    'preview_edit',
     'edit_file',
     'execute_command',
   ]);

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -787,15 +787,31 @@ function applyWorkspaceEdits(
 async function previewWorkspaceEdit(
   root: string,
   request: WorkspacePreviewEditRequest,
+  signal?: AbortSignal,
 ): Promise<WorkspacePreviewEditResult> {
   const original = await readConfinedFileBuffer(root, request.path);
+  if (signal?.aborted) {
+    throw new WorkspaceToolError(
+      'Workspace tool execution aborted',
+      'EXECUTION_ABORTED',
+    );
+  }
   const { updated, replacements } = applyWorkspaceEdits(original, request);
+  if (signal?.aborted) {
+    throw new WorkspaceToolError(
+      'Workspace tool execution aborted',
+      'EXECUTION_ABORTED',
+    );
+  }
+  const hasUtf8Bom =
+    updated[0] === 0xef && updated[1] === 0xbb && updated[2] === 0xbf;
   return {
     protocolVersion: BRIDGE_PROTOCOL_VERSION,
     operation: 'preview_edit',
     workspaceId: request.workspaceId,
     path: request.path,
-    content: updated.toString('utf8'),
+    content: decodeWorkspaceText(updated),
+    hasUtf8Bom,
     baseSha256: createHash('sha256').update(original).digest('hex'),
     replacements,
     bytesWritten: updated.byteLength,
@@ -1503,7 +1519,7 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
         return writeWorkspaceFile(root, request, signal);
       }
       return request.operation === 'preview_edit'
-        ? previewWorkspaceEdit(root, request)
+        ? previewWorkspaceEdit(root, request, signal)
         : editWorkspaceFile(root, request, signal);
     }
 

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -1403,6 +1403,7 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
     workspaces: BridgeWorkspaceDescriptor[],
     writeFileModes?: BridgeWorkspaceToolCapabilities['writeFileModes'],
     editFileModes?: BridgeWorkspaceToolCapabilities['editFileModes'],
+    editFileFeatures?: BridgeWorkspaceToolCapabilities['editFileFeatures'],
   ) {
     this.capabilities = {
       protocolVersion: BRIDGE_PROTOCOL_VERSION,
@@ -1410,6 +1411,7 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
       workspaces,
       ...(writeFileModes != null ? { writeFileModes } : {}),
       ...(editFileModes != null ? { editFileModes } : {}),
+      ...(editFileFeatures != null ? { editFileFeatures } : {}),
     };
   }
 
@@ -1444,6 +1446,9 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
       workspaces,
       ...(anyWritable ? { writeFileModes: ['replace', 'create'] } : {}),
       ...(anyWritable ? { editFileModes: ['single', 'batch'] } : {}),
+      ...(anyWritable
+        ? { editFileFeatures: ['expected_base_sha256'] }
+        : {}),
     };
     if (!isValidBridgeWorkspaceToolCapabilities(capabilities)) {
       throw new WorkspaceToolError(
@@ -1473,6 +1478,7 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
       workspaces,
       capabilities.writeFileModes,
       capabilities.editFileModes,
+      capabilities.editFileFeatures,
     );
   }
 
@@ -1609,6 +1615,9 @@ export class SandboxWorkspaceTools implements WorkspaceToolExecutor {
         : {}),
       ...(base.editFileModes != null
         ? { editFileModes: base.editFileModes }
+        : {}),
+      ...(base.editFileFeatures != null
+        ? { editFileFeatures: base.editFileFeatures }
         : {}),
       workspaces: base.workspaces.map((workspace) => ({
         ...workspace,

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { constants } from 'node:fs';
 import { link, lstat, open, realpath, rename, stat, unlink } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path';
@@ -27,6 +27,8 @@ import type {
   WorkspaceReadFileResult,
   WorkspaceEditFileRequest,
   WorkspaceEditFileResult,
+  WorkspacePreviewEditRequest,
+  WorkspacePreviewEditResult,
   WorkspaceExecuteCommandRequest,
   WorkspaceExecuteCommandResult,
   WorkspaceListFilesRequest,
@@ -47,6 +49,8 @@ export type {
   WorkspaceReadFileResult,
   WorkspaceEditFileRequest,
   WorkspaceEditFileResult,
+  WorkspacePreviewEditRequest,
+  WorkspacePreviewEditResult,
   WorkspaceExecuteCommandRequest,
   WorkspaceExecuteCommandResult,
   WorkspaceListFilesRequest,
@@ -119,7 +123,7 @@ const READ_OPERATIONS = [
   'search_text',
   'list_files',
 ] as const;
-const WRITE_OPERATIONS = ['write_file', 'edit_file'] as const;
+const WRITE_OPERATIONS = ['write_file', 'preview_edit', 'edit_file'] as const;
 
 function isUtf8ScalarString(value: string): boolean {
   return Buffer.from(value).toString('utf8') === value;
@@ -698,40 +702,17 @@ async function editWorkspaceFile(
       );
     }
     const original = await readBoundedEditFile(opened);
-    const hasBom =
-      original[0] === 0xef && original[1] === 0xbb && original[2] === 0xbf;
-    const body = hasBom ? original.subarray(3) : original;
-    const text = body.toString('utf8');
-    if (!Buffer.from(text, 'utf8').equals(body)) {
+    if (
+      request.expectedBaseSha256 !== undefined &&
+      createHash('sha256').update(original).digest('hex') !==
+        request.expectedBaseSha256
+    ) {
       throw new WorkspaceToolError(
-        'Workspace file is not UTF-8 text',
-        'INVALID_REQUEST',
+        'Workspace file changed after edit preview',
+        'EDIT_CONFLICT',
       );
     }
-    const edits = request.edits ?? [
-      { oldText: request.oldText ?? '', newText: request.newText ?? '' },
-    ];
-    let updatedText = text;
-    for (const edit of edits) {
-      const first = updatedText.indexOf(edit.oldText);
-      if (
-        first < 0 ||
-        updatedText.indexOf(edit.oldText, first + 1) >= 0
-      ) {
-        throw new WorkspaceToolError(
-          'Workspace edit must match exactly once',
-          'EDIT_CONFLICT',
-        );
-      }
-      updatedText =
-        updatedText.slice(0, first) +
-        edit.newText +
-        updatedText.slice(first + edit.oldText.length);
-    }
-    const updatedBody = Buffer.from(updatedText, 'utf8');
-    const updated = hasBom
-      ? Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), updatedBody])
-      : updatedBody;
+    const { updated, replacements } = applyWorkspaceEdits(original, request);
     await atomicWriteConfinedFile(
       root,
       request.path,
@@ -748,7 +729,7 @@ async function editWorkspaceFile(
       operation: 'edit_file',
       workspaceId: request.workspaceId,
       path: request.path,
-      replacements: edits.length,
+      replacements,
       bytesWritten: updated.byteLength,
     };
   } catch (error) {
@@ -757,6 +738,68 @@ async function editWorkspaceFile(
   } finally {
     await opened?.close().catch(() => undefined);
   }
+}
+
+function applyWorkspaceEdits(
+  original: Buffer,
+  request: WorkspaceEditFileRequest | WorkspacePreviewEditRequest,
+): { updated: Buffer; replacements: number } {
+  const hasBom =
+    original[0] === 0xef && original[1] === 0xbb && original[2] === 0xbf;
+  const body = hasBom ? original.subarray(3) : original;
+  const text = body.toString('utf8');
+  if (!Buffer.from(text, 'utf8').equals(body)) {
+    throw new WorkspaceToolError(
+      'Workspace file is not UTF-8 text',
+      'INVALID_REQUEST',
+    );
+  }
+  const edits = request.edits ?? [
+    { oldText: request.oldText ?? '', newText: request.newText ?? '' },
+  ];
+  let updatedText = text;
+  for (const edit of edits) {
+    const first = updatedText.indexOf(edit.oldText);
+    if (first < 0 || updatedText.indexOf(edit.oldText, first + 1) >= 0) {
+      throw new WorkspaceToolError(
+        'Workspace edit must match exactly once',
+        'EDIT_CONFLICT',
+      );
+    }
+    updatedText =
+      updatedText.slice(0, first) +
+      edit.newText +
+      updatedText.slice(first + edit.oldText.length);
+  }
+  const updatedBody = Buffer.from(updatedText, 'utf8');
+  const updated = hasBom
+    ? Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), updatedBody])
+    : updatedBody;
+  if (updated.byteLength > BRIDGE_WORKSPACE_WRITE_MAX_BYTES) {
+    throw new WorkspaceToolError(
+      'Workspace file exceeds write limit',
+      'WRITE_LIMIT_EXCEEDED',
+    );
+  }
+  return { updated, replacements: edits.length };
+}
+
+async function previewWorkspaceEdit(
+  root: string,
+  request: WorkspacePreviewEditRequest,
+): Promise<WorkspacePreviewEditResult> {
+  const original = await readConfinedFileBuffer(root, request.path);
+  const { updated, replacements } = applyWorkspaceEdits(original, request);
+  return {
+    protocolVersion: BRIDGE_PROTOCOL_VERSION,
+    operation: 'preview_edit',
+    workspaceId: request.workspaceId,
+    path: request.path,
+    content: updated.toString('utf8'),
+    baseSha256: createHash('sha256').update(original).digest('hex'),
+    replacements,
+    bytesWritten: updated.byteLength,
+  };
 }
 
 interface SearchCandidates {
@@ -1439,7 +1482,11 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
     }
     const { root } = workspace;
 
-    if (request.operation === 'write_file' || request.operation === 'edit_file') {
+    if (
+      request.operation === 'write_file' ||
+      request.operation === 'preview_edit' ||
+      request.operation === 'edit_file'
+    ) {
       if (!workspace.writable) {
         throw new WorkspaceToolError(
           'Workspace mutations are disabled by the worker',
@@ -1452,8 +1499,11 @@ export class LocalWorkspaceTools implements WorkspaceToolExecutor {
           'EXECUTION_ABORTED',
         );
       }
-      return request.operation === 'write_file'
-        ? writeWorkspaceFile(root, request, signal)
+      if (request.operation === 'write_file') {
+        return writeWorkspaceFile(root, request, signal);
+      }
+      return request.operation === 'preview_edit'
+        ? previewWorkspaceEdit(root, request)
         : editWorkspaceFile(root, request, signal);
     }
 

--- a/service/src/bridge/router.test.ts
+++ b/service/src/bridge/router.test.ts
@@ -290,6 +290,7 @@ describe('paired bridge HTTP API', () => {
       ],
       supportedWorkspaceWriteFileModes: ['replace', 'create'],
       supportedWorkspaceEditFileModes: ['single', 'batch'],
+      supportedWorkspaceEditFileFeatures: ['expected_base_sha256'],
     });
 
     const crossDeploymentRevoke = await fetch(

--- a/service/src/bridge/router.test.ts
+++ b/service/src/bridge/router.test.ts
@@ -284,6 +284,7 @@ describe('paired bridge HTTP API', () => {
         'search_text',
         'list_files',
         'write_file',
+        'preview_edit',
         'edit_file',
         'execute_command',
       ],

--- a/service/src/bridge/router.ts
+++ b/service/src/bridge/router.ts
@@ -390,6 +390,7 @@ router.post(
         ],
         supportedWorkspaceWriteFileModes: ['replace', 'create'],
         supportedWorkspaceEditFileModes: ['single', 'batch'],
+        supportedWorkspaceEditFileFeatures: ['expected_base_sha256'],
       });
     } catch (error) {
       if (error instanceof BridgeStoreError) {

--- a/service/src/bridge/router.ts
+++ b/service/src/bridge/router.ts
@@ -384,6 +384,7 @@ router.post(
           'search_text',
           'list_files',
           'write_file',
+          'preview_edit',
           'edit_file',
           'execute_command',
         ],

--- a/service/src/bridge/store.ts
+++ b/service/src/bridge/store.ts
@@ -90,10 +90,20 @@ function supportsWorkspaceTool(
     const mode = request.overwrite === false ? 'create' : 'replace';
     return capabilities?.writeFileModes?.includes(mode) === true;
   }
-  if (request.operation === 'edit_file') {
+  if (
+    request.operation === 'preview_edit' ||
+    request.operation === 'edit_file'
+  ) {
     const mode = request.edits === undefined ? 'single' : 'batch';
     const modes = capabilities?.editFileModes;
-    return modes == null ? mode === 'single' : modes.includes(mode);
+    const supportsMode = modes == null ? mode === 'single' : modes.includes(mode);
+    if (request.operation === 'preview_edit') return supportsMode;
+    return (
+      supportsMode &&
+      (request.expectedBaseSha256 === undefined ||
+        capabilities?.editFileFeatures?.includes('expected_base_sha256') ===
+          true)
+    );
   }
   return true;
 }

--- a/service/src/bridge/workspace-store.test.ts
+++ b/service/src/bridge/workspace-store.test.ts
@@ -212,6 +212,77 @@ test('rejects batch edits from workers without the negotiated mode', async () =>
   expect(await redis.keys('codeapi:bridge:v1:assignment:*')).toHaveLength(0);
 });
 
+test('rejects fenced edits from workers without the negotiated feature', async () => {
+  await store.register({
+    protocolVersion: BRIDGE_PROTOCOL_VERSION,
+    workerId: 'workspace-worker',
+    incarnationId,
+    capabilities: {
+      statefulWorkspace: true,
+      sandboxProfile: 'nsjail',
+      runtimes: ['bash'],
+      workspaceTools: {
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        operations: ['edit_file'],
+        editFileModes: ['single'],
+        workspaces: [{ id: 'primary' }],
+      },
+    },
+  });
+
+  await expect(
+    store.dispatchWorkspaceTool({
+      workerId: 'workspace-worker',
+      request: {
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        operation: 'edit_file',
+        workspaceId: 'primary',
+        path: 'notes.txt',
+        oldText: 'before',
+        newText: 'after',
+        expectedBaseSha256: 'a'.repeat(64),
+      },
+      deadlineAtMs: Date.now() + 1_000,
+      signal: new AbortController().signal,
+    }),
+  ).rejects.toMatchObject({ code: 'WORKER_MISMATCH' });
+  expect(await redis.keys('codeapi:bridge:v1:assignment:*')).toHaveLength(0);
+});
+
+test('rejects batch previews from workers without the negotiated mode', async () => {
+  await store.register({
+    protocolVersion: BRIDGE_PROTOCOL_VERSION,
+    workerId: 'workspace-worker',
+    incarnationId,
+    capabilities: {
+      statefulWorkspace: true,
+      sandboxProfile: 'nsjail',
+      runtimes: ['bash'],
+      workspaceTools: {
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        operations: ['preview_edit'],
+        workspaces: [{ id: 'primary' }],
+      },
+    },
+  });
+
+  await expect(
+    store.dispatchWorkspaceTool({
+      workerId: 'workspace-worker',
+      request: {
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        operation: 'preview_edit',
+        workspaceId: 'primary',
+        path: 'notes.txt',
+        edits: [{ oldText: 'before', newText: 'after' }],
+      },
+      deadlineAtMs: Date.now() + 1_000,
+      signal: new AbortController().signal,
+    }),
+  ).rejects.toMatchObject({ code: 'WORKER_MISMATCH' });
+  expect(await redis.keys('codeapi:bridge:v1:assignment:*')).toHaveLength(0);
+});
+
 test('rejects a fulfilled workspace settlement that violates the result contract', async () => {
   await store.register({
     protocolVersion: BRIDGE_PROTOCOL_VERSION,


### PR DESCRIPTION
## Summary

I added a non-mutating workspace edit preview and an optimistic revision fence so LibreChat can inspect the exact final file content before a BYOM worker commits it.

- Add the `preview_edit` capability and validate its bounded request/result shapes.
- Return the exact post-edit UTF-8 content with a SHA-256 revision for the original bytes.
- Reject `edit_file` commits when the supplied preview revision no longer matches.
- Reuse the exact ordered replacement implementation for preview and commit.
- Advertise the operation through capability negotiation for rolling compatibility.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran `npm test` in `packages/code`: 228 passed, 1 platform skip.
- Verified preview is non-mutating and a concurrent file change causes `EDIT_CONFLICT`.
- Service router test was not run locally because this focused worktree does not have service dependencies installed; CI will cover it.

### **Test Configuration**:

- macOS
- Node.js 22-compatible package toolchain

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.