### PR TITLE
🏯 fix: Guard Worker Credentials From Local Accounts

### DIFF
--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -8,6 +8,7 @@ import { pairBridgeWorker } from './pairing.js';
 import { startFileRelay } from './relay.js';
 import { DockerFileRelaySupervisor } from './relay-runtime.js';
 import {
+  assertIdentityPathIsPrivate,
   assertWorkspaceMutationQuarantineOwner,
   clearWorkspaceMutationQuarantine,
   defaultBridgeIdentityPath,
@@ -128,8 +129,14 @@ async function pair(args: string[]): Promise<void> {
     option(args, '--identity') ??
     process.env.LIBRECHAT_CODE_IDENTITY_FILE ??
     defaultBridgeIdentityPath(workerId);
-  const identity = await pairBridgeWorker({ codeApiUrl, workerId, code });
-  await saveBridgeIdentity(identityPath, identity);
+  const reservation = await assertIdentityPathIsPrivate(identityPath);
+  try {
+    const identity = await pairBridgeWorker({ codeApiUrl, workerId, code });
+    await saveBridgeIdentity(identityPath, identity);
+  } catch (error) {
+    await reservation.release();
+    throw error;
+  }
   process.stdout.write(
     `Paired worker ${workerId}. Identity saved to ${identityPath}\n`,
   );

--- a/packages/code/src/storage.test.ts
+++ b/packages/code/src/storage.test.ts
@@ -1,15 +1,5 @@
 import assert from 'node:assert/strict';
-import {
-  chmod,
-  mkdir,
-  mkdtemp,
-  open,
-  readdir,
-  rm,
-  stat,
-  symlink,
-  writeFile,
-} from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, open, readdir, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -17,6 +7,7 @@ import test from 'node:test';
 import type { FileHandle } from 'node:fs/promises';
 
 import {
+  assertIdentityPathIsPrivate,
   clearWorkspaceMutationQuarantine,
   defaultBridgeIdentityPath,
   defaultWorkspaceQuarantinePath,
@@ -225,16 +216,6 @@ test('workspace mutation quarantine cannot be replaced or cleared by another own
   }
 });
 
-const SAMPLE_IDENTITY = {
-  protocolVersion: 1 as const,
-  workerId: 'vm-1',
-  codeApiUrl: 'https://code.example/v1',
-  credential: 'credential',
-  expiresAt: new Date(Date.now() + 60_000).toISOString(),
-  publicKey: 'public',
-  privateKey: 'private',
-};
-
 /**
  * Locate a mount that ignores POSIX permissions (WSL2 DrvFs under `/mnt/<drive>`).
  * Returns undefined on hosts where every writable filesystem honours chmod.
@@ -273,7 +254,15 @@ test('credential storage fails closed on filesystems that ignore chmod', async (
   try {
     const identityPath = join(directory, 'worker.json');
     await assert.rejects(
-      saveBridgeIdentity(identityPath, SAMPLE_IDENTITY),
+      saveBridgeIdentity(identityPath, {
+        protocolVersion: 1,
+        workerId: 'vm-1',
+        codeApiUrl: 'https://code.example/v1',
+        credential: 'credential',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        publicKey: 'public',
+        privateKey: 'private',
+      }),
       /owner-only access/,
     );
     /* The private key must not be left behind on a world-readable path. */
@@ -309,12 +298,69 @@ test('an already-exposed identity is refused on load', async (t) => {
     return;
   }
   try {
-    /* Written the way a release without the save-time check would have. */
+    /* Write it the way a release without the save-time check would have. */
     const path = join(directory, 'legacy-worker.json');
-    await writeFile(path, JSON.stringify(SAMPLE_IDENTITY), { mode: 0o600 });
+    await writeFile(
+      path,
+      JSON.stringify({
+        protocolVersion: 1,
+        workerId: 'vm-1',
+        codeApiUrl: 'https://code.example/v1',
+        credential: 'credential',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        publicKey: 'public',
+        privateKey: 'private',
+      }),
+      { mode: 0o600 },
+    );
     await assert.rejects(loadBridgeIdentity(path), /accessible beyond its owner/);
   } finally {
     await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('the identity destination is rejected before a pairing code is spent', async (t) => {
+  const directory = await findChmodIgnoringDirectory();
+  if (!directory) {
+    t.skip('no chmod-ignoring filesystem available on this host');
+    return;
+  }
+  try {
+    const identityPath = join(directory, 'worker.json');
+    await assert.rejects(
+      assertIdentityPathIsPrivate(identityPath),
+      /owner-only access/,
+    );
+    /* The probe must not survive the rejection. */
+    assert.deepEqual(
+      (await readdir(directory)).filter((name) => name.includes('.probe')),
+      [],
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('a symlinked owner-only identity is accepted', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'librechat-code-storage-'));
+  try {
+    const identity = {
+      protocolVersion: 1 as const,
+      workerId: 'vm-1',
+      codeApiUrl: 'https://code.example/v1',
+      credential: 'credential',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      publicKey: 'public',
+      privateKey: 'private',
+    };
+    const target = join(base, 'real.json');
+    await saveBridgeIdentity(target, identity);
+    /* A link's own mode is always 0777; the credential's mode is the target's. */
+    const link = join(base, 'link.json');
+    await symlink(target, link);
+    assert.deepEqual(await loadBridgeIdentity(link), identity);
+  } finally {
+    await rm(base, { recursive: true, force: true });
   }
 });
 
@@ -325,6 +371,7 @@ test('an already-exposed quarantine marker is refused on load', async (t) => {
     return;
   }
   try {
+    /* Write it the way a release without the save-time check would have. */
     const path = join(directory, 'quarantine.json');
     await writeFile(
       path,
@@ -347,16 +394,257 @@ test('an already-exposed quarantine marker is refused on load', async (t) => {
   }
 });
 
-test('a symlinked owner-only identity is accepted', async () => {
+test('a directory at the identity path is rejected before the code is spent', async () => {
   const base = await mkdtemp(join(tmpdir(), 'librechat-code-storage-'));
   try {
-    const target = join(base, 'real.json');
-    await saveBridgeIdentity(target, SAMPLE_IDENTITY);
-    /* A link's own mode is always 0777; the credential's mode is the target's. */
-    const link = join(base, 'link.json');
-    await symlink(target, link);
-    assert.deepEqual(await loadBridgeIdentity(link), SAMPLE_IDENTITY);
+    const identityPath = join(base, 'worker.json');
+    await mkdir(identityPath);
+    await assert.rejects(
+      assertIdentityPathIsPrivate(identityPath),
+      /is a directory/,
+    );
   } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('re-pairing over an existing owner-only identity is still allowed', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'librechat-code-storage-'));
+  try {
+    const identity = {
+      protocolVersion: 1 as const,
+      workerId: 'vm-1',
+      codeApiUrl: 'https://code.example/v1',
+      credential: 'credential',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      publicKey: 'public',
+      privateKey: 'private',
+    };
+    const identityPath = join(base, 'worker.json');
+    await saveBridgeIdentity(identityPath, identity);
+    await assertIdentityPathIsPrivate(identityPath);
+    const replacement = { ...identity, credential: 'rotated' };
+    await saveBridgeIdentity(identityPath, replacement);
+    assert.deepEqual(await loadBridgeIdentity(identityPath), replacement);
+    /* No probe may survive a successful preflight either. */
+    assert.deepEqual(
+      (await readdir(base)).filter((name) => name.includes('.probe')),
+      [],
+    );
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('an owned identity file in a sticky directory is still replaceable', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'librechat-code-storage-'));
+  try {
+    /* Ownership only blocks rename under the sticky bit, and only for a file
+     * this account does not own - which /tmp-style directories make common. */
+    const sticky = join(base, 'sticky');
+    await mkdir(sticky);
+    await chmod(sticky, 0o1777);
+    const identityPath = join(sticky, 'worker.json');
+    await writeFile(identityPath, '{}', { mode: 0o600 });
+    await assertIdentityPathIsPrivate(identityPath);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('a credential in a shared writable directory is refused', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'librechat-code-storage-'));
+  try {
+    const identity = {
+      protocolVersion: 1 as const,
+      workerId: 'vm-1',
+      codeApiUrl: 'https://code.example/v1',
+      credential: 'credential',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      publicKey: 'public',
+      privateKey: 'private',
+    };
+    const shared = join(base, 'shared');
+    await mkdir(shared);
+    const identityPath = join(shared, 'worker.json');
+    await saveBridgeIdentity(identityPath, identity);
+    /* 0600 still, but anyone may now unlink and substitute it. */
+    await chmod(shared, 0o777);
+    await assert.rejects(
+      loadBridgeIdentity(identityPath),
+      /writable by other accounts/,
+    );
+    await assert.rejects(
+      assertIdentityPathIsPrivate(identityPath),
+      /writable by other accounts/,
+    );
+
+    /* The sticky bit restores owner-only unlink, so /tmp-style parents work. */
+    await chmod(shared, 0o1777);
+    assert.deepEqual(await loadBridgeIdentity(identityPath), identity);
+    await assertIdentityPathIsPrivate(identityPath);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('a symlink entry in a shared writable directory is refused', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'librechat-code-storage-'));
+  try {
+    const identity = {
+      protocolVersion: 1 as const,
+      workerId: 'vm-1',
+      codeApiUrl: 'https://code.example/v1',
+      credential: 'credential',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      publicKey: 'public',
+      privateKey: 'private',
+    };
+    /* Credential is private; the link naming it is not, so the link can be
+     * repointed at an attacker's file. */
+    const priv = join(base, 'private');
+    await mkdir(priv, { mode: 0o700 });
+    const target = join(priv, 'worker.json');
+    await saveBridgeIdentity(target, identity);
+    const shared = join(base, 'shared');
+    await mkdir(shared);
+    const link = join(shared, 'worker.json');
+    await symlink(target, link);
+    assert.deepEqual(await loadBridgeIdentity(link), identity);
+    await chmod(shared, 0o777);
+    await assert.rejects(
+      loadBridgeIdentity(link),
+      /writable by other accounts/,
+    );
+    /* Pairing publishes by replacing the link entry, so the same directory
+     * governs the write path too. */
+    await assert.rejects(
+      assertIdentityPathIsPrivate(link),
+      /writable by other accounts/,
+    );
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('a symlink into a shared writable directory is refused', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'librechat-code-storage-'));
+  try {
+    const identity = {
+      protocolVersion: 1 as const,
+      workerId: 'vm-1',
+      codeApiUrl: 'https://code.example/v1',
+      credential: 'credential',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      publicKey: 'public',
+      privateKey: 'private',
+    };
+    const shared = join(base, 'shared');
+    await mkdir(shared);
+    const target = join(shared, 'worker.json');
+    await saveBridgeIdentity(target, identity);
+    /* The link sits in a private directory; the credential does not. */
+    const priv = join(base, 'private');
+    await mkdir(priv, { mode: 0o700 });
+    const link = join(priv, 'worker.json');
+    await symlink(target, link);
+    assert.deepEqual(await loadBridgeIdentity(link), identity);
+    await chmod(shared, 0o777);
+    await assert.rejects(
+      loadBridgeIdentity(link),
+      /writable by other accounts/,
+    );
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('the identity destination is reserved across pairing and released on failure', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'librechat-code-storage-'));
+  try {
+    const identityPath = join(base, 'worker.json');
+    const reservation = await assertIdentityPathIsPrivate(identityPath);
+    /* The name is claimed while the pairing request is in flight, so another
+     * account cannot take it and strand a spent code. */
+    assert.equal((await stat(identityPath)).mode & 0o777, 0o600);
+    await reservation.release();
+    await assert.rejects(stat(identityPath), { code: 'ENOENT' });
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('releasing never removes a pre-existing identity', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'librechat-code-storage-'));
+  try {
+    const identity = {
+      protocolVersion: 1 as const,
+      workerId: 'vm-1',
+      codeApiUrl: 'https://code.example/v1',
+      credential: 'credential',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      publicKey: 'public',
+      privateKey: 'private',
+    };
+    const identityPath = join(base, 'worker.json');
+    await saveBridgeIdentity(identityPath, identity);
+    const reservation = await assertIdentityPathIsPrivate(identityPath);
+    await reservation.release();
+    assert.deepEqual(await loadBridgeIdentity(identityPath), identity);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('releasing never removes an identity another pairing published', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'librechat-code-storage-'));
+  try {
+    const identity = {
+      protocolVersion: 1 as const,
+      workerId: 'vm-1',
+      codeApiUrl: 'https://code.example/v1',
+      credential: 'credential',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      publicKey: 'public',
+      privateKey: 'private',
+    };
+    const identityPath = join(base, 'worker.json');
+    const first = await assertIdentityPathIsPrivate(identityPath);
+    /* A concurrent pair publishes over the reserved name and completes. */
+    await saveBridgeIdentity(identityPath, identity);
+    /* The first invocation then fails and unwinds; its credential is gone, but
+     * the one that succeeded must survive. */
+    await first.release();
+    assert.deepEqual(await loadBridgeIdentity(identityPath), identity);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('an identity in a directory that denies creation is rejected before pairing', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'librechat-code-storage-'));
+  const locked = join(base, 'locked');
+  try {
+    const identity = {
+      protocolVersion: 1 as const,
+      workerId: 'vm-1',
+      codeApiUrl: 'https://code.example/v1',
+      credential: 'credential',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      publicKey: 'public',
+      privateKey: 'private',
+    };
+    await mkdir(locked, { mode: 0o700 });
+    const identityPath = join(locked, 'worker.json');
+    await saveBridgeIdentity(identityPath, identity);
+    /* Readable and owner-only, but the publish writes a sibling first. */
+    await chmod(locked, 0o500);
+    await assert.rejects(
+      assertIdentityPathIsPrivate(identityPath),
+      /could not be published there/,
+    );
+  } finally {
+    await chmod(locked, 0o700).catch(() => undefined);
     await rm(base, { recursive: true, force: true });
   }
 });

--- a/packages/code/src/storage.ts
+++ b/packages/code/src/storage.ts
@@ -1,5 +1,15 @@
 import { createHash, randomBytes } from 'node:crypto';
-import { chmod, lstat, mkdir, open, readFile, rename, rm, stat } from 'node:fs/promises';
+import {
+  chmod,
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  stat,
+} from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 
@@ -169,8 +179,118 @@ async function groupOrOtherAccessMode(
   path: string,
 ): Promise<number | undefined> {
   if (process.platform === 'win32') return undefined;
+  /* Resolve symlinks: the bytes live at the target, and a link's own mode is
+   * always 0777 and ignored by the kernel. */
   const mode = (await stat(path)).mode & 0o777;
   return (mode & 0o077) === 0 ? undefined : mode;
+}
+
+/**
+ * A `0600` file in a directory other accounts can write is not owner-only in
+ * practice: they cannot read it, but they can unlink and substitute it, so a
+ * swapped credential or a forged quarantine marker would be trusted. The sticky
+ * bit counts as protection, which keeps shared `/tmp`-style parents usable. A
+ * writable ancestor above a private directory could still have that directory
+ * renamed out from under us, which is broader hardening than this addresses.
+ *
+ * Deliberately not applied to the registered workspace, which is the user's own
+ * project directory and may legitimately be shared.
+ */
+async function assertDirectoryNotSharedWritable(
+  directory: string,
+  path: string,
+): Promise<void> {
+  const metadata = await stat(directory);
+  const mode = metadata.mode & 0o7777;
+  const uid = process.getuid?.();
+  if (uid !== undefined && !isTrustedOwner(metadata.uid, uid)) {
+    throw new BridgeProtocolError(
+      `Directory ${directory} is owned by another account (uid ${metadata.uid}), ` +
+        `which can grant itself write access and replace ${path}. Keep worker ` +
+        'credentials in a directory this account owns.',
+    );
+  }
+  if ((mode & 0o022) === 0) return;
+  if ((mode & 0o1000) !== 0 && (metadata.uid === uid || metadata.uid === 0)) {
+    return;
+  }
+  throw new BridgeProtocolError(
+    `Directory ${directory} is writable by other accounts (mode ${mode.toString(8)}), ` +
+      `so ${path} can be replaced even while owner-only. Keep worker credentials ` +
+      'in a directory only this account can write.',
+  );
+}
+
+/** Publishing goes through `rename`, which replaces the named entry itself. */
+async function assertWriteContainerPrivate(path: string): Promise<void> {
+  if (process.platform === 'win32' || process.getuid === undefined) return;
+  await assertDirectoryNotSharedWritable(await realpath(dirname(path)), path);
+}
+
+/**
+ * Reading follows the link, so both the entry and the file it names are trust
+ * boundaries: a writable directory at either end allows a substitution.
+ */
+async function assertReadPathPrivate(path: string): Promise<void> {
+  if (process.platform === 'win32' || process.getuid === undefined) return;
+  const entryDirectory = await realpath(dirname(path));
+  await assertDirectoryNotSharedWritable(entryDirectory, path);
+  const targetDirectory = dirname(await realpath(path));
+  if (targetDirectory !== entryDirectory) {
+    await assertDirectoryNotSharedWritable(targetDirectory, path);
+  }
+}
+
+/** Root is the trust root; anyone else holding a credential path is not. */
+function isTrustedOwner(uid: number, self: number): boolean {
+  return uid === self || uid === 0;
+}
+
+/**
+ * Mode bits alone do not establish trust. A `0600` file owned by another
+ * account is unreadable by others yet fully rewritable by its owner, who then
+ * controls the credential the worker loads - or, for a quarantine marker, can
+ * delete it and let mutations resume.
+ */
+async function assertOwnedByWorker(path: string): Promise<void> {
+  const self = process.getuid?.();
+  if (self === undefined) return;
+  const { uid } = await stat(path);
+  if (isTrustedOwner(uid, self)) return;
+  throw new BridgeProtocolError(
+    `${path} is owned by another account (uid ${uid}), which can rewrite it. ` +
+      'Keep worker credentials on a path this account owns.',
+  );
+}
+
+/**
+ * Validate and read through one descriptor. Re-resolving the path after a
+ * check lets a multi-hop symlink be toggled in between, so the file that was
+ * judged need not be the file that is read; holding the descriptor removes the
+ * second resolution entirely.
+ */
+async function readGuardedFile(
+  path: string,
+  exposed: (mode: string) => string,
+): Promise<string> {
+  const handle = await open(path, 'r');
+  try {
+    const stats = await handle.stat();
+    const self = process.getuid?.();
+    if (self !== undefined && !isTrustedOwner(stats.uid, self)) {
+      throw new BridgeProtocolError(
+        `${path} is owned by another account (uid ${stats.uid}), which can rewrite it. ` +
+          'Keep worker credentials on a path this account owns.',
+      );
+    }
+    if (process.platform !== 'win32') {
+      const mode = stats.mode & 0o777;
+      if ((mode & 0o077) !== 0) throw new BridgeProtocolError(exposed(mode.toString(8)));
+    }
+    return await handle.readFile('utf8');
+  } finally {
+    await handle.close();
+  }
 }
 
 async function assertOwnerOnlyPath(
@@ -187,29 +307,6 @@ async function assertOwnerOnlyPath(
   );
 }
 
-/**
- * Validate and read through one descriptor. Checking a path and then reading it
- * resolves the name twice, so a symlink retargeted in between would let the file
- * that was judged differ from the file that is read.
- */
-async function readGuardedFile(
-  path: string,
-  exposed: (mode: string) => string,
-): Promise<string> {
-  const handle = await open(path, 'r');
-  try {
-    if (process.platform !== 'win32') {
-      const mode = (await handle.stat()).mode & 0o777;
-      if ((mode & 0o077) !== 0) {
-        throw new BridgeProtocolError(exposed(mode.toString(8)));
-      }
-    }
-    return await handle.readFile('utf8');
-  } finally {
-    await handle.close();
-  }
-}
-
 export async function ensurePrivateWorkspaceDirectory(
   path: string,
 ): Promise<void> {
@@ -220,6 +317,135 @@ export async function ensurePrivateWorkspaceDirectory(
   }
   await chmod(path, 0o700);
   await assertOwnerOnlyPath(path);
+  /* This directory is application-owned by contract; a pre-existing one under
+   * another account lets that owner alter workspace inputs and results. */
+  await assertOwnedByWorker(path);
+}
+
+/**
+ * `saveBridgeIdentity` publishes by `rename`, which cannot replace a directory
+ * and cannot replace a file this account does not own in a sticky directory.
+ * Probing a sibling path alone would miss both, and the failure would land
+ * after the code was already spent.
+ */
+async function assertIdentityDestinationIsReplaceable(
+  path: string,
+): Promise<void> {
+  let metadata;
+  try {
+    metadata = await lstat(path);
+  } catch (error) {
+    if (isMissingPathError(error)) return;
+    throw error;
+  }
+  if (metadata.isDirectory()) {
+    throw new BridgeProtocolError(
+      `Bridge identity path ${path} is a directory. Point --identity at a file.`,
+    );
+  }
+  const uid = process.platform === 'win32' ? undefined : process.getuid?.();
+  if (uid === undefined || uid === 0 || metadata.uid === uid) return;
+  /* Ownership only blocks `rename` under the sticky bit, and owning the
+   * directory is enough there; elsewhere the parent's write bit decides. */
+  const parent = await stat(dirname(path));
+  if ((parent.mode & 0o1000) === 0 || parent.uid === uid) return;
+  throw new BridgeProtocolError(
+    `Bridge identity path ${path} is owned by another account (uid ${metadata.uid}) ` +
+      `inside the sticky directory ${dirname(path)}, so it cannot be replaced. ` +
+      'Choose a path this account owns.',
+  );
+}
+
+/**
+ * Probe the identity destination before a one-time pairing code is redeemed, so
+ * a filesystem that cannot hold the credential fails validation instead of
+ * burning the code and leaving an orphaned remote pairing.
+ */
+export interface IdentityPathReservation {
+  /** Drop a destination this call created, when pairing does not reach a save. */
+  release(): Promise<void>;
+}
+
+/**
+ * `saveBridgeIdentity` publishes by writing `<path>.<random>.tmp` beside the
+ * destination and renaming it over. A directory that holds a readable identity
+ * but denies creation - `0500`, say - passes every check on the file itself and
+ * still fails the save, so exercise the sibling write rather than infer it.
+ */
+async function assertSiblingPublishable(path: string): Promise<void> {
+  const probePath = `${path}.${randomBytes(8).toString('hex')}.probe`;
+  try {
+    await (await open(probePath, 'wx', 0o600)).close();
+  } catch (error) {
+    throw new BridgeProtocolError(
+      `Cannot create a temporary file beside ${path} (${
+        isRecord(error) && typeof error.code === 'string' ? error.code : 'unknown'
+      }), so the identity could not be published there. Choose a writable directory.`,
+    );
+  } finally {
+    await rm(probePath, { force: true });
+  }
+}
+
+export async function assertIdentityPathIsPrivate(
+  path: string,
+): Promise<IdentityPathReservation> {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  await assertIdentityDestinationIsReplaceable(path);
+  let created = false;
+  let reservedInode: bigint | undefined;
+  try {
+    /* Claiming the destination itself, rather than probing a sibling and
+     * letting go, is what keeps the verdict true across the pairing request:
+     * a shared sticky directory otherwise lets another account take the name
+     * in that window, and the save would fail with the code already spent. */
+    const reserved = await open(path, 'wx', 0o600);
+    try {
+      created = true;
+      await reserved.chmod(0o600);
+      await assertOwnerOnlyPath(path);
+      reservedInode = (await reserved.stat({ bigint: true })).ino;
+    } finally {
+      await reserved.close();
+    }
+  } catch (error) {
+    if (created) {
+      await rm(path, { force: true });
+      throw error;
+    }
+    if (!isRecord(error) || error.code !== 'EEXIST') throw error;
+    /* Already present: judge what is there instead of the placeholder, and
+     * prove the publish itself is possible - an unwritable parent would
+     * otherwise surface as EACCES only after the code was spent. */
+    await assertOwnedByWorker(path);
+    await assertOwnerOnlyPath(path);
+    await assertSiblingPublishable(path);
+  }
+  try {
+    /* After the mode verdict, so a filesystem that cannot hold an owner-only
+     * file keeps the more specific diagnosis. */
+    await assertWriteContainerPrivate(path);
+  } catch (error) {
+    if (created) await rm(path, { force: true });
+    throw error;
+  }
+  return {
+    async release(): Promise<void> {
+      if (!created || reservedInode === undefined) return;
+      /* Only ever drop the placeholder this call made. A concurrent `pair`
+       * may have published a real identity over the name since, and removing
+       * that would destroy a credential whose code is already spent. */
+      const current = await lstat(path, { bigint: true }).catch(() => undefined);
+      if (
+        current === undefined ||
+        current.ino !== reservedInode ||
+        current.size !== 0n
+      ) {
+        return;
+      }
+      await rm(path, { force: true });
+    },
+  };
 }
 
 export async function saveBridgeIdentity(
@@ -231,8 +457,6 @@ export async function saveBridgeIdentity(
   try {
     const file = await open(temporaryPath, 'wx', 0o600);
     try {
-      /* Tighten every way available before judging, and judge before the key
-       * is written, so no private key reaches a world-readable path. */
       await file.chmod(0o600);
       await assertOwnerOnlyPath(temporaryPath, path);
       await file.writeFile(`${JSON.stringify(identity, null, 2)}\n`, 'utf8');
@@ -274,14 +498,15 @@ export async function saveWorkspaceMutationQuarantine(
     try {
       await file.chmod(0o600);
       await assertOwnerOnlyPath(path);
+      await assertWriteContainerPrivate(path);
       await file.writeFile(`${JSON.stringify(record, null, 2)}\n`, 'utf8');
       await file.sync();
     } finally {
       await file.close();
     }
   } catch (error) {
-    /* A partial marker fails every later load, so undoing it has to reach the
-     * disk as durably as the write it is undoing. */
+    /* A partially written marker would fail every later load, so the removal
+     * has to reach the disk as durably as the write it is undoing. */
     await rm(path, { force: true });
     try {
       await syncParentDirectory(path);
@@ -296,6 +521,8 @@ export async function saveWorkspaceMutationQuarantine(
 export async function loadWorkspaceMutationQuarantine(
   path: string,
 ): Promise<WorkspaceMutationQuarantineRecord | undefined> {
+  /* A marker another account can rewrite is not a control: it could be cleared
+   * to resume mutations, or forged to wedge the worker under a foreign owner. */
   let content: string;
   try {
     content = await readGuardedFile(
@@ -305,10 +532,9 @@ export async function loadWorkspaceMutationQuarantine(
         'Another local account could clear or forge it. Keep worker state on a ' +
         'native Linux filesystem.',
     );
+    await assertReadPathPrivate(path);
   } catch (error) {
-    if (isMissingPathError(error)) {
-      return undefined;
-    }
+    if (isMissingPathError(error)) return undefined;
     throw error;
   }
   let record: unknown;
@@ -369,6 +595,8 @@ export async function loadBridgeIdentity(
       'Treat its private key as compromised: revoke the worker and pair again with an ' +
       'identity path on a native Linux filesystem.',
   );
+  /* After the file's own verdict, so an exposed mode keeps its diagnosis. */
+  await assertReadPathPrivate(path);
   const identity = JSON.parse(content) as unknown;
   if (!isPairedIdentity(identity)) {
     throw new BridgeProtocolError(`Invalid bridge identity file: ${path}`);


### PR DESCRIPTION
Follow-up to #107, now merged. That PR fixed a reproducible defect — `chmod` silently no-ops on WSL2 DrvFs, so the worker's Ed25519 private key was written world-readable while pairing reported success. This one is different in kind, and needs its own decision.

## The question this PR is really asking

**Is another local account on the same host in scope for BYOM?**

Everything here defends that threat. BYOM's stated model is a worker on the user's own machine or VM, with the trusted worker outside the sandbox and the *sandboxed command* as the adversary. Under that model none of this is needed. Under a shared or managed host, all of it is.

It is separate because these checks buy that defence by **trading deployment flexibility**, and that trade should be made deliberately rather than accumulated under review pressure. Two of them can refuse setups that work today:

- **Container ownership** refuses an identity in a directory owned by a provisioning or service account — plausible in containerized deployments.
- **Default-workspace ownership** refuses a pre-provisioned workspace directory owned by another account.

If the answer to the question above is "no", most of this should be dropped rather than merged. I would rather ask than assume.

## What it adds

**Ownership.** Mode bits do not establish trust: a `0600` file owned by another account is unreadable by others yet fully rewritable by its owner, who then controls the credential the worker loads — or, for a quarantine marker, can delete it and let mutations resume. The containing directory is judged the same way, since an owner lacking write bits today can grant them tomorrow. Root counts as the trust root. `--default-workspace` is application-owned by contract, so a pre-existing one under another account is refused too.

**Containers.** A `0600` file in a directory others can write can be unlinked and replaced. Publishing goes through `rename`, which replaces the named entry, so the write path judges the *entry's* directory; reading follows the link, so *both* ends are judged. The sticky bit counts as protection, keeping `/tmp`-style parents usable.

**Pairing preflight.** `pair` redeemed the one-time code before the destination was known usable, so an unusable path cost the code and left an orphaned remote pairing — reproduced with `--identity <existing dir>`, which surfaced a raw `EISDIR` *after* the code was spent. The destination is now validated and then **claimed**, so another account cannot take the name while the request is in flight. The claim records its inode and is released only if the file is still that inode and still empty, so a concurrent pairing that published a real identity over the name is never destroyed by another invocation's unwind.

## Verification

| | before | after |
|---|---|---|
| `pair --identity <existing dir>` | raw `EISDIR`, **code spent** | rejected in preflight; the same code then pairs successfully |
| `pair` into a `0500` directory | `EACCES` at save, **code spent** | rejected in preflight |
| concurrent `pair`, first one unwinds | **deletes the other's credential** | the published identity survives |
| `pair` with an invalid code | — | no stray placeholder left behind |
| credential in a world-writable directory | trusted | refused (sticky parents still accepted) |
| symlink whose *entry* is in a shared directory | trusted | refused |
| `pair` to ext4 / default `~/.config`, and re-pairing | `0600` | `0600` (unchanged) |

Measured against real paths before committing to the rule: `~` is `0750` and `~/.config` `0751` here, both accepted; `/tmp` at `1777` is accepted via the sticky bit. A naive `& 0o077` ancestor check would have rejected the **default** identity path, which is why the rule is write-bits-plus-sticky rather than mode-wide.

**41/41** focused tests (`storage`, `cli`, `workspace-cli` — the only dependents of the changed functions). `tsc --noEmit` clean.

## Known gaps, left explicit rather than half-done

- **Only the immediate container is checked.** A writable ancestor could still rename a private directory out from under the worker.
- **Bind-mounted destinations** still fail at `rename` with `EBUSY`. Every detection I found either false-positives on btrfs subvolumes (`st_dev`) or races (`/proc/mounts`), and a test-rename would clobber the file it protects.
- **macOS extended ACLs and Windows ACLs** are both outside what a mode check can see. Node exposes no ACL API, so this needs a subprocess validated on a host that has those platforms — neither is available here, and an unverified subprocess in the credential path is worse than a stated limit.

The sticky-plus-foreign-owner reject path cannot be exercised without root, so the test there covers the regression instead: an owned file in a sticky directory stays replaceable.
