### PR TITLE
🎖️ fix: Enforce Owner-Only Worker Credentials

### DIFF
--- a/packages/code/src/storage.test.ts
+++ b/packages/code/src/storage.test.ts
@@ -1,5 +1,15 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, open, rm, stat, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  open,
+  readdir,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -170,7 +180,8 @@ test('workspace mutation quarantine persists until explicitly cleared', async (t
     await clearWorkspaceMutationQuarantine(path);
     assert.equal(syncCalls, process.platform === 'win32' ? 1 : 4);
     assert.equal(await loadWorkspaceMutationQuarantine(path), undefined);
-    await writeFile(path, '{bad json', 'utf8');
+    /* Owner-only, so this exercises the parse failure and not the mode check. */
+    await writeFile(path, '{bad json', { encoding: 'utf8', mode: 0o600 });
     await assert.rejects(
       loadWorkspaceMutationQuarantine(path),
       /invalid workspace quarantine file/i,
@@ -211,5 +222,154 @@ test('workspace mutation quarantine cannot be replaced or cleared by another own
     assert.equal(await loadWorkspaceMutationQuarantine(path), undefined);
   } finally {
     await rm(directory, { recursive: true, force: true });
+  }
+});
+
+const SAMPLE_IDENTITY = {
+  protocolVersion: 1 as const,
+  workerId: 'vm-1',
+  codeApiUrl: 'https://code.example/v1',
+  credential: 'credential',
+  expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  publicKey: 'public',
+  privateKey: 'private',
+};
+
+/**
+ * Locate a mount that ignores POSIX permissions (WSL2 DrvFs under `/mnt/<drive>`).
+ * Returns undefined on hosts where every writable filesystem honours chmod.
+ */
+async function findChmodIgnoringDirectory(): Promise<string | undefined> {
+  const roots: string[] = [];
+  const configured = process.env.LIBRECHAT_CODE_TEST_NONPOSIX_DIR?.trim();
+  if (configured) roots.push(configured);
+  try {
+    for (const entry of await readdir('/mnt')) roots.push(join('/mnt', entry));
+  } catch {
+    /* No /mnt on this host. */
+  }
+  for (const root of roots) {
+    let directory: string | undefined;
+    try {
+      directory = await mkdtemp(join(root, 'librechat-code-mode-'));
+      const probe = join(directory, 'probe');
+      await writeFile(probe, '', { mode: 0o600 });
+      await chmod(probe, 0o600);
+      if (((await stat(probe)).mode & 0o077) !== 0) return directory;
+    } catch {
+      /* Root is absent or not writable. */
+    }
+    if (directory) await rm(directory, { recursive: true, force: true });
+  }
+  return undefined;
+}
+
+test('credential storage fails closed on filesystems that ignore chmod', async (t) => {
+  const directory = await findChmodIgnoringDirectory();
+  if (!directory) {
+    t.skip('no chmod-ignoring filesystem available on this host');
+    return;
+  }
+  try {
+    const identityPath = join(directory, 'worker.json');
+    await assert.rejects(
+      saveBridgeIdentity(identityPath, SAMPLE_IDENTITY),
+      /owner-only access/,
+    );
+    /* The private key must not be left behind on a world-readable path. */
+    await assert.rejects(stat(identityPath), { code: 'ENOENT' });
+
+    await assert.rejects(
+      ensurePrivateWorkspaceDirectory(join(directory, 'workspace')),
+      /owner-only access/,
+    );
+
+    const quarantinePath = join(directory, 'quarantine.json');
+    await assert.rejects(
+      saveWorkspaceMutationQuarantine(quarantinePath, {
+        version: 1,
+        workerId: 'vm-1',
+        workspaceId: 'primary',
+        quarantinedAt: new Date().toISOString(),
+        reason: 'test',
+      }),
+      /owner-only access/,
+    );
+    /* An unreadable half-written marker would wedge every later load. */
+    await assert.rejects(stat(quarantinePath), { code: 'ENOENT' });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('an already-exposed identity is refused on load', async (t) => {
+  const directory = await findChmodIgnoringDirectory();
+  if (!directory) {
+    t.skip('no chmod-ignoring filesystem available on this host');
+    return;
+  }
+  try {
+    /* Written the way a release without the save-time check would have. */
+    const path = join(directory, 'legacy-worker.json');
+    await writeFile(path, JSON.stringify(SAMPLE_IDENTITY), { mode: 0o600 });
+    await assert.rejects(loadBridgeIdentity(path), /accessible beyond its owner/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('an already-exposed quarantine marker is refused on load', async (t) => {
+  const directory = await findChmodIgnoringDirectory();
+  if (!directory) {
+    t.skip('no chmod-ignoring filesystem available on this host');
+    return;
+  }
+  try {
+    const path = join(directory, 'quarantine.json');
+    await writeFile(
+      path,
+      JSON.stringify({
+        version: 1,
+        workerId: 'vm-1',
+        workspaceId: 'primary',
+        ownerId: 'incarnation-1',
+        quarantinedAt: new Date().toISOString(),
+        reason: 'test',
+      }),
+      { mode: 0o600 },
+    );
+    await assert.rejects(
+      loadWorkspaceMutationQuarantine(path),
+      /accessible beyond its owner/,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('a symlinked owner-only identity is accepted', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'librechat-code-storage-'));
+  try {
+    const target = join(base, 'real.json');
+    await saveBridgeIdentity(target, SAMPLE_IDENTITY);
+    /* A link's own mode is always 0777; the credential's mode is the target's. */
+    const link = join(base, 'link.json');
+    await symlink(target, link);
+    assert.deepEqual(await loadBridgeIdentity(link), SAMPLE_IDENTITY);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('default workspace directories are tightened when they already exist', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'librechat-code-storage-'));
+  try {
+    const workspace = join(base, 'workspace');
+    await mkdir(workspace, { mode: 0o777 });
+    await chmod(workspace, 0o777);
+    await ensurePrivateWorkspaceDirectory(workspace);
+    assert.equal((await stat(workspace)).mode & 0o777, 0o700);
+  } finally {
+    await rm(base, { recursive: true, force: true });
   }
 });

--- a/packages/code/src/storage.ts
+++ b/packages/code/src/storage.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from 'node:crypto';
-import { chmod, lstat, mkdir, open, readFile, rename, rm } from 'node:fs/promises';
+import { chmod, lstat, mkdir, open, readFile, rename, rm, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 
@@ -149,6 +149,60 @@ export function defaultWorkspaceQuarantinePath(
   );
 }
 
+/**
+ * Verify a path really is owner-only. `chmod` reports success without effect on
+ * mounts that do not implement POSIX permissions - notably WSL2 DrvFs
+ * (`/mnt/<drive>`), where the result stays world-accessible - so a credential
+ * that cannot be protected must fail closed rather than appear protected.
+ *
+ * Symlinks are resolved: a link's own mode is always `0777` and ignored by the
+ * kernel, so the file the bytes live in is what counts.
+ */
+async function groupOrOtherAccessMode(
+  path: string,
+): Promise<number | undefined> {
+  if (process.platform === 'win32') return undefined;
+  const mode = (await stat(path)).mode & 0o777;
+  return (mode & 0o077) === 0 ? undefined : mode;
+}
+
+async function assertOwnerOnlyPath(
+  path: string,
+  reportedPath: string = path,
+): Promise<void> {
+  const mode = await groupOrOtherAccessMode(path);
+  if (mode === undefined) return;
+  throw new BridgeProtocolError(
+    `Cannot restrict ${reportedPath} to owner-only access (mode ${mode.toString(8)}). ` +
+      'Filesystems that ignore POSIX permissions, such as Windows drives mounted ' +
+      'under /mnt, cannot protect worker credentials or workspaces. Use a path on a ' +
+      'native Linux filesystem.',
+  );
+}
+
+/**
+ * Validate and read through one descriptor. Checking a path and then reading it
+ * resolves the name twice, so a symlink retargeted in between would let the file
+ * that was judged differ from the file that is read.
+ */
+async function readGuardedFile(
+  path: string,
+  exposed: (mode: string) => string,
+): Promise<string> {
+  const handle = await open(path, 'r');
+  try {
+    if (process.platform !== 'win32') {
+      const mode = (await handle.stat()).mode & 0o777;
+      if ((mode & 0o077) !== 0) {
+        throw new BridgeProtocolError(exposed(mode.toString(8)));
+      }
+    }
+    return await handle.readFile('utf8');
+  } finally {
+    await handle.close();
+  }
+}
+
 export async function ensurePrivateWorkspaceDirectory(
   path: string,
 ): Promise<void> {
@@ -158,6 +212,7 @@ export async function ensurePrivateWorkspaceDirectory(
     throw new BridgeProtocolError('Default workspace path must be a directory');
   }
   await chmod(path, 0o700);
+  await assertOwnerOnlyPath(path);
 }
 
 export async function saveBridgeIdentity(
@@ -169,6 +224,10 @@ export async function saveBridgeIdentity(
   try {
     const file = await open(temporaryPath, 'wx', 0o600);
     try {
+      /* Tighten every way available before judging, and judge before the key
+       * is written, so no private key reaches a world-readable path. */
+      await file.chmod(0o600);
+      await assertOwnerOnlyPath(temporaryPath, path);
       await file.writeFile(`${JSON.stringify(identity, null, 2)}\n`, 'utf8');
       await file.sync();
     } finally {
@@ -205,10 +264,24 @@ export async function saveWorkspaceMutationQuarantine(
   await ensureDurableDirectory(dirname(path));
   const file = await open(path, 'wx', 0o600);
   try {
-    await file.writeFile(`${JSON.stringify(record, null, 2)}\n`, 'utf8');
-    await file.sync();
-  } finally {
-    await file.close();
+    try {
+      await file.chmod(0o600);
+      await assertOwnerOnlyPath(path);
+      await file.writeFile(`${JSON.stringify(record, null, 2)}\n`, 'utf8');
+      await file.sync();
+    } finally {
+      await file.close();
+    }
+  } catch (error) {
+    /* A partial marker fails every later load, so undoing it has to reach the
+     * disk as durably as the write it is undoing. */
+    await rm(path, { force: true });
+    try {
+      await syncParentDirectory(path);
+    } catch {
+      /* Surface the original failure, not a cleanup-durability one. */
+    }
+    throw error;
   }
   await syncParentDirectory(path);
 }
@@ -218,13 +291,15 @@ export async function loadWorkspaceMutationQuarantine(
 ): Promise<WorkspaceMutationQuarantineRecord | undefined> {
   let content: string;
   try {
-    content = await readFile(path, 'utf8');
+    content = await readGuardedFile(
+      path,
+      (mode) =>
+        `Workspace quarantine ${path} is accessible beyond its owner (mode ${mode}). ` +
+        'Another local account could clear or forge it. Keep worker state on a ' +
+        'native Linux filesystem.',
+    );
   } catch (error) {
-    if (
-      isRecord(error) &&
-      'code' in error &&
-      error.code === 'ENOENT'
-    ) {
+    if (isMissingPathError(error)) {
       return undefined;
     }
     throw error;
@@ -278,7 +353,16 @@ export async function assertWorkspaceMutationQuarantineOwner(
 export async function loadBridgeIdentity(
   path: string,
 ): Promise<PairedBridgeWorkerIdentity> {
-  const identity = JSON.parse(await readFile(path, 'utf8')) as unknown;
+  /* An identity written before this check, or by an older release, is still a
+   * private key other local accounts can read. Refuse it rather than booting. */
+  const content = await readGuardedFile(
+    path,
+    (mode) =>
+      `Bridge identity ${path} is accessible beyond its owner (mode ${mode}). ` +
+      'Treat its private key as compromised: revoke the worker and pair again with an ' +
+      'identity path on a native Linux filesystem.',
+  );
+  const identity = JSON.parse(content) as unknown;
   if (!isPairedIdentity(identity)) {
     throw new BridgeProtocolError(`Invalid bridge identity file: ${path}`);
   }

--- a/packages/code/src/storage.ts
+++ b/packages/code/src/storage.ts
@@ -157,6 +157,13 @@ export function defaultWorkspaceQuarantinePath(
  *
  * Symlinks are resolved: a link's own mode is always `0777` and ignored by the
  * kernel, so the file the bytes live in is what counts.
+ *
+ * This reads POSIX mode bits, which is not the whole access story everywhere.
+ * A Linux POSIX ACL surfaces its mask in the group bits and so is caught, but
+ * a macOS extended ACL inherited from the parent directory is invisible here
+ * and survives `chmod`, and Windows is exempt entirely. Establishing owner-only
+ * storage on those needs real ACL inspection; until then this verifies what the
+ * mode can express and nothing more.
  */
 async function groupOrOtherAccessMode(
   path: string,


### PR DESCRIPTION
## Problem

Found while validating the native SRT path on WSL2.

`chmod` reports success without effect on mounts that do not implement POSIX permissions. On WSL2 DrvFs (`/mnt/<drive>`), `librechat-code pair --identity /mnt/c/...` reported success while the identity file — which holds the worker's Ed25519 **private key** — stayed world-accessible:

```
$ stat -c '%a' /mnt/c/.../worker.json
777

# Windows ACL on the same file
BUILTIN\Users                    = ReadAndExecute, Synchronize
NT AUTHORITY\Authenticated Users = Modify, Synchronize
```

Any authenticated local user on the Windows host could read the key. The same silent degradation hit `ensurePrivateWorkspaceDirectory` (0700 requested, 777 actual) and the mutation-quarantine marker. This contradicts `packages/code/README.md` ("writes its paired identity to ... with owner-only permissions"), and it fails silently — pairing exits 0.

## Fix

Tighten explicitly, then verify, and fail closed when group or other access survives — on **both** the write and read paths, since hardening only writes leaves already-paired workers booting on an exposed key.

- The identity verdict is taken against the **still-empty temporary file**, so no private key is ever written to a world-readable path.
- The load paths validate and read through a **single descriptor**, so a symlink retargeted in between cannot make the file that was judged differ from the file that is read.
- Symlinks resolve for the verdict (`stat`, not `lstat`) — a link's own mode is always `0777` and ignored by the kernel — so a link to a `0600` file stays valid.
- A quarantine marker that cannot be protected is removed rather than left unparseable for every later load, and that removal is synced as durably as the write it undoes.
- Skipped on `win32`, where POSIX mode bits are not meaningful and NTFS ACLs govern access.

## Verification

| | before | after |
|---|---|---|
| `pair --identity /mnt/c/...` | exits 0, key at mode 777 | refused, **no key written** |
| worker start with an existing 777 identity | starts normally | refuses: *treat its private key as compromised* |
| `pair` to ext4 / default `~/.config` | `0600` | `0600` (unchanged) |
| identity via symlink to a `0600` file | accepted | accepted |

Tests needing a chmod-ignoring mount discover one (any `/mnt/*`, or `LIBRECHAT_CODE_TEST_NONPOSIX_DIR`) and skip where none exists. They **executed, not skipped**, on the WSL2 host.

Focused suite — `storage.test.ts` plus `cli.test.ts` and `workspace-cli.test.ts`, the only dependents of the changed functions: **30/30 pass**. `tsc --noEmit` clean. End to end: pairing to the default path and starting a worker against it both unchanged.

One pre-existing fixture now writes owner-only so it still exercises the malformed-JSON path rather than tripping the new mode check first.

## Scope

This PR was deliberately **narrowed back** to the defect above. It previously carried a further twelve commits hardening credentials against *another local account on the same host* — ownership checks, container-writability checks, and a pairing preflight. That defends a different threat model than BYOM states (a worker on the user's own machine, with the sandboxed command as the adversary), and it trades real deployment flexibility for it, so it deserves its own decision rather than riding along here.

That work is intact and open as a stacked follow-up: **#112**.

No protocol change, no change to the worker/command-sandbox seam, no new dependencies, no new exports.
