### PR TITLE
🔤 fix: Stabilize Truncated Workspace Search Results

### DIFF
--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -840,6 +840,10 @@ async function listSearchCandidates(
         '--files',
         '--no-config',
         '--no-follow',
+        /* Deterministic order, as list_files uses: without it ripgrep's parallel
+         * walk decides both result order and which files survive truncation. */
+        '--sort',
+        'path',
         '--path-separator',
         '/',
         '--null',


### PR DESCRIPTION
## Problem

Found while standing up CI for `packages/code`.

`list_files` passes `--sort path` to ripgrep; the `search_text` candidate listing does not. Ripgrep's parallel directory walk therefore decides the order — and, more importantly, **which files survive truncation** when `MAX_SEARCH_CANDIDATES` or `maxResults` bites. A bounded search can silently return different matches for identical input.

The existing test `search decodes BOM-marked UTF-16 text` asserts a fixed result order and fails **12/12 on ext4 with ripgrep 13.0.0**:

```
actual:   [ { path: 'little-endian.txt', ... }, { path: 'big-endian.txt', ... } ]
expected: [ { path: 'big-endian.txt', ... }, { path: 'little-endian.txt', ... } ]
```

It passes only where the walk happens to emit sorted order, which is why this went unnoticed on macOS.

## Fix

Sort the candidate listing, exactly as `list_files` already does.

## Verification

- Before: **12/12 runs fail**. After: **0/6 runs fail** on this branch against `main` (61 tests, 60 pass, 1 skipped).
- Sorting disables ripgrep's parallel walk, so I measured the cost rather than assuming: **16ms vs 8ms** over a 4,856-file tree, against the 10s search budget the pre-scan shares with content matching. Immaterial, and the same tradeoff `list_files` already makes.

Sorting *after* collection was considered and rejected: truncation happens during collection, so it would fix result order while leaving which files get searched arbitrary — the actual defect.

## Scope

One flag. No protocol change, no new dependencies.