### PR TITLE
🧫 ci: Run Code Package Tests on Pull Requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,37 @@ jobs:
       - name: Bun tests
         run: bun run test
 
+  code-package-tests:
+    name: Code Package Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/code
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          # The suite fails 47 worker tests on Node 22 despite the package's
+          # ">=20.11" engines range, so CI pins the version it is green on.
+          node-version: 24.16.0
+          cache: npm
+          cache-dependency-path: packages/code/package-lock.json
+
+      - name: Install ripgrep
+        # list_files and search_text shell out to rg. Without it the workspace
+        # tools degrade to LIST_UNAVAILABLE / SEARCH_UNAVAILABLE and 37 tests
+        # fail, so the dependency is part of the job, not an assumption.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ripgrep
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Tests
+        run: npm test
+
   lambda-microvm-provisioning:
     name: Lambda MicroVM Provisioning
     runs-on: ubuntu-latest


### PR DESCRIPTION
> **Stacked on #109.** That PR fixes a search-ordering defect that makes this job red; merge it first, and this PR's base will retarget to `main` automatically.

## Problem

`.github/workflows/ci.yml` has jobs for `api/`, `service/`, deployment config, and lambda-microvm — but nothing runs `packages/code`. Its **234 tests never execute on a pull request**, including the coverage for the bridge identity, the mutation quarantine, and the workspace tools.

## What the job does

Adds `Code Package Tests`, following the file's existing conventions (SHA-pinned actions, exact toolchain pin, `working-directory` defaults).

Two things are deliberate rather than incidental:

**Ripgrep is installed explicitly.** `list_files` and `search_text` shell out to `rg`; without it 37 tests fail with `LIST_UNAVAILABLE` / `SEARCH_UNAVAILABLE`. It is a dependency of the suite, not an assumption about the runner image.

**Node is pinned to 24.16.0, not the engines range.** Measured on this branch:

| Node | Result |
|---|---|
| **24.16.0** | 234 tests, **233 pass, 0 fail**, 1 skipped |
| 22.14.0 | **47 failures**, all in `worker.test.ts` |

The package declares `engines: ">=20.11"`, but the suite does not pass on 22. CI should pin the version it is green on rather than advertise a range nothing verifies. **Whether the engines range or the worker tests are wrong is a real question this PR does not answer** — it only stops the gap from being invisible.

## Verification

`npm ci` resolves against the committed `package-lock.json`; the workflow parses and the job graph is `deployment-config-tests, api-unit-tests, service-unit-tests, code-package-tests, lambda-microvm-provisioning, lambda-microvm-runner-build`.

## Follow-up needed outside this repo

`ci.yml`'s header says *"Keep it in sync with `ci-codeapi.yml`"* — this file is published from the monorepo's `services/codeapi`. That counterpart is not in this repository, so **the same job needs adding there**, or the next publish will drop it.