### PR TITLE
🚢 fix: Pack Code Protocol Into Egress Gateway Image

### DIFF
--- a/service/Dockerfile.egress-gateway
+++ b/service/Dockerfile.egress-gateway
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf 
 COPY --from=install /temp/prod/node_modules ./node_modules
 COPY service/src ./src
 COPY shared /shared
+COPY packages/code/src /packages/code/src
 EXPOSE 3190
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:3190/health || exit 1
@@ -28,5 +29,6 @@ ENV NODE_ENV=development
 COPY --from=install /temp/dev/node_modules node_modules
 COPY service/src ./src
 COPY shared /shared
+COPY packages/code/src /packages/code/src
 EXPOSE 3190 9230
 CMD ["bun", "run", "--watch", "src/egress-gateway.ts"]


### PR DESCRIPTION
The egress-gateway container crash-loops on startup:

    error: Cannot find module '../../packages/code/src/protocol'
    from '/app/src/secure-startup.ts'

`service/src/egress-gateway.ts` imports `./secure-startup`, and `service/src/secure-startup.ts` imports `../../packages/code/src/protocol`. `service/Dockerfile.egress-gateway` copies `service/src` and `shared` but never copies `packages/code/src`, so from `/app/src/…` the relative import resolves to `/packages/code/src/protocol`, which is absent from the image.

The other service images (`Dockerfile.node`, `Dockerfile.worker`) already `COPY packages/code/src /packages/code/src` next to `COPY shared /shared`; this adds the same line to both the production and development stages of the egress-gateway image, matching that convention.

Tested by building `service/Dockerfile.egress-gateway` and confirming the container reaches its `/health` endpoint on 3190 instead of exiting.