### PR TITLE
🔐 feat: Add Sandboxed GitHub Authentication

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -104,6 +104,8 @@ read only by the trusted worker, which mints and refreshes short-lived
 installation tokens. A personal access token is supported as a fallback with
 `LIBRECHAT_CODE_GITHUB_TOKEN`, but the GitHub App is the safer default because
 its repository access and permissions can be narrowly installed and revoked.
+Native Windows currently requires token mode because the worker cannot
+reliably validate private-key ACLs there; use WSL2 for GitHub App mode.
 
 Git receives authentication through process-scoped `GIT_CONFIG_*` variables.
 The same isolated config supplies the standard Git LFS filters; hosts using LFS

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -86,6 +86,42 @@ policy: an allowed destination can receive workspace data. The normalized
 allowlist is included in the worker policy digest. Tool approval hooks remain
 the user-facing allow/deny boundary for each invocation.
 
+### GitHub authentication
+
+The native BYOM worker can provide Git HTTPS authentication without exposing a
+real token to the command sandbox. Prefer a GitHub App installed only on the
+repositories the agent may access:
+
+```bash
+LIBRECHAT_CODE_GITHUB_APP_ID=12345 \
+LIBRECHAT_CODE_GITHUB_INSTALLATION_ID=67890 \
+LIBRECHAT_CODE_GITHUB_PRIVATE_KEY_FILE=/secure/librechat-agent.pem \
+librechat-code run --worker-dir /path/to/project --allow-workspace-commands
+```
+
+The private key must be an owner-only regular file outside the workspace. It is
+read only by the trusted worker, which mints and refreshes short-lived
+installation tokens. A personal access token is supported as a fallback with
+`LIBRECHAT_CODE_GITHUB_TOKEN`, but the GitHub App is the safer default because
+its repository access and permissions can be narrowly installed and revoked.
+
+Git receives authentication through process-scoped `GIT_CONFIG_*` variables.
+SRT replaces only the bearer-token portion with a sentinel inside the sandbox
+and substitutes the real value in its host proxy only for `github.com` HTTPS
+traffic. TLS termination is enabled for that substitution. The worker restores
+the parent environment immediately after constructing the sandbox command; it
+never writes credentials into the repository, a remote URL, or Git config.
+GitHub's required domains are added to the command egress allowlist only when
+authentication is configured. The worker identity, GitHub App key path, token
+source variables, and mutation-quarantine record remain denied to sandboxed
+commands.
+
+For GitHub Enterprise Server, set `LIBRECHAT_CODE_GITHUB_HOST` to its hostname
+and `LIBRECHAT_CODE_GITHUB_API_URL` to its HTTPS API base URL. GitHub
+authentication currently requires the `native-srt` command sandbox. Every
+clone, commit, or push command still crosses LibreChat's tool-approval policy;
+the credential boundary does not grant approval by itself.
+
 Select the backend explicitly when desired:
 
 ```bash

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -106,6 +106,9 @@ installation tokens. A personal access token is supported as a fallback with
 its repository access and permissions can be narrowly installed and revoked.
 
 Git receives authentication through process-scoped `GIT_CONFIG_*` variables.
+The same isolated config supplies the standard Git LFS filters; hosts using LFS
+must install `git-lfs`, and checkout fails instead of silently leaving pointer
+files when it is unavailable.
 SRT replaces only the bearer-token portion with a sentinel inside the sandbox
 and substitutes the real value in its host proxy only for `github.com` HTTPS
 traffic. TLS termination is enabled for that substitution. The worker restores

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -34,6 +34,10 @@
     "./native-sandbox": {
       "types": "./dist/native-sandbox.d.ts",
       "import": "./dist/native-sandbox.js"
+    },
+    "./github": {
+      "types": "./dist/github.d.ts",
+      "import": "./dist/github.js"
     }
   },
   "bin": {

--- a/packages/code/src/cli.test.ts
+++ b/packages/code/src/cli.test.ts
@@ -94,6 +94,51 @@ test('CLI rejects an unknown command sandbox before entering the run loop', () =
   );
 });
 
+test('CLI rejects incomplete GitHub App authentication before worker registration', () => {
+  const result = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL('./cli.js', import.meta.url))],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        LIBRECHAT_CODE_URL: 'https://code.example/v1',
+        LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
+        LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
+        LIBRECHAT_CODE_GITHUB_APP_ID: '123',
+        LIBRECHAT_CODE_GITHUB_INSTALLATION_ID: undefined,
+        LIBRECHAT_CODE_GITHUB_PRIVATE_KEY_FILE: undefined,
+      },
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /GitHub App authentication requires/);
+});
+
+test('CLI refuses GitHub credentials without native sandboxed commands', () => {
+  const result = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL('./cli.js', import.meta.url))],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        LIBRECHAT_CODE_URL: 'https://code.example/v1',
+        LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
+        LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
+        LIBRECHAT_CODE_GITHUB_TOKEN: 'github_pat_abcdefghijklmnopqrstuvwxyz',
+      },
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /GitHub authentication requires workspace commands/,
+  );
+});
+
 test('CLI requires a runtime image for Docker supervision', () => {
   const result = spawnSync(
     process.execPath,
@@ -132,7 +177,10 @@ test('CLI requires the macOS NsJail seccomp profile', () => {
   );
 
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /LIBRECHAT_CODE_DOCKER_SECCOMP_PROFILE is required/);
+  assert.match(
+    result.stderr,
+    /LIBRECHAT_CODE_DOCKER_SECCOMP_PROFILE is required/,
+  );
 });
 
 test('CLI requires a package mount for the macOS NsJail profile', () => {
@@ -154,7 +202,10 @@ test('CLI requires a package mount for the macOS NsJail profile', () => {
   );
 
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /LIBRECHAT_CODE_DOCKER_PACKAGES_PATH is required/);
+  assert.match(
+    result.stderr,
+    /LIBRECHAT_CODE_DOCKER_PACKAGES_PATH is required/,
+  );
 });
 
 test('CLI reset does not require Docker runtime launch inputs', () => {

--- a/packages/code/src/cli.test.ts
+++ b/packages/code/src/cli.test.ts
@@ -139,6 +139,60 @@ test('CLI refuses GitHub credentials without native sandboxed commands', () => {
   );
 });
 
+test('CLI rejects a GitHub App API URL that does not match its Git host', () => {
+  const result = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL('./cli.js', import.meta.url))],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        LIBRECHAT_CODE_URL: 'https://code.example/v1',
+        LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
+        LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
+        LIBRECHAT_CODE_GITHUB_APP_ID: '123',
+        LIBRECHAT_CODE_GITHUB_INSTALLATION_ID: '456',
+        LIBRECHAT_CODE_GITHUB_PRIVATE_KEY_FILE: '/does/not/matter',
+        LIBRECHAT_CODE_GITHUB_HOST: 'github.example.test',
+        LIBRECHAT_CODE_GITHUB_API_URL: 'https://other.example.test/api/v3',
+      },
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /LIBRECHAT_CODE_GITHUB_HOST must match the GitHub App API hostname/,
+  );
+});
+
+test('CLI validates GitHub App credentials before worker registration', () => {
+  const result = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL('./cli.js', import.meta.url))],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        LIBRECHAT_CODE_URL: 'http://127.0.0.1:1/v1',
+        LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
+        LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
+        LIBRECHAT_CODE_WORKER_DIR: process.cwd(),
+        LIBRECHAT_CODE_ALLOW_WORKSPACE_COMMANDS: 'true',
+        LIBRECHAT_CODE_GITHUB_APP_ID: '123',
+        LIBRECHAT_CODE_GITHUB_INSTALLATION_ID: '456',
+        LIBRECHAT_CODE_GITHUB_PRIVATE_KEY_FILE: '/does/not/exist/app.pem',
+        LIBRECHAT_CODE_GITHUB_HOST: undefined,
+        LIBRECHAT_CODE_GITHUB_API_URL: undefined,
+      },
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /ENOENT|no such file/i);
+  assert.doesNotMatch(result.stderr, /fetch failed/);
+});
+
 test('CLI requires a runtime image for Docker supervision', () => {
   const result = spawnSync(
     process.execPath,
@@ -227,6 +281,7 @@ test('CLI reset does not require Docker runtime launch inputs', () => {
         LIBRECHAT_CODE_RUNTIME_IMAGE: undefined,
         LIBRECHAT_CODE_DOCKER_SECCOMP_PROFILE: undefined,
         LIBRECHAT_CODE_DOCKER_PACKAGES_PATH: undefined,
+        LIBRECHAT_CODE_GITHUB_TOKEN: 'github_pat_abcdefghijklmnopqrstuvwxyz',
       },
     },
   );
@@ -235,6 +290,10 @@ test('CLI reset does not require Docker runtime launch inputs', () => {
   assert.doesNotMatch(
     result.stderr,
     /LIBRECHAT_CODE_(?:RUNTIME_IMAGE|DOCKER_SECCOMP_PROFILE|DOCKER_PACKAGES_PATH) is required/,
+  );
+  assert.doesNotMatch(
+    result.stderr,
+    /GitHub authentication requires workspace commands/,
   );
 });
 

--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -33,6 +33,7 @@ import {
   GITHUB_CREDENTIAL_ENV_NAME,
   GitHubAppCredentialProvider,
   StaticGitHubCredentialProvider,
+  gitHubAuthenticationPolicyIdentity,
   gitHubCredentialEnvironment,
   wrapGitHubCredentialCommand,
 } from './github.js';
@@ -130,6 +131,7 @@ function githubCredentials(): {
   host: string;
   privateKeyPath?: string;
   mode?: 'app' | 'token';
+  policyIdentity: string;
 } {
   const token = nonEmpty(process.env.LIBRECHAT_CODE_GITHUB_TOKEN);
   const appId = nonEmpty(process.env.LIBRECHAT_CODE_GITHUB_APP_ID);
@@ -183,6 +185,12 @@ function githubCredentials(): {
     return {
       host,
       mode: 'app',
+      policyIdentity: gitHubAuthenticationPolicyIdentity({
+        mode: 'app',
+        host,
+        appId,
+        installationId,
+      }),
       privateKeyPath,
       provider: new GitHubAppCredentialProvider({
         appId: appId!,
@@ -194,6 +202,10 @@ function githubCredentials(): {
   }
   return {
     host,
+    policyIdentity: gitHubAuthenticationPolicyIdentity({
+      mode: token ? 'token' : undefined,
+      host,
+    }),
     ...(token
       ? {
           provider: new StaticGitHubCredentialProvider(token),
@@ -388,7 +400,14 @@ async function run(
     );
   }
   const github =
-    runtimeSessionId == null ? githubCredentials() : { host: 'github.com' };
+    runtimeSessionId == null
+      ? githubCredentials()
+      : {
+          host: 'github.com',
+          policyIdentity: gitHubAuthenticationPolicyIdentity({
+            host: 'github.com',
+          }),
+        };
   if (github.provider && !allowWorkspaceCommands) {
     throw new Error(
       'GitHub authentication requires workspace commands to be enabled',
@@ -701,7 +720,7 @@ async function run(
       .update(policy)
       .update(
         allowWorkspaceCommands && commandSandboxMode === 'native-srt'
-          ? `\0native-srt\0${commandAllowedDomains.join('\0')}\0github-auth:${github.mode ?? 'none'}:${github.host}`
+          ? `\0native-srt\0${commandAllowedDomains.join('\0')}\0${github.policyIdentity}`
           : '',
       )
       .digest('hex'),

--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -151,7 +151,27 @@ function githubCredentials(): {
       'Configure either GitHub App authentication or a GitHub token, not both',
     );
   }
-  const host = nonEmpty(process.env.LIBRECHAT_CODE_GITHUB_HOST) ?? 'github.com';
+  const configuredHost = nonEmpty(process.env.LIBRECHAT_CODE_GITHUB_HOST);
+  const apiUrl = nonEmpty(process.env.LIBRECHAT_CODE_GITHUB_API_URL);
+  let apiHost: string | undefined;
+  if (apiUrl) {
+    let parsedApiUrl: URL;
+    try {
+      parsedApiUrl = new URL(apiUrl);
+    } catch {
+      throw new Error('LIBRECHAT_CODE_GITHUB_API_URL must be a valid URL');
+    }
+    apiHost =
+      parsedApiUrl.hostname.toLowerCase() === 'api.github.com'
+        ? 'github.com'
+        : parsedApiUrl.hostname.toLowerCase();
+  }
+  if (configuredHost && apiHost && configuredHost.toLowerCase() !== apiHost) {
+    throw new Error(
+      'LIBRECHAT_CODE_GITHUB_HOST must match the GitHub App API hostname',
+    );
+  }
+  const host = configuredHost ?? apiHost ?? 'github.com';
   if (
     !/^[A-Za-z0-9.-]+$/.test(host) ||
     host.startsWith('.') ||
@@ -168,7 +188,7 @@ function githubCredentials(): {
         appId: appId!,
         installationId: installationId!,
         privateKeyPath: privateKeyPath!,
-        apiUrl: nonEmpty(process.env.LIBRECHAT_CODE_GITHUB_API_URL),
+        apiUrl,
       }),
     };
   }
@@ -367,7 +387,8 @@ async function run(
       'LIBRECHAT_CODE_COMMAND_SANDBOX must be native-srt or runtime',
     );
   }
-  const github = githubCredentials();
+  const github =
+    runtimeSessionId == null ? githubCredentials() : { host: 'github.com' };
   if (github.provider && !allowWorkspaceCommands) {
     throw new Error(
       'GitHub authentication requires workspace commands to be enabled',
@@ -632,7 +653,7 @@ async function run(
                   variables: [
                     {
                       name: GITHUB_CREDENTIAL_ENV_NAME,
-                      extract: '^Authorization: Bearer (.+)$',
+                      extract: '^(.+)$',
                       injectHosts: [github.host],
                     },
                   ],
@@ -694,6 +715,7 @@ async function run(
     );
   }
   try {
+    await github.provider?.getCredential(controller.signal);
     await nativeCommandSandbox?.prepare();
   } catch (error) {
     await fileRelaySupervisor?.stop().catch(() => undefined);

--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -35,6 +35,7 @@ import {
   StaticGitHubCredentialProvider,
   gitHubAuthenticationPolicyIdentity,
   gitHubCredentialEnvironment,
+  normalizeGitHubHost,
   wrapGitHubCredentialCommand,
 } from './github.js';
 import type { RuntimeSupervisor } from './runtime.js';
@@ -153,7 +154,12 @@ function githubCredentials(): {
       'Configure either GitHub App authentication or a GitHub token, not both',
     );
   }
-  const configuredHost = nonEmpty(process.env.LIBRECHAT_CODE_GITHUB_HOST);
+  const configuredHostValue = nonEmpty(
+    process.env.LIBRECHAT_CODE_GITHUB_HOST,
+  );
+  const configuredHost = configuredHostValue
+    ? normalizeGitHubHost(configuredHostValue)
+    : undefined;
   const apiUrl = nonEmpty(process.env.LIBRECHAT_CODE_GITHUB_API_URL);
   let apiHost: string | undefined;
   if (apiUrl) {
@@ -173,14 +179,7 @@ function githubCredentials(): {
       'LIBRECHAT_CODE_GITHUB_HOST must match the GitHub App API hostname',
     );
   }
-  const host = configuredHost ?? apiHost ?? 'github.com';
-  if (
-    !/^[A-Za-z0-9.-]+$/.test(host) ||
-    host.startsWith('.') ||
-    host.endsWith('.')
-  ) {
-    throw new Error('LIBRECHAT_CODE_GITHUB_HOST must be a DNS hostname');
-  }
+  const host = normalizeGitHubHost(configuredHost ?? apiHost ?? 'github.com');
   if (hasApp) {
     return {
       host,

--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -21,14 +21,23 @@ import {
   saveWorkspaceMutationQuarantine,
 } from './storage.js';
 import { BridgeWorker } from './worker.js';
+import { LocalWorkspaceTools, SandboxWorkspaceTools } from './workspace.js';
 import {
-  LocalWorkspaceTools,
-  SandboxWorkspaceTools,
-} from './workspace.js';
-import { DockerRuntimeSupervisor, EndpointRuntimeSupervisor } from './runtime.js';
+  DockerRuntimeSupervisor,
+  EndpointRuntimeSupervisor,
+} from './runtime.js';
 import { RuntimeWorkspaceCommandSandbox } from './workspace-runtime.js';
 import { NativeSrtWorkspaceCommandSandbox } from './native-sandbox.js';
+import {
+  GITHUB_ALLOWED_DOMAINS,
+  GITHUB_CREDENTIAL_ENV_NAME,
+  GitHubAppCredentialProvider,
+  StaticGitHubCredentialProvider,
+  gitHubCredentialEnvironment,
+  wrapGitHubCredentialCommand,
+} from './github.js';
 import type { RuntimeSupervisor } from './runtime.js';
+import type { GitHubCredentialProvider } from './github.js';
 import type { WorkspaceToolExecutor } from './workspace.js';
 import {
   BRIDGE_WORKSPACE_NAME_MAX_LENGTH,
@@ -74,7 +83,11 @@ function list(value: string | undefined): string[] {
   );
 }
 
-function positiveInteger(name: string, value: string | undefined, fallback: number): number {
+function positiveInteger(
+  name: string,
+  value: string | undefined,
+  fallback: number,
+): number {
   if (value == null || value.trim().length === 0) return fallback;
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
@@ -103,14 +116,77 @@ const MACOS_NSJAIL_CAPABILITIES = [
 function option(args: string[], name: string): string | undefined {
   const index = args.indexOf(name);
   if (index >= 0) return args[index + 1];
-  return args.find((value) => value.startsWith(`${name}=`))?.slice(name.length + 1);
+  return args
+    .find((value) => value.startsWith(`${name}=`))
+    ?.slice(name.length + 1);
 }
 
 function nonEmpty(value: string | undefined): string | undefined {
   return value?.trim().length ? value : undefined;
 }
 
-function defaultWorkspaceName(workerDirectory: string, workspaceId: string): string {
+function githubCredentials(): {
+  provider?: GitHubCredentialProvider;
+  host: string;
+  privateKeyPath?: string;
+  mode?: 'app' | 'token';
+} {
+  const token = nonEmpty(process.env.LIBRECHAT_CODE_GITHUB_TOKEN);
+  const appId = nonEmpty(process.env.LIBRECHAT_CODE_GITHUB_APP_ID);
+  const installationId = nonEmpty(
+    process.env.LIBRECHAT_CODE_GITHUB_INSTALLATION_ID,
+  );
+  const privateKeyPath = nonEmpty(
+    process.env.LIBRECHAT_CODE_GITHUB_PRIVATE_KEY_FILE,
+  );
+  const appValues = [appId, installationId, privateKeyPath];
+  const hasApp = appValues.some(Boolean);
+  if (hasApp && !appValues.every(Boolean)) {
+    throw new Error(
+      'GitHub App authentication requires LIBRECHAT_CODE_GITHUB_APP_ID, LIBRECHAT_CODE_GITHUB_INSTALLATION_ID, and LIBRECHAT_CODE_GITHUB_PRIVATE_KEY_FILE',
+    );
+  }
+  if (hasApp && token) {
+    throw new Error(
+      'Configure either GitHub App authentication or a GitHub token, not both',
+    );
+  }
+  const host = nonEmpty(process.env.LIBRECHAT_CODE_GITHUB_HOST) ?? 'github.com';
+  if (
+    !/^[A-Za-z0-9.-]+$/.test(host) ||
+    host.startsWith('.') ||
+    host.endsWith('.')
+  ) {
+    throw new Error('LIBRECHAT_CODE_GITHUB_HOST must be a DNS hostname');
+  }
+  if (hasApp) {
+    return {
+      host,
+      mode: 'app',
+      privateKeyPath,
+      provider: new GitHubAppCredentialProvider({
+        appId: appId!,
+        installationId: installationId!,
+        privateKeyPath: privateKeyPath!,
+        apiUrl: nonEmpty(process.env.LIBRECHAT_CODE_GITHUB_API_URL),
+      }),
+    };
+  }
+  return {
+    host,
+    ...(token
+      ? {
+          provider: new StaticGitHubCredentialProvider(token),
+          mode: 'token' as const,
+        }
+      : {}),
+  };
+}
+
+function defaultWorkspaceName(
+  workerDirectory: string,
+  workspaceId: string,
+): string {
   const directoryName = basename(resolve(workerDirectory));
   return directoryName.trim().length > 0 &&
     directoryName.length <= BRIDGE_WORKSPACE_NAME_MAX_LENGTH
@@ -168,7 +244,9 @@ async function relay(): Promise<void> {
       8,
     ),
   });
-  process.stdout.write(`librechat-code: file relay listening at ${handle.url}\n`);
+  process.stdout.write(
+    `librechat-code: file relay listening at ${handle.url}\n`,
+  );
   await new Promise<void>((resolve) => {
     process.once('SIGINT', resolve);
     process.once('SIGTERM', resolve);
@@ -176,9 +254,13 @@ async function relay(): Promise<void> {
   await handle.close();
 }
 
-async function run(runtimeSessionId?: string, args: string[] = []): Promise<void> {
+async function run(
+  runtimeSessionId?: string,
+  args: string[] = [],
+): Promise<void> {
   const configuredWorkerId = process.env.LIBRECHAT_CODE_WORKER_ID?.trim();
-  const configuredIdentityPath = process.env.LIBRECHAT_CODE_IDENTITY_FILE?.trim();
+  const configuredIdentityPath =
+    process.env.LIBRECHAT_CODE_IDENTITY_FILE?.trim();
   const configuredToken = process.env.LIBRECHAT_CODE_WORKER_TOKEN?.trim();
   const identityPath =
     configuredIdentityPath ??
@@ -211,7 +293,8 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
     process.env.LIBRECHAT_CODE_STATEFUL_WORKSPACE?.trim().toLowerCase() ===
     'true';
   const runtimeMode =
-    process.env.LIBRECHAT_CODE_RUNTIME_SUPERVISOR?.trim().toLowerCase() ?? 'endpoint';
+    process.env.LIBRECHAT_CODE_RUNTIME_SUPERVISOR?.trim().toLowerCase() ??
+    'endpoint';
   if (
     runtimeMode !== 'endpoint' &&
     runtimeMode !== 'docker' &&
@@ -284,8 +367,27 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
       'LIBRECHAT_CODE_COMMAND_SANDBOX must be native-srt or runtime',
     );
   }
+  const github = githubCredentials();
+  if (github.provider && !allowWorkspaceCommands) {
+    throw new Error(
+      'GitHub authentication requires workspace commands to be enabled',
+    );
+  }
+  if (github.provider && commandSandboxMode !== 'native-srt') {
+    throw new Error(
+      'GitHub authentication currently requires the native-srt command sandbox',
+    );
+  }
+  const githubDomains = github.provider
+    ? github.host === 'github.com'
+      ? [...GITHUB_ALLOWED_DOMAINS]
+      : [github.host]
+    : [];
   const commandAllowedDomains = [
-    ...new Set(list(process.env.LIBRECHAT_CODE_COMMAND_ALLOWED_DOMAINS)),
+    ...new Set([
+      ...list(process.env.LIBRECHAT_CODE_COMMAND_ALLOWED_DOMAINS),
+      ...githubDomains,
+    ]),
   ].sort();
   if (explicitWorkerDirectory && useDefaultWorkspace) {
     throw new Error(
@@ -457,9 +559,15 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
                   securityOptions: [`seccomp=${seccompProfile}`],
                   profileRevision,
                   restartStoppedContainers: false,
-                  ...(fileRelayProfile ? { network: fileRelayProfile.network } : {}),
+                  ...(fileRelayProfile
+                    ? { network: fileRelayProfile.network }
+                    : {}),
                   bindMounts: [
-                    { source: packagesPath, target: '/pkgs', readOnly: true },
+                    {
+                      source: packagesPath,
+                      target: '/pkgs',
+                      readOnly: true,
+                    },
                     ...(workspaceMount ? [workspaceMount] : []),
                   ],
                   httpClient: 'bun' as const,
@@ -469,18 +577,25 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
                     ...(workspaceMount
                       ? {
                           SANDBOX_EXTERNAL_WORKSPACE_ENABLED: 'true',
-                          SANDBOX_EXTERNAL_WORKSPACE_ROOT: workspaceMount.target,
-                          SANDBOX_EXTERNAL_WORKSPACE_TOKEN: workspaceCommandToken!,
+                          SANDBOX_EXTERNAL_WORKSPACE_ROOT:
+                            workspaceMount.target,
+                          SANDBOX_EXTERNAL_WORKSPACE_TOKEN:
+                            workspaceCommandToken!,
                         }
                       : {}),
                     ...(fileRelayProfile
                       ? {
                           EGRESS_GATEWAY_URL: fileRelayProfile.url,
-                          SANDBOX_PRIME_CONCURRENCY: String(fileRelayLimits!.maxConcurrentRequests),
-                          SANDBOX_UPLOAD_CONCURRENCY: String(fileRelayLimits!.maxConcurrentRequests),
+                          SANDBOX_PRIME_CONCURRENCY: String(
+                            fileRelayLimits!.maxConcurrentRequests,
+                          ),
+                          SANDBOX_UPLOAD_CONCURRENCY: String(
+                            fileRelayLimits!.maxConcurrentRequests,
+                          ),
                           SANDBOX_FILE_RELAY_TOKEN: fileRelayProfile.token,
                           SANDBOX_REQUIRE_EGRESS_MANIFEST: 'true',
-                          SANDBOX_EXECUTION_MANIFEST_PUBLIC_KEY: executionManifestPublicKey!,
+                          SANDBOX_EXECUTION_MANIFEST_PUBLIC_KEY:
+                            executionManifestPublicKey!,
                         }
                       : {}),
                   },
@@ -505,10 +620,37 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
     allowWorkspaceCommands && commandSandboxMode === 'native-srt'
       ? new NativeSrtWorkspaceCommandSandbox({
           workspaceRoot: canonicalWorkerDirectory!,
-          protectedPaths: [identityPath, mutationQuarantinePath].filter(
-            (path): path is string => path != null,
-          ),
+          protectedPaths: [
+            identityPath,
+            mutationQuarantinePath,
+            github.privateKeyPath,
+          ].filter((path): path is string => path != null),
           allowedDomains: commandAllowedDomains,
+          ...(github.provider
+            ? {
+                maskedEnvironment: {
+                  variables: [
+                    {
+                      name: GITHUB_CREDENTIAL_ENV_NAME,
+                      extract: '^Authorization: Bearer (.+)$',
+                      injectHosts: [github.host],
+                    },
+                  ],
+                  async resolve(signal?: AbortSignal) {
+                    return gitHubCredentialEnvironment(
+                      await github.provider!.getCredential(signal),
+                    );
+                  },
+                  wrapCommand(command: string, platform: NodeJS.Platform) {
+                    return wrapGitHubCredentialCommand(
+                      command,
+                      github.host,
+                      platform,
+                    );
+                  },
+                },
+              }
+            : {}),
         })
       : undefined;
   if (allowWorkspaceCommands && workspaceTools) {
@@ -538,7 +680,7 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
       .update(policy)
       .update(
         allowWorkspaceCommands && commandSandboxMode === 'native-srt'
-          ? `\0native-srt\0${commandAllowedDomains.join('\0')}`
+          ? `\0native-srt\0${commandAllowedDomains.join('\0')}\0github-auth:${github.mode ?? 'none'}:${github.host}`
           : '',
       )
       .digest('hex'),
@@ -659,7 +801,8 @@ async function run(runtimeSessionId?: string, args: string[] = []): Promise<void
 
 async function clearMutationQuarantine(args: string[]): Promise<void> {
   const configuredWorkerId = process.env.LIBRECHAT_CODE_WORKER_ID?.trim();
-  const configuredIdentityPath = process.env.LIBRECHAT_CODE_IDENTITY_FILE?.trim();
+  const configuredIdentityPath =
+    process.env.LIBRECHAT_CODE_IDENTITY_FILE?.trim();
   const configuredToken = process.env.LIBRECHAT_CODE_WORKER_TOKEN?.trim();
   const identityPath =
     configuredIdentityPath ??
@@ -682,7 +825,8 @@ async function clearMutationQuarantine(args: string[]): Promise<void> {
     process.env.LIBRECHAT_CODE_WORKSPACE_ID?.trim() ??
     'primary';
   const explicitWorkerDirectory = nonEmpty(
-    option(args, '--worker-dir') ?? process.env.LIBRECHAT_CODE_WORKER_DIR?.trim(),
+    option(args, '--worker-dir') ??
+      process.env.LIBRECHAT_CODE_WORKER_DIR?.trim(),
   );
   const useDefaultWorkspace =
     args.includes('--default-workspace') ||

--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -204,6 +204,7 @@ function githubCredentials(): {
     policyIdentity: gitHubAuthenticationPolicyIdentity({
       mode: token ? 'token' : undefined,
       host,
+      token,
     }),
     ...(token
       ? {

--- a/packages/code/src/github.test.ts
+++ b/packages/code/src/github.test.ts
@@ -1,11 +1,19 @@
 import { generateKeyPairSync } from 'node:crypto';
-import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  mkdtemp,
+  mkdir,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  GITHUB_ALLOWED_DOMAINS,
   GitHubAppCredentialProvider,
   StaticGitHubCredentialProvider,
   GITHUB_CREDENTIAL_ENV_NAME,
@@ -98,4 +106,62 @@ test('rejects an insecure GitHub App API endpoint before reading the private key
       }),
     /must be an HTTPS URL/,
   );
+});
+
+test('rejects a GitHub App key in a shared writable directory', async (t) => {
+  if (process.platform === 'win32') {
+    t.skip('POSIX directory permissions are unavailable on Windows');
+    return;
+  }
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-github-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const directory = join(root, 'shared');
+  await mkdir(directory, { mode: 0o700 });
+  const privateKeyPath = join(directory, 'app.pem');
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  await writeFile(
+    privateKeyPath,
+    privateKey.export({ type: 'pkcs8', format: 'pem' }),
+    { mode: 0o600 },
+  );
+  await chmod(directory, 0o777);
+  const provider = new GitHubAppCredentialProvider({
+    appId: '123',
+    installationId: '456',
+    privateKeyPath,
+  });
+
+  await assert.rejects(
+    provider.getCredential(),
+    /private key directory must not be writable/,
+  );
+});
+
+test('rejects a symlinked GitHub App key without reopening its target', async (t) => {
+  if (process.platform === 'win32') {
+    t.skip('O_NOFOLLOW is unavailable on Windows');
+    return;
+  }
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-github-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const target = join(root, 'target.pem');
+  const link = join(root, 'app.pem');
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  await writeFile(target, privateKey.export({ type: 'pkcs8', format: 'pem' }), {
+    mode: 0o600,
+  });
+  await symlink(target, link);
+  const provider = new GitHubAppCredentialProvider({
+    appId: '123',
+    installationId: '456',
+    privateKeyPath: link,
+  });
+
+  await assert.rejects(provider.getCredential(), /ELOOP|symbolic link/i);
+});
+
+test('allows the GitHub LFS object delivery hosts', () => {
+  assert.ok(GITHUB_ALLOWED_DOMAINS.includes('objects.githubusercontent.com'));
+  assert.ok(GITHUB_ALLOWED_DOMAINS.includes('*.githubusercontent.com'));
+  assert.ok(GITHUB_ALLOWED_DOMAINS.includes('github-cloud.s3.amazonaws.com'));
 });

--- a/packages/code/src/github.test.ts
+++ b/packages/code/src/github.test.ts
@@ -16,10 +16,37 @@ import {
   GITHUB_ALLOWED_DOMAINS,
   GitHubAppCredentialProvider,
   StaticGitHubCredentialProvider,
+  gitHubAuthenticationPolicyIdentity,
   GITHUB_CREDENTIAL_ENV_NAME,
   gitHubCredentialEnvironment,
   wrapGitHubCredentialCommand,
 } from './github.js';
+
+test('binds the GitHub App installation to the public policy identity', () => {
+  assert.equal(
+    gitHubAuthenticationPolicyIdentity({
+      mode: 'app',
+      host: 'github.com',
+      appId: '123',
+      installationId: '456',
+    }),
+    'github-auth:app:github.com:app:123:installation:456',
+  );
+  assert.notEqual(
+    gitHubAuthenticationPolicyIdentity({
+      mode: 'app',
+      host: 'github.com',
+      appId: '123',
+      installationId: '456',
+    }),
+    gitHubAuthenticationPolicyIdentity({
+      mode: 'app',
+      host: 'github.com',
+      appId: '123',
+      installationId: '789',
+    }),
+  );
+});
 
 test('mints and caches a short-lived GitHub App installation token', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'librechat-code-github-'));

--- a/packages/code/src/github.test.ts
+++ b/packages/code/src/github.test.ts
@@ -19,8 +19,14 @@ import {
   gitHubAuthenticationPolicyIdentity,
   GITHUB_CREDENTIAL_ENV_NAME,
   gitHubCredentialEnvironment,
+  normalizeGitHubHost,
   wrapGitHubCredentialCommand,
 } from './github.js';
+
+test('normalizes GitHub DNS hostnames before policy and allowlist use', () => {
+  assert.equal(normalizeGitHubHost('GitHub.COM'), 'github.com');
+  assert.throws(() => normalizeGitHubHost('.github.com'), /DNS hostname/);
+});
 
 test('binds the GitHub App installation to the public policy identity', () => {
   assert.equal(

--- a/packages/code/src/github.test.ts
+++ b/packages/code/src/github.test.ts
@@ -1,0 +1,101 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  GitHubAppCredentialProvider,
+  StaticGitHubCredentialProvider,
+  GITHUB_CREDENTIAL_ENV_NAME,
+  gitHubCredentialEnvironment,
+  wrapGitHubCredentialCommand,
+} from './github.js';
+
+test('mints and caches a short-lived GitHub App installation token', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'librechat-code-github-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const privateKeyPath = join(directory, 'app.pem');
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  await writeFile(
+    privateKeyPath,
+    privateKey.export({ type: 'pkcs8', format: 'pem' }),
+    { mode: 0o600 },
+  );
+  await chmod(privateKeyPath, 0o600);
+  let calls = 0;
+  const request = async (
+    _input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    calls += 1;
+    assert.match(
+      String(new Headers(init?.headers).get('authorization')),
+      /^Bearer eyJ/,
+    );
+    return new Response(
+      JSON.stringify({
+        token: 'ghs_abcdefghijklmnopqrstuvwxyz',
+        expires_at: '2030-01-01T01:00:00Z',
+      }),
+      { status: 201 },
+    );
+  };
+  const provider = new GitHubAppCredentialProvider({
+    appId: '123',
+    installationId: '456',
+    privateKeyPath,
+    fetch: request as typeof fetch,
+    now: () => new Date('2030-01-01T00:00:00Z'),
+  });
+
+  assert.equal(
+    (await provider.getCredential()).value,
+    'ghs_abcdefghijklmnopqrstuvwxyz',
+  );
+  assert.equal(
+    (await provider.getCredential()).value,
+    'ghs_abcdefghijklmnopqrstuvwxyz',
+  );
+  assert.equal(calls, 1);
+});
+
+test('builds process-scoped Git HTTPS authorization without embedding credentials in URLs', async () => {
+  const provider = new StaticGitHubCredentialProvider(
+    'github_pat_abcdefghijklmnopqrstuvwxyz',
+  );
+  assert.deepEqual(
+    gitHubCredentialEnvironment(await provider.getCredential()),
+    {
+      [GITHUB_CREDENTIAL_ENV_NAME]:
+        'Authorization: Bearer github_pat_abcdefghijklmnopqrstuvwxyz',
+    },
+  );
+});
+
+test('composes the masked credential with SRT Git configuration inside the sandbox', () => {
+  const wrapped = wrapGitHubCredentialCommand(
+    'git push',
+    'github.com',
+    'darwin',
+  );
+  assert.match(wrapped, /http\.proxyAuthMethod=basic/);
+  assert.match(wrapped, /http\.https:\/\/github\.com\/\.extraheader/);
+  assert.match(wrapped, /\$\{LIBRECHAT_CODE_GITHUB_AUTHORIZATION\}/);
+  assert.match(wrapped, /unset LIBRECHAT_CODE_GITHUB_AUTHORIZATION/);
+  assert.ok(!wrapped.includes('github_pat_'));
+});
+
+test('rejects an insecure GitHub App API endpoint before reading the private key', () => {
+  assert.throws(
+    () =>
+      new GitHubAppCredentialProvider({
+        appId: '123',
+        installationId: '456',
+        privateKeyPath: '/does/not/matter',
+        apiUrl: 'http://github.example.test/api/v3',
+      }),
+    /must be an HTTPS URL/,
+  );
+});

--- a/packages/code/src/github.test.ts
+++ b/packages/code/src/github.test.ts
@@ -68,8 +68,7 @@ test('builds process-scoped Git HTTPS authorization without embedding credential
   assert.deepEqual(
     gitHubCredentialEnvironment(await provider.getCredential()),
     {
-      [GITHUB_CREDENTIAL_ENV_NAME]:
-        'Authorization: Bearer github_pat_abcdefghijklmnopqrstuvwxyz',
+      [GITHUB_CREDENTIAL_ENV_NAME]: 'github_pat_abcdefghijklmnopqrstuvwxyz',
     },
   );
 });
@@ -84,6 +83,7 @@ test('composes the masked credential with SRT Git configuration inside the sandb
   assert.match(wrapped, /http\.https:\/\/github\.com\/\.extraheader/);
   assert.match(wrapped, /\$\{LIBRECHAT_CODE_GITHUB_AUTHORIZATION\}/);
   assert.match(wrapped, /unset LIBRECHAT_CODE_GITHUB_AUTHORIZATION/);
+  assert.equal(wrapped.match(/Authorization: Bearer/g)?.length, 1);
   assert.ok(!wrapped.includes('github_pat_'));
 });
 

--- a/packages/code/src/github.test.ts
+++ b/packages/code/src/github.test.ts
@@ -54,6 +54,37 @@ test('binds the GitHub App installation to the public policy identity', () => {
   );
 });
 
+test('binds token credentials to policy identity without exposing the token', () => {
+  const firstToken = 'github_pat_abcdefghijklmnopqrstuvwxyz';
+  const secondToken = 'github_pat_zyxwvutsrqponmlkjihgfedcba';
+  const first = gitHubAuthenticationPolicyIdentity({
+    mode: 'token',
+    host: 'github.com',
+    token: firstToken,
+  });
+  const second = gitHubAuthenticationPolicyIdentity({
+    mode: 'token',
+    host: 'github.com',
+    token: secondToken,
+  });
+
+  assert.notEqual(first, second);
+  assert.ok(!first.includes(firstToken));
+});
+
+test('rejects GitHub App authentication where key ACLs cannot be validated', () => {
+  assert.throws(
+    () =>
+      new GitHubAppCredentialProvider({
+        appId: '123',
+        installationId: '456',
+        privateKeyPath: 'C:\\secure\\app.pem',
+        platform: 'win32',
+      }),
+    /private key ACLs cannot be validated securely/,
+  );
+});
+
 test('mints and caches a short-lived GitHub App installation token', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'librechat-code-github-'));
   t.after(() => rm(directory, { recursive: true, force: true }));

--- a/packages/code/src/github.ts
+++ b/packages/code/src/github.ts
@@ -215,6 +215,18 @@ export function gitHubAuthenticationPolicyIdentity(options: {
   return `${identity}:app:${options.appId}:installation:${options.installationId}`;
 }
 
+export function normalizeGitHubHost(value: string): string {
+  const host = value.toLowerCase();
+  if (
+    !/^[a-z0-9.-]+$/.test(host) ||
+    host.startsWith('.') ||
+    host.endsWith('.')
+  ) {
+    throw new Error('LIBRECHAT_CODE_GITHUB_HOST must be a DNS hostname');
+  }
+  return host;
+}
+
 export function wrapGitHubCredentialCommand(
   command: string,
   host = 'github.com',

--- a/packages/code/src/github.ts
+++ b/packages/code/src/github.ts
@@ -1,5 +1,7 @@
+import { constants } from 'node:fs';
 import { createPrivateKey, sign } from 'node:crypto';
-import { lstat, readFile } from 'node:fs/promises';
+import { open, realpath, stat } from 'node:fs/promises';
+import { dirname } from 'node:path';
 
 export const GITHUB_CREDENTIAL_ENV_NAME = 'LIBRECHAT_CODE_GITHUB_AUTHORIZATION';
 export const GITHUB_ALLOWED_DOMAINS = [
@@ -7,6 +9,9 @@ export const GITHUB_ALLOWED_DOMAINS = [
   '*.github.com',
   'api.github.com',
   'lfs.github.com',
+  'objects.githubusercontent.com',
+  '*.githubusercontent.com',
+  'github-cloud.s3.amazonaws.com',
 ] as const;
 
 export interface GitHubCredential {
@@ -38,16 +43,49 @@ function assertPositiveIdentifier(name: string, value: string): void {
 }
 
 async function readPrivateKey(path: string): Promise<string> {
-  const metadata = await lstat(path);
-  if (!metadata.isFile() || metadata.isSymbolicLink()) {
-    throw new Error('GitHub App private key must be a regular file');
+  if (process.platform !== 'win32') {
+    const directory = await stat(await realpath(dirname(path)));
+    const uid = process.getuid?.();
+    if (uid !== undefined && directory.uid !== uid && directory.uid !== 0) {
+      throw new Error(
+        'GitHub App private key directory must be owned by this user or root',
+      );
+    }
+    const mode = directory.mode & 0o7777;
+    const protectedByStickyBit =
+      (mode & 0o1000) !== 0 && (directory.uid === uid || directory.uid === 0);
+    if ((mode & 0o022) !== 0 && !protectedByStickyBit) {
+      throw new Error(
+        'GitHub App private key directory must not be writable by group or other users',
+      );
+    }
   }
-  if (process.platform !== 'win32' && (metadata.mode & 0o077) !== 0) {
-    throw new Error(
-      'GitHub App private key must not be accessible by group or other users',
-    );
+
+  const handle = await open(
+    path,
+    constants.O_RDONLY |
+      (process.platform === 'win32' ? 0 : constants.O_NOFOLLOW),
+  );
+  try {
+    const metadata = await handle.stat();
+    if (!metadata.isFile()) {
+      throw new Error('GitHub App private key must be a regular file');
+    }
+    const uid = process.getuid?.();
+    if (uid !== undefined && metadata.uid !== uid && metadata.uid !== 0) {
+      throw new Error(
+        'GitHub App private key must be owned by this user or root',
+      );
+    }
+    if (process.platform !== 'win32' && (metadata.mode & 0o077) !== 0) {
+      throw new Error(
+        'GitHub App private key must not be accessible by group or other users',
+      );
+    }
+    return await handle.readFile('utf8');
+  } finally {
+    await handle.close();
   }
-  return await readFile(path, 'utf8');
 }
 
 function createAppJwt(appId: string, privateKey: string, now: Date): string {

--- a/packages/code/src/github.ts
+++ b/packages/code/src/github.ts
@@ -1,5 +1,5 @@
 import { constants } from 'node:fs';
-import { createPrivateKey, sign } from 'node:crypto';
+import { createHash, createPrivateKey, sign } from 'node:crypto';
 import { open, realpath, stat } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
@@ -30,6 +30,7 @@ export interface GitHubAppCredentialProviderOptions {
   apiUrl?: string;
   fetch?: typeof globalThis.fetch;
   now?: () => Date;
+  platform?: NodeJS.Platform;
 }
 
 function base64UrlJson(value: unknown): string {
@@ -109,6 +110,11 @@ export class GitHubAppCredentialProvider implements GitHubCredentialProvider {
   private cached?: GitHubCredential;
 
   constructor(private readonly options: GitHubAppCredentialProviderOptions) {
+    if ((options.platform ?? process.platform) === 'win32') {
+      throw new Error(
+        'GitHub App authentication is unavailable on native Windows because private key ACLs cannot be validated securely; use a token or WSL2',
+      );
+    }
     assertPositiveIdentifier('GitHub App ID', options.appId);
     assertPositiveIdentifier(
       'GitHub App installation ID',
@@ -204,8 +210,19 @@ export function gitHubAuthenticationPolicyIdentity(options: {
   host: string;
   appId?: string;
   installationId?: string;
+  token?: string;
 }): string {
   const identity = `github-auth:${options.mode ?? 'none'}:${options.host}`;
+  if (options.mode === 'token') {
+    if (!options.token) {
+      throw new Error('GitHub token policy identity requires a token');
+    }
+    const fingerprint = createHash('sha256')
+      .update('librechat-code-github-token-v1\0')
+      .update(options.token)
+      .digest('hex');
+    return `${identity}:fingerprint:${fingerprint}`;
+  }
   if (options.mode !== 'app') return identity;
   if (!options.appId || !options.installationId) {
     throw new Error(

--- a/packages/code/src/github.ts
+++ b/packages/code/src/github.ts
@@ -199,6 +199,22 @@ export function gitHubCredentialEnvironment(
   };
 }
 
+export function gitHubAuthenticationPolicyIdentity(options: {
+  mode?: 'app' | 'token';
+  host: string;
+  appId?: string;
+  installationId?: string;
+}): string {
+  const identity = `github-auth:${options.mode ?? 'none'}:${options.host}`;
+  if (options.mode !== 'app') return identity;
+  if (!options.appId || !options.installationId) {
+    throw new Error(
+      'GitHub App policy identity requires an App and installation ID',
+    );
+  }
+  return `${identity}:app:${options.appId}:installation:${options.installationId}`;
+}
+
 export function wrapGitHubCredentialCommand(
   command: string,
   host = 'github.com',

--- a/packages/code/src/github.ts
+++ b/packages/code/src/github.ts
@@ -1,0 +1,185 @@
+import { createPrivateKey, sign } from 'node:crypto';
+import { lstat, readFile } from 'node:fs/promises';
+
+export const GITHUB_CREDENTIAL_ENV_NAME = 'LIBRECHAT_CODE_GITHUB_AUTHORIZATION';
+export const GITHUB_ALLOWED_DOMAINS = [
+  'github.com',
+  '*.github.com',
+  'api.github.com',
+  'lfs.github.com',
+] as const;
+
+export interface GitHubCredential {
+  value: string;
+  expiresAt?: Date;
+}
+
+export interface GitHubCredentialProvider {
+  getCredential(signal?: AbortSignal): Promise<GitHubCredential>;
+}
+
+export interface GitHubAppCredentialProviderOptions {
+  appId: string;
+  installationId: string;
+  privateKeyPath: string;
+  apiUrl?: string;
+  fetch?: typeof globalThis.fetch;
+  now?: () => Date;
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+function assertPositiveIdentifier(name: string, value: string): void {
+  if (!/^[1-9][0-9]*$/.test(value)) {
+    throw new Error(`${name} must be a positive decimal identifier`);
+  }
+}
+
+async function readPrivateKey(path: string): Promise<string> {
+  const metadata = await lstat(path);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    throw new Error('GitHub App private key must be a regular file');
+  }
+  if (process.platform !== 'win32' && (metadata.mode & 0o077) !== 0) {
+    throw new Error(
+      'GitHub App private key must not be accessible by group or other users',
+    );
+  }
+  return await readFile(path, 'utf8');
+}
+
+function createAppJwt(appId: string, privateKey: string, now: Date): string {
+  const issuedAt = Math.floor(now.getTime() / 1000) - 60;
+  const header = base64UrlJson({ alg: 'RS256', typ: 'JWT' });
+  const payload = base64UrlJson({
+    iss: appId,
+    iat: issuedAt,
+    exp: issuedAt + 600,
+  });
+  const unsigned = `${header}.${payload}`;
+  const signature = sign(
+    'RSA-SHA256',
+    Buffer.from(unsigned),
+    createPrivateKey(privateKey),
+  );
+  return `${unsigned}.${signature.toString('base64url')}`;
+}
+
+export class GitHubAppCredentialProvider implements GitHubCredentialProvider {
+  private cached?: GitHubCredential;
+
+  constructor(private readonly options: GitHubAppCredentialProviderOptions) {
+    assertPositiveIdentifier('GitHub App ID', options.appId);
+    assertPositiveIdentifier(
+      'GitHub App installation ID',
+      options.installationId,
+    );
+    if (options.apiUrl != null) {
+      const apiUrl = new URL(options.apiUrl);
+      if (apiUrl.protocol !== 'https:' || apiUrl.username || apiUrl.password) {
+        throw new Error(
+          'GitHub API URL must be an HTTPS URL without credentials',
+        );
+      }
+    }
+  }
+
+  async getCredential(signal?: AbortSignal): Promise<GitHubCredential> {
+    const now = (this.options.now ?? (() => new Date()))();
+    if (
+      this.cached?.expiresAt != null &&
+      this.cached.expiresAt.getTime() - now.getTime() > 5 * 60_000
+    ) {
+      return this.cached;
+    }
+    const privateKey = await readPrivateKey(this.options.privateKeyPath);
+    const jwt = createAppJwt(this.options.appId, privateKey, now);
+    const apiUrl = (this.options.apiUrl ?? 'https://api.github.com').replace(
+      /\/+$/,
+      '',
+    );
+    const request = this.options.fetch ?? globalThis.fetch;
+    const response = await request(
+      `${apiUrl}/app/installations/${this.options.installationId}/access_tokens`,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${jwt}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        signal,
+      },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `GitHub App token request failed with status ${response.status}`,
+      );
+    }
+    const body = (await response.json()) as {
+      token?: unknown;
+      expires_at?: unknown;
+    };
+    if (
+      typeof body.token !== 'string' ||
+      body.token.length < 20 ||
+      typeof body.expires_at !== 'string'
+    ) {
+      throw new Error('GitHub App token response is invalid');
+    }
+    const expiresAt = new Date(body.expires_at);
+    if (
+      !Number.isFinite(expiresAt.getTime()) ||
+      expiresAt.getTime() <= now.getTime()
+    ) {
+      throw new Error('GitHub App token expiry is invalid');
+    }
+    this.cached = { value: body.token, expiresAt };
+    return this.cached;
+  }
+}
+
+export class StaticGitHubCredentialProvider implements GitHubCredentialProvider {
+  constructor(private readonly token: string) {
+    if (token.trim().length < 20 || /[\0\r\n]/.test(token)) {
+      throw new Error('GitHub token is invalid');
+    }
+  }
+
+  async getCredential(): Promise<GitHubCredential> {
+    return { value: this.token };
+  }
+}
+
+export function gitHubCredentialEnvironment(
+  credential: GitHubCredential,
+): Record<string, string> {
+  return {
+    [GITHUB_CREDENTIAL_ENV_NAME]: `Authorization: Bearer ${credential.value}`,
+  };
+}
+
+export function wrapGitHubCredentialCommand(
+  command: string,
+  host = 'github.com',
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const key = `http.https://${host}/.extraheader`;
+  if (platform === 'win32') {
+    return [
+      'set "GIT_CONFIG_GLOBAL=NUL"',
+      'set "GIT_CONFIG_NOSYSTEM=1"',
+      `set "GIT_CONFIG_PARAMETERS='http.proxyAuthMethod=basic' '${key}=Authorization: Bearer %${GITHUB_CREDENTIAL_ENV_NAME}%'"`,
+      `set "${GITHUB_CREDENTIAL_ENV_NAME}="`,
+      command,
+    ].join(' && ');
+  }
+  return [
+    'export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1',
+    `export GIT_CONFIG_PARAMETERS="'http.proxyAuthMethod=basic' '${key}=Authorization: Bearer \${${GITHUB_CREDENTIAL_ENV_NAME}}'"`,
+    `unset ${GITHUB_CREDENTIAL_ENV_NAME}`,
+    command,
+  ].join(';\n');
+}

--- a/packages/code/src/github.ts
+++ b/packages/code/src/github.ts
@@ -157,7 +157,7 @@ export function gitHubCredentialEnvironment(
   credential: GitHubCredential,
 ): Record<string, string> {
   return {
-    [GITHUB_CREDENTIAL_ENV_NAME]: `Authorization: Bearer ${credential.value}`,
+    [GITHUB_CREDENTIAL_ENV_NAME]: credential.value,
   };
 }
 

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -6,4 +6,5 @@ export * from './runtime.js';
 export * from './workspace.js';
 export * from './workspace-runtime.js';
 export * from './native-sandbox.js';
+export * from './github.js';
 export * from './worker.js';

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -33,6 +33,7 @@ function fakeManager(
     dependencyErrors?: string[];
     beforeWrap?: () => Promise<void>;
     appendGitSafeDirectory?: boolean;
+    inheritedGitEnvironment?: Record<string, string>;
   } = {},
 ) {
   let config: SandboxRuntimeConfig | undefined;
@@ -60,6 +61,7 @@ function fakeManager(
       if (options.appendGitSafeDirectory) {
         const index = Number(ambientGitEnvironment.GIT_CONFIG_COUNT ?? '0');
         gitEnvironment = {
+          ...(options.inheritedGitEnvironment ?? {}),
           GIT_CONFIG_COUNT: String(index + 1),
           [`GIT_CONFIG_KEY_${index}`]: 'safe.directory',
           [`GIT_CONFIG_VALUE_${index}`]: '/workspace',
@@ -286,7 +288,14 @@ test('isolates Git from host-level global and system configuration', async (t) =
 test('restores trusted Git LFS filters without reading host Git configuration', async (t) => {
   const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
   t.after(() => rm(root, { recursive: true, force: true }));
-  const fake = fakeManager({ appendGitSafeDirectory: true });
+  const fake = fakeManager({
+    appendGitSafeDirectory: true,
+    inheritedGitEnvironment: {
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'include.path',
+      GIT_CONFIG_VALUE_0: '/untrusted/host-config',
+    },
+  });
   const sandbox = new NativeSrtWorkspaceCommandSandbox({
     workspaceRoot: root,
     environment: {
@@ -302,12 +311,12 @@ test('restores trusted Git LFS filters without reading host Git configuration', 
     ...request,
     maxOutputBytes: 256,
     command:
-      'printf "%s|%s|%s|%s|%s" "$(git config --get filter.lfs.clean)" "$(git config --get filter.lfs.smudge)" "$(git config --get filter.lfs.process)" "$(git config --get filter.lfs.required)" "$(git config --get safe.directory)"',
+      'printf "%s|%s|%s|%s|%s|%s" "$(git config --get filter.lfs.clean)" "$(git config --get filter.lfs.smudge)" "$(git config --get filter.lfs.process)" "$(git config --get filter.lfs.required)" "$(git config --get safe.directory)" "$(git config --get include.path)"',
   });
 
   assert.equal(
     result.stdout,
-    'git-lfs clean -- %f|git-lfs smudge -- %f|git-lfs filter-process|true|/workspace',
+    'git-lfs clean -- %f|git-lfs smudge -- %f|git-lfs filter-process|true|/workspace|',
   );
   assert.equal(fake.gitLfsRequiredSeenDuringWrap, 'true');
   const denied = fake.config?.credentials?.envVars?.map(({ name }) => name);

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -273,6 +273,12 @@ test('restores trusted Git LFS filters without reading host Git configuration', 
   const fake = fakeManager();
   const sandbox = new NativeSrtWorkspaceCommandSandbox({
     workspaceRoot: root,
+    environment: {
+      ...process.env,
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'include.path',
+      GIT_CONFIG_VALUE_0: '/untrusted/host-config',
+    },
     manager: fake.manager,
   });
 
@@ -288,6 +294,10 @@ test('restores trusted Git LFS filters without reading host Git configuration', 
     'git-lfs clean -- %f|git-lfs smudge -- %f|git-lfs filter-process|true',
   );
   assert.equal(fake.gitLfsRequiredSeenDuringWrap, 'true');
+  const denied = fake.config?.credentials?.envVars?.map(({ name }) => name);
+  assert.ok(!denied?.includes('GIT_CONFIG_COUNT'));
+  assert.ok(!denied?.includes('GIT_CONFIG_KEY_0'));
+  assert.ok(!denied?.includes('GIT_CONFIG_VALUE_0'));
 });
 
 test('filters environment names case-insensitively only on Windows', async (t) => {

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -337,6 +337,19 @@ test('filters environment names case-insensitively only on Windows', async (t) =
       Path: 'C:\\Windows\\System32',
       LC_API_TOKEN: 'secret',
       librechat_code_worker_token: 'secret',
+      librechat_code_github_authorization: 'secret',
+      git_config_count: '1',
+    },
+    maskedEnvironment: {
+      variables: [
+        {
+          name: 'LIBRECHAT_CODE_GITHUB_AUTHORIZATION',
+          injectHosts: ['github.com'],
+        },
+      ],
+      async resolve() {
+        return {};
+      },
     },
     manager: fake.manager,
   });
@@ -347,6 +360,8 @@ test('filters environment names case-insensitively only on Windows', async (t) =
   assert.ok(!denied?.includes('Path'));
   assert.ok(!denied?.includes('LC_API_TOKEN'));
   assert.ok(denied?.includes('librechat_code_worker_token'));
+  assert.ok(!denied?.includes('librechat_code_github_authorization'));
+  assert.ok(!denied?.includes('git_config_count'));
 });
 
 test('fails closed when the configured POSIX shell is unavailable', async (t) => {

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -32,6 +32,7 @@ function fakeManager(
   options: {
     dependencyErrors?: string[];
     beforeWrap?: () => Promise<void>;
+    appendGitSafeDirectory?: boolean;
   } = {},
 ) {
   let config: SandboxRuntimeConfig | undefined;
@@ -50,10 +51,22 @@ function fakeManager(
       await options.beforeWrap?.();
       credentialSeenDuringWrap = process.env.LIBRECHAT_CODE_TEST_CREDENTIAL;
       gitLfsRequiredSeenDuringWrap = process.env.GIT_CONFIG_VALUE_3;
+      const gitEnvironment = Object.fromEntries(
+        Object.entries(process.env).filter(
+          ([name, value]) => name.startsWith('GIT_CONFIG_') && value != null,
+        ),
+      );
+      if (options.appendGitSafeDirectory) {
+        const index = Number(gitEnvironment.GIT_CONFIG_COUNT ?? '0');
+        gitEnvironment.GIT_CONFIG_COUNT = String(index + 1);
+        gitEnvironment[`GIT_CONFIG_KEY_${index}`] = 'safe.directory';
+        gitEnvironment[`GIT_CONFIG_VALUE_${index}`] = '/workspace';
+      }
       return {
         argv: ['/bin/bash', '-c', command],
         env: {
           PATH: process.env.PATH,
+          ...gitEnvironment,
           ...(credentialSeenDuringWrap
             ? {
                 LIBRECHAT_CODE_TEST_CREDENTIAL:
@@ -270,7 +283,7 @@ test('isolates Git from host-level global and system configuration', async (t) =
 test('restores trusted Git LFS filters without reading host Git configuration', async (t) => {
   const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
   t.after(() => rm(root, { recursive: true, force: true }));
-  const fake = fakeManager();
+  const fake = fakeManager({ appendGitSafeDirectory: true });
   const sandbox = new NativeSrtWorkspaceCommandSandbox({
     workspaceRoot: root,
     environment: {
@@ -286,12 +299,12 @@ test('restores trusted Git LFS filters without reading host Git configuration', 
     ...request,
     maxOutputBytes: 256,
     command:
-      'printf "%s|%s|%s|%s" "$(git config --get filter.lfs.clean)" "$(git config --get filter.lfs.smudge)" "$(git config --get filter.lfs.process)" "$(git config --get filter.lfs.required)"',
+      'printf "%s|%s|%s|%s|%s" "$(git config --get filter.lfs.clean)" "$(git config --get filter.lfs.smudge)" "$(git config --get filter.lfs.process)" "$(git config --get filter.lfs.required)" "$(git config --get safe.directory)"',
   });
 
   assert.equal(
     result.stdout,
-    'git-lfs clean -- %f|git-lfs smudge -- %f|git-lfs filter-process|true',
+    'git-lfs clean -- %f|git-lfs smudge -- %f|git-lfs filter-process|true|/workspace',
   );
   assert.equal(fake.gitLfsRequiredSeenDuringWrap, 'true');
   const denied = fake.config?.credentials?.envVars?.map(({ name }) => name);

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -37,6 +37,7 @@ function fakeManager(
   let config: SandboxRuntimeConfig | undefined;
   let reset = false;
   let credentialSeenDuringWrap: string | undefined;
+  let gitLfsRequiredSeenDuringWrap: string | undefined;
   const manager = {
     isSupportedPlatform: () => true,
     async checkDependenciesAsync() {
@@ -48,6 +49,7 @@ function fakeManager(
     async wrapWithSandboxArgv(command: string) {
       await options.beforeWrap?.();
       credentialSeenDuringWrap = process.env.LIBRECHAT_CODE_TEST_CREDENTIAL;
+      gitLfsRequiredSeenDuringWrap = process.env.GIT_CONFIG_VALUE_3;
       return {
         argv: ['/bin/bash', '-c', command],
         env: {
@@ -79,6 +81,9 @@ function fakeManager(
     },
     get credentialSeenDuringWrap() {
       return credentialSeenDuringWrap;
+    },
+    get gitLfsRequiredSeenDuringWrap() {
+      return gitLfsRequiredSeenDuringWrap;
     },
   };
 }
@@ -265,9 +270,10 @@ test('isolates Git from host-level global and system configuration', async (t) =
 test('restores trusted Git LFS filters without reading host Git configuration', async (t) => {
   const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
   t.after(() => rm(root, { recursive: true, force: true }));
+  const fake = fakeManager();
   const sandbox = new NativeSrtWorkspaceCommandSandbox({
     workspaceRoot: root,
-    manager: fakeManager().manager,
+    manager: fake.manager,
   });
 
   const result = await sandbox.execute({
@@ -281,6 +287,7 @@ test('restores trusted Git LFS filters without reading host Git configuration', 
     result.stdout,
     'git-lfs clean -- %f|git-lfs smudge -- %f|git-lfs filter-process|true',
   );
+  assert.equal(fake.gitLfsRequiredSeenDuringWrap, 'true');
 });
 
 test('filters environment names case-insensitively only on Windows', async (t) => {

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -31,6 +31,7 @@ const request = {
 function fakeManager(options: { dependencyErrors?: string[] } = {}) {
   let config: SandboxRuntimeConfig | undefined;
   let reset = false;
+  let credentialSeenDuringWrap: string | undefined;
   const manager = {
     isSupportedPlatform: () => true,
     async checkDependenciesAsync() {
@@ -40,9 +41,18 @@ function fakeManager(options: { dependencyErrors?: string[] } = {}) {
       config = value;
     },
     async wrapWithSandboxArgv(command: string) {
+      credentialSeenDuringWrap = process.env.LIBRECHAT_CODE_TEST_CREDENTIAL;
       return {
         argv: ['/bin/bash', '-c', command],
-        env: { PATH: process.env.PATH },
+        env: {
+          PATH: process.env.PATH,
+          ...(credentialSeenDuringWrap
+            ? {
+                LIBRECHAT_CODE_TEST_CREDENTIAL:
+                  'Authorization: Bearer srt-sentinel',
+              }
+            : {}),
+        },
       };
     },
     annotateStderrWithSandboxFailures(_commandId: string, stderr: string) {
@@ -60,6 +70,9 @@ function fakeManager(options: { dependencyErrors?: string[] } = {}) {
     },
     get reset() {
       return reset;
+    },
+    get credentialSeenDuringWrap() {
+      return credentialSeenDuringWrap;
     },
   };
 }
@@ -104,6 +117,74 @@ test('initializes SRT with a default-deny network and scrubbed worker credential
   assert.ok(denied?.includes('lc_api_token'));
   await sandbox.close();
   assert.equal(fake.reset, true);
+});
+
+test('masks a host credential for only its injection host and restores the parent environment', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const fake = fakeManager();
+  const original = process.env.LIBRECHAT_CODE_TEST_CREDENTIAL;
+  delete process.env.LIBRECHAT_CODE_TEST_CREDENTIAL;
+  t.after(() => {
+    if (original === undefined)
+      delete process.env.LIBRECHAT_CODE_TEST_CREDENTIAL;
+    else process.env.LIBRECHAT_CODE_TEST_CREDENTIAL = original;
+  });
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    allowedDomains: ['github.com'],
+    maskedEnvironment: {
+      variables: [
+        {
+          name: 'LIBRECHAT_CODE_TEST_CREDENTIAL',
+          extract: '^Authorization: Bearer (.+)$',
+          injectHosts: ['github.com'],
+        },
+      ],
+      async resolve() {
+        return {
+          LIBRECHAT_CODE_TEST_CREDENTIAL: 'Authorization: Bearer real-secret',
+        };
+      },
+    },
+    manager: fake.manager,
+  });
+
+  const result = await sandbox.execute({
+    ...request,
+    command: 'printf %s "$LIBRECHAT_CODE_TEST_CREDENTIAL"',
+  });
+
+  assert.equal(
+    fake.credentialSeenDuringWrap,
+    'Authorization: Bearer real-secret',
+  );
+  assert.equal(result.stdout, 'Authorization: Bearer srt-sentinel');
+  assert.equal(process.env.LIBRECHAT_CODE_TEST_CREDENTIAL, undefined);
+  assert.deepEqual(fake.config?.network.tlsTerminate, {});
+  assert.deepEqual(fake.config?.credentials?.envVars?.at(-1), {
+    name: 'LIBRECHAT_CODE_TEST_CREDENTIAL',
+    extract: '^Authorization: Bearer (.+)$',
+    injectHosts: ['github.com'],
+    mode: 'mask',
+    onExtractNoMatch: 'error',
+  });
+});
+
+test('isolates Git from host-level global and system configuration', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fakeManager().manager,
+  });
+
+  const result = await sandbox.execute({
+    ...request,
+    command: 'printf "%s|%s" "$GIT_CONFIG_GLOBAL" "$GIT_CONFIG_NOSYSTEM"',
+  });
+
+  assert.equal(result.stdout, '/dev/null|1');
 });
 
 test('filters environment names case-insensitively only on Windows', async (t) => {

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -28,7 +28,12 @@ const request = {
   maxOutputBytes: 64,
 };
 
-function fakeManager(options: { dependencyErrors?: string[] } = {}) {
+function fakeManager(
+  options: {
+    dependencyErrors?: string[];
+    beforeWrap?: () => Promise<void>;
+  } = {},
+) {
   let config: SandboxRuntimeConfig | undefined;
   let reset = false;
   let credentialSeenDuringWrap: string | undefined;
@@ -41,6 +46,7 @@ function fakeManager(options: { dependencyErrors?: string[] } = {}) {
       config = value;
     },
     async wrapWithSandboxArgv(command: string) {
+      await options.beforeWrap?.();
       credentialSeenDuringWrap = process.env.LIBRECHAT_CODE_TEST_CREDENTIAL;
       return {
         argv: ['/bin/bash', '-c', command],
@@ -169,6 +175,75 @@ test('masks a host credential for only its injection host and restores the paren
     mode: 'mask',
     onExtractNoMatch: 'error',
   });
+});
+
+test('serializes credential handoff across concurrent sandbox instances', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const original = process.env.LIBRECHAT_CODE_TEST_CREDENTIAL;
+  delete process.env.LIBRECHAT_CODE_TEST_CREDENTIAL;
+  t.after(() => {
+    if (original === undefined)
+      delete process.env.LIBRECHAT_CODE_TEST_CREDENTIAL;
+    else process.env.LIBRECHAT_CODE_TEST_CREDENTIAL = original;
+  });
+  let firstEntered!: () => void;
+  const firstEnteredPromise = new Promise<void>((resolve) => {
+    firstEntered = resolve;
+  });
+  let releaseFirst!: () => void;
+  const firstGate = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  let secondEntered = false;
+  const first = fakeManager({
+    async beforeWrap() {
+      firstEntered();
+      await firstGate;
+    },
+  });
+  const second = fakeManager({
+    async beforeWrap() {
+      secondEntered = true;
+    },
+  });
+  const sandbox = (
+    manager: ReturnType<typeof fakeManager>['manager'],
+    value: string,
+  ) =>
+    new NativeSrtWorkspaceCommandSandbox({
+      workspaceRoot: root,
+      allowedDomains: ['github.com'],
+      maskedEnvironment: {
+        variables: [
+          {
+            name: 'LIBRECHAT_CODE_TEST_CREDENTIAL',
+            injectHosts: ['github.com'],
+          },
+        ],
+        async resolve() {
+          return { LIBRECHAT_CODE_TEST_CREDENTIAL: value };
+        },
+      },
+      manager,
+    });
+
+  const firstExecution = sandbox(first.manager, 'first-secret').execute(
+    request,
+  );
+  await firstEnteredPromise;
+  const secondExecution = sandbox(second.manager, 'second-secret').execute(
+    request,
+  );
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(secondEntered, false);
+  releaseFirst();
+  await firstExecution;
+  await secondExecution;
+
+  assert.equal(first.credentialSeenDuringWrap, 'first-secret');
+  assert.equal(second.credentialSeenDuringWrap, 'second-secret');
+  assert.equal(process.env.LIBRECHAT_CODE_TEST_CREDENTIAL, undefined);
 });
 
 test('isolates Git from host-level global and system configuration', async (t) => {

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -51,16 +51,19 @@ function fakeManager(
       await options.beforeWrap?.();
       credentialSeenDuringWrap = process.env.LIBRECHAT_CODE_TEST_CREDENTIAL;
       gitLfsRequiredSeenDuringWrap = process.env.GIT_CONFIG_VALUE_3;
-      const gitEnvironment = Object.fromEntries(
+      const ambientGitEnvironment = Object.fromEntries(
         Object.entries(process.env).filter(
           ([name, value]) => name.startsWith('GIT_CONFIG_') && value != null,
         ),
       );
+      let gitEnvironment = ambientGitEnvironment;
       if (options.appendGitSafeDirectory) {
-        const index = Number(gitEnvironment.GIT_CONFIG_COUNT ?? '0');
-        gitEnvironment.GIT_CONFIG_COUNT = String(index + 1);
-        gitEnvironment[`GIT_CONFIG_KEY_${index}`] = 'safe.directory';
-        gitEnvironment[`GIT_CONFIG_VALUE_${index}`] = '/workspace';
+        const index = Number(ambientGitEnvironment.GIT_CONFIG_COUNT ?? '0');
+        gitEnvironment = {
+          GIT_CONFIG_COUNT: String(index + 1),
+          [`GIT_CONFIG_KEY_${index}`]: 'safe.directory',
+          [`GIT_CONFIG_VALUE_${index}`]: '/workspace',
+        };
       }
       return {
         argv: ['/bin/bash', '-c', command],

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -262,6 +262,27 @@ test('isolates Git from host-level global and system configuration', async (t) =
   assert.equal(result.stdout, '/dev/null|1');
 });
 
+test('restores trusted Git LFS filters without reading host Git configuration', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fakeManager().manager,
+  });
+
+  const result = await sandbox.execute({
+    ...request,
+    maxOutputBytes: 256,
+    command:
+      'printf "%s|%s|%s|%s" "$(git config --get filter.lfs.clean)" "$(git config --get filter.lfs.smudge)" "$(git config --get filter.lfs.process)" "$(git config --get filter.lfs.required)"',
+  });
+
+  assert.equal(
+    result.stdout,
+    'git-lfs clean -- %f|git-lfs smudge -- %f|git-lfs filter-process|true',
+  );
+});
+
 test('filters environment names case-insensitively only on Windows', async (t) => {
   const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
   t.after(() => rm(root, { recursive: true, force: true }));

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -48,6 +48,8 @@ const SAFE_CHILD_ENV_NAMES = new Set([
   'USER',
 ]);
 
+let hostEnvironmentMutationQueue: Promise<void> = Promise.resolve();
+
 interface NativeSandboxManager {
   isSupportedPlatform(): boolean;
   checkDependenciesAsync(): Promise<{ warnings: string[]; errors: string[] }>;
@@ -355,6 +357,12 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
     values: Record<string, string>,
     action: () => Promise<T>,
   ): Promise<T> {
+    const previousMutation = hostEnvironmentMutationQueue;
+    let releaseMutation!: () => void;
+    hostEnvironmentMutationQueue = new Promise<void>((resolve) => {
+      releaseMutation = resolve;
+    });
+    await previousMutation;
     const previous = new Map<string, string | undefined>();
     try {
       for (const [name, value] of Object.entries(values)) {
@@ -367,6 +375,7 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
         if (value === undefined) delete process.env[name];
         else process.env[name] = value;
       }
+      releaseMutation();
     }
   }
 

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -50,6 +50,18 @@ const SAFE_CHILD_ENV_NAMES = new Set([
 
 let hostEnvironmentMutationQueue: Promise<void> = Promise.resolve();
 
+const TRUSTED_GIT_ENVIRONMENT = {
+  GIT_CONFIG_COUNT: '4',
+  GIT_CONFIG_KEY_0: 'filter.lfs.clean',
+  GIT_CONFIG_VALUE_0: 'git-lfs clean -- %f',
+  GIT_CONFIG_KEY_1: 'filter.lfs.smudge',
+  GIT_CONFIG_VALUE_1: 'git-lfs smudge -- %f',
+  GIT_CONFIG_KEY_2: 'filter.lfs.process',
+  GIT_CONFIG_VALUE_2: 'git-lfs filter-process',
+  GIT_CONFIG_KEY_3: 'filter.lfs.required',
+  GIT_CONFIG_VALUE_3: 'true',
+} as const;
+
 interface NativeSandboxManager {
   isSupportedPlatform(): boolean;
   checkDependenciesAsync(): Promise<{ warnings: string[]; errors: string[] }>;
@@ -401,6 +413,7 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
               GIT_CONFIG_GLOBAL:
                 this.platform === 'win32' ? 'NUL' : '/dev/null',
               GIT_CONFIG_NOSYSTEM: '1',
+              ...TRUSTED_GIT_ENVIRONMENT,
             },
             detached: this.platform !== 'win32',
             shell: false,

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -417,7 +417,6 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
               GIT_CONFIG_GLOBAL:
                 this.platform === 'win32' ? 'NUL' : '/dev/null',
               GIT_CONFIG_NOSYSTEM: '1',
-              ...TRUSTED_GIT_ENVIRONMENT,
             },
             detached: this.platform !== 'win32',
             shell: false,

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -331,7 +331,10 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
       const credentialEnvironment =
         await this.options.maskedEnvironment?.resolve(signal);
       wrapped = await this.withTemporaryHostEnvironment(
-        credentialEnvironment ?? {},
+        {
+          ...TRUSTED_GIT_ENVIRONMENT,
+          ...(credentialEnvironment ?? {}),
+        },
         () =>
           this.manager.wrapWithSandboxArgv(
             sandboxedCommand,

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -61,6 +61,10 @@ const TRUSTED_GIT_ENVIRONMENT = {
   GIT_CONFIG_KEY_3: 'filter.lfs.required',
   GIT_CONFIG_VALUE_3: 'true',
 } as const;
+const {
+  GIT_CONFIG_COUNT: TRUSTED_GIT_CONFIG_COUNT,
+  ...TRUSTED_GIT_CONFIG_ENTRIES
+} = TRUSTED_GIT_ENVIRONMENT;
 
 interface NativeSandboxManager {
   isSupportedPlatform(): boolean;
@@ -413,8 +417,10 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
           child = this.spawnCommand(wrapped.argv[0], wrapped.argv.slice(1), {
             cwd,
             env: {
-              ...TRUSTED_GIT_ENVIRONMENT,
               ...wrapped.env,
+              ...TRUSTED_GIT_CONFIG_ENTRIES,
+              GIT_CONFIG_COUNT:
+                wrapped.env.GIT_CONFIG_COUNT ?? TRUSTED_GIT_CONFIG_COUNT,
               GIT_CONFIG_GLOBAL:
                 this.platform === 'win32' ? 'NUL' : '/dev/null',
               GIT_CONFIG_NOSYSTEM: '1',

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -413,6 +413,7 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
           child = this.spawnCommand(wrapped.argv[0], wrapped.argv.slice(1), {
             cwd,
             env: {
+              ...TRUSTED_GIT_ENVIRONMENT,
               ...wrapped.env,
               GIT_CONFIG_GLOBAL:
                 this.platform === 'win32' ? 'NUL' : '/dev/null',

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -264,6 +264,7 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
           ...safeEnvironmentNames(this.environment, this.platform)
             .filter(
               (name) =>
+                !Object.hasOwn(TRUSTED_GIT_ENVIRONMENT, name) &&
                 !this.options.maskedEnvironment?.variables.some(
                   (variable) => variable.name === name,
                 ),

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -163,6 +163,13 @@ function safeEnvironmentNames(
     .sort();
 }
 
+function normalizedEnvironmentName(
+  name: string,
+  platform: NodeJS.Platform,
+): string {
+  return platform === 'win32' ? name.toUpperCase() : name;
+}
+
 export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox {
   readonly mutationFailuresAreAtomic = true as const;
   private readonly manager: NativeSandboxManager;
@@ -266,13 +273,22 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
         })),
         envVars: [
           ...safeEnvironmentNames(this.environment, this.platform)
-            .filter(
-              (name) =>
-                !Object.hasOwn(TRUSTED_GIT_ENVIRONMENT, name) &&
+            .filter((name) => {
+              const normalized = normalizedEnvironmentName(
+                name,
+                this.platform,
+              );
+              return (
+                !Object.hasOwn(TRUSTED_GIT_ENVIRONMENT, normalized) &&
                 !this.options.maskedEnvironment?.variables.some(
-                  (variable) => variable.name === name,
-                ),
-            )
+                  (variable) =>
+                    normalizedEnvironmentName(
+                      variable.name,
+                      this.platform,
+                    ) === normalized,
+                )
+              );
+            })
             .map((name) => ({ name, mode: 'deny' as const })),
           ...(this.options.maskedEnvironment?.variables.map((variable) => ({
             ...variable,

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -83,6 +83,16 @@ export interface NativeSrtWorkspaceCommandSandboxOptions {
   platform?: NodeJS.Platform;
   /** Trusted shell path used by SRT on POSIX hosts. */
   shellPath?: string;
+  /** Host-owned credentials exposed only as SRT sentinels inside the sandbox. */
+  maskedEnvironment?: {
+    variables: Array<{
+      name: string;
+      injectHosts: string[];
+      extract?: string;
+    }>;
+    resolve(signal?: AbortSignal): Promise<Record<string, string>>;
+    wrapCommand?(command: string, platform: NodeJS.Platform): string;
+  };
 }
 
 function isWithin(root: string, candidate: string): boolean {
@@ -222,6 +232,7 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
         strictAllowlist: true,
         allowAllUnixSockets: false,
         allowLocalBinding: false,
+        ...(this.options.maskedEnvironment ? { tlsTerminate: {} } : {}),
       },
       filesystem: {
         denyRead: [home],
@@ -235,10 +246,21 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
           path,
           mode: 'deny' as const,
         })),
-        envVars: safeEnvironmentNames(this.environment, this.platform).map((name) => ({
-          name,
-          mode: 'deny' as const,
-        })),
+        envVars: [
+          ...safeEnvironmentNames(this.environment, this.platform)
+            .filter(
+              (name) =>
+                !this.options.maskedEnvironment?.variables.some(
+                  (variable) => variable.name === name,
+                ),
+            )
+            .map((name) => ({ name, mode: 'deny' as const })),
+          ...(this.options.maskedEnvironment?.variables.map((variable) => ({
+            ...variable,
+            mode: 'mask' as const,
+            ...(variable.extract ? { onExtractNoMatch: 'error' as const } : {}),
+          })) ?? []),
+        ],
       },
       allowAppleEvents: false,
       enableWeakerNestedSandbox: false,
@@ -282,19 +304,31 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
       );
     }
     const commandId = `librechat-code-${randomUUID()}`;
+    const sandboxedCommand = this.options.maskedEnvironment?.wrapCommand
+      ? this.options.maskedEnvironment.wrapCommand(
+          request.command,
+          this.platform,
+        )
+      : request.command;
     let wrapped: Awaited<
       ReturnType<NativeSandboxManager['wrapWithSandboxArgv']>
     >;
     try {
-      wrapped = await this.manager.wrapWithSandboxArgv(
-        request.command,
-        this.platform === 'win32'
-          ? undefined
-          : this.options.shellPath ?? '/bin/bash',
-        undefined,
-        signal,
-        cwd,
-        { commandId, commandText: request.command },
+      const credentialEnvironment =
+        await this.options.maskedEnvironment?.resolve(signal);
+      wrapped = await this.withTemporaryHostEnvironment(
+        credentialEnvironment ?? {},
+        () =>
+          this.manager.wrapWithSandboxArgv(
+            sandboxedCommand,
+            this.platform === 'win32'
+              ? undefined
+              : (this.options.shellPath ?? '/bin/bash'),
+            undefined,
+            signal,
+            cwd,
+            { commandId, commandText: request.command },
+          ),
       );
     } catch (error) {
       if (signal?.aborted) {
@@ -317,6 +351,25 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
     return await this.runWrapped(request, wrapped, cwd, commandId, signal);
   }
 
+  private async withTemporaryHostEnvironment<T>(
+    values: Record<string, string>,
+    action: () => Promise<T>,
+  ): Promise<T> {
+    const previous = new Map<string, string | undefined>();
+    try {
+      for (const [name, value] of Object.entries(values)) {
+        previous.set(name, process.env[name]);
+        process.env[name] = value;
+      }
+      return await action();
+    } finally {
+      for (const [name, value] of previous) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+    }
+  }
+
   private async runWrapped(
     request: WorkspaceExecuteCommandRequest,
     wrapped: { argv: string[]; env: NodeJS.ProcessEnv },
@@ -334,7 +387,12 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
         try {
           child = this.spawnCommand(wrapped.argv[0], wrapped.argv.slice(1), {
             cwd,
-            env: wrapped.env,
+            env: {
+              ...wrapped.env,
+              GIT_CONFIG_GLOBAL:
+                this.platform === 'win32' ? 'NUL' : '/dev/null',
+              GIT_CONFIG_NOSYSTEM: '1',
+            },
             detached: this.platform !== 'win32',
             shell: false,
             windowsHide: true,
@@ -467,7 +525,10 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
   }
 
   private protocolExitCode(code: number | null): number {
-    return Number.isSafeInteger(code) && code != null && code >= 0 && code <= 255
+    return Number.isSafeInteger(code) &&
+      code != null &&
+      code >= 0 &&
+      code <= 255
       ? code
       : 1;
   }


### PR DESCRIPTION
## Summary

I added worker-local GitHub authentication for native BYOM coding environments without placing real credentials in the sandbox, repository, remote URL, or Git config.

- Add a provider-neutral GitHub credential module with GitHub App installation-token minting, five-minute refresh margin, and PAT fallback.
- Require owner-only regular private-key files and protect them alongside the worker identity and mutation quarantine.
- Mask the bearer token with Anthropic SRT and substitute it only through TLS-terminated requests to the configured GitHub host.
- Compose the masked sentinel with SRT-owned Git configuration without colliding with safe-directory entries.
- Ignore host system/global Git config so credential helpers, aliases, and filters do not bleed into agent commands.
- Add GitHub domains to egress only when authentication is configured and bind authentication mode/host into the worker policy digest.
- Document GitHub App, PAT fallback, and GitHub Enterprise configuration.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- Ran `npm test` in `packages/code`: 258 passed, 5 platform-dependent skips.
- Ran a real macOS SRT credential test and confirmed the sandbox sees only an SRT sentinel while the real token is absent from output.
- Ran a real macOS SRT Git lifecycle: initialized a repository and bare remote, committed with an agent identity, pushed, and verified matching local/remote commit hashes.

### **Test Configuration**:

- macOS native SRT
- Node.js 24.16.0
- Non-networked local bare Git remote for mutation verification

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes