### PR TITLE
fix: arbitrate bridge settlement and dispatch closure atomically

### DIFF
--- a/service/src/bridge/settlement-race.test.ts
+++ b/service/src/bridge/settlement-race.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import Redis from 'ioredis';
+import RedisMock from 'ioredis-mock';
+import { BRIDGE_PROTOCOL_VERSION } from '../../../packages/code/src/protocol';
+import type * as t from '../types';
+import { RedisBridgeStore } from './store';
+import type { CodeBridgeAssignment, CodeBridgeSettlement } from './store';
+
+function barrier(): { promise: Promise<void>; release: () => void } {
+  let release!: () => void;
+  const promise = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+// Optional real Redis run: use a test server. Keys are isolated per test and
+// cleaned up by prefix, with separate dispatcher and worker connections.
+const redisUrl = process.env.BRIDGE_TEST_REDIS_URL;
+for (const backend of ['mock', 'redis'] as const) {
+  const suite =
+    backend === 'redis' && (redisUrl == null || redisUrl === '')
+      ? describe.skip
+      : describe;
+  suite(`settlement/close arbitration (${backend})`, () => {
+    let redis: Redis;
+    let workerRedis: Redis;
+    let admin: Redis | undefined;
+    let prefix: string;
+    let store: RedisBridgeStore;
+    let worker: RedisBridgeStore;
+    let originalEval: Redis['eval'];
+    let originalGet: Redis['get'];
+    const incarnationId = 'incarnation-settlement-race';
+    const workerId = 'settlement-race';
+    const markerPattern =
+      'codeapi:bridge:v1:worker:settlement-race:workspace:*:quarantined';
+
+    beforeEach(() => {
+      prefix = `race-test:${randomUUID()}:`;
+      if (backend === 'redis') {
+        admin = new Redis(redisUrl!);
+        redis = new Redis(redisUrl!, { keyPrefix: prefix });
+        workerRedis = new Redis(redisUrl!, { keyPrefix: prefix });
+      } else {
+        redis = new RedisMock() as unknown as Redis;
+        workerRedis = redis;
+      }
+      store = new RedisBridgeStore(redis, 60, 100);
+      worker = new RedisBridgeStore(workerRedis, 60, 100);
+      originalEval = redis.eval.bind(redis) as Redis['eval'];
+      originalGet = redis.get.bind(redis) as Redis['get'];
+    });
+    afterEach(async () => {
+      if (admin) {
+        const keys = await admin.keys(`${prefix}*`);
+        if (keys.length) await admin.del(...keys);
+        admin.disconnect();
+        admin = undefined;
+      } else {
+        await redis.flushall();
+      }
+      redis.disconnect();
+      workerRedis.disconnect();
+    });
+    async function start(stateful = true): Promise<{
+      controller: AbortController;
+      completion: Promise<CodeBridgeSettlement>;
+      assignment: CodeBridgeAssignment;
+      finalizations: string[];
+    }> {
+      await store.register({
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        workerId,
+        incarnationId,
+        capabilities: {
+          statefulWorkspace: stateful,
+          sandboxProfile: 'nsjail',
+          runtimes: [],
+        },
+      });
+      const controller = new AbortController();
+      const finalizations: string[] = [];
+      const completion = store.dispatch({
+        workerId,
+        body: { language: 'bash' } as t.PayloadBody,
+        headers: {},
+        ...(stateful ? { runtimeSessionId: 'race-workspace' } : {}),
+        deadlineAtMs: Date.now() + 10_000,
+        signal: controller.signal,
+        finalize: async settlement => {
+          finalizations.push(settlement.status);
+          return settlement;
+        },
+      });
+      void completion.catch(() => undefined);
+      const assignment = (await worker.lease(workerId, incarnationId, 1_000))!;
+      expect(assignment).toBeDefined();
+      await worker.acknowledgeLease(
+        workerId,
+        incarnationId,
+        assignment.assignmentId,
+        assignment.generation,
+        assignment.leaseToken,
+      );
+      return { controller, completion, assignment, finalizations };
+    }
+    function result(assignment: CodeBridgeAssignment): CodeBridgeSettlement {
+      return {
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        incarnationId,
+        generation: assignment.generation,
+        leaseToken: assignment.leaseToken,
+        status: 'fulfilled' as const,
+        result: {
+          language: 'bash',
+          version: '5.2',
+          session_id: 'race-result',
+          files: [],
+        },
+      };
+    }
+    async function markers(): Promise<string[]> {
+      return admin
+        ? admin.keys(`${prefix}${markerPattern}`)
+        : redis.keys(markerPattern);
+    }
+    for (const stateful of [true, false]) {
+      test(`close rejects fulfillment already past preflight (stateful=${stateful})`, async () => {
+        const { controller, completion, assignment, finalizations } =
+          await start(stateful);
+        const entered = barrier();
+        const resume = barrier();
+        const workerEval = workerRedis.eval.bind(workerRedis);
+        workerRedis.eval = (async (...args: Parameters<Redis['eval']>) => {
+          if (
+            String(args[0]).includes(
+              'local existing = redis.call(\'GET\', KEYS[2])',
+            )
+          ) {
+            entered.release();
+            await resume.promise;
+          }
+          return workerEval(...args);
+        }) as Redis['eval'];
+        const settling = worker.settle(
+          workerId,
+          assignment.assignmentId,
+          result(assignment),
+        );
+        void settling.catch(() => undefined);
+        await entered.promise;
+        controller.abort();
+        try {
+          await expect(completion).rejects.toMatchObject({
+            code: 'ASSIGNMENT_EXPIRED',
+          });
+        } finally {
+          resume.release();
+        }
+        await expect(settling).rejects.toMatchObject({
+          code: 'ASSIGNMENT_EXPIRED',
+        });
+        expect(
+          await redis.get(
+            `codeapi:bridge:v1:assignment:${assignment.assignmentId}:settlement`,
+          ),
+        ).toBeNull();
+        expect(
+          await redis.exists(
+            `codeapi:bridge:v1:assignment:${assignment.assignmentId}:deadline`,
+          ),
+        ).toBe(0);
+        expect(finalizations).toEqual([]);
+        expect(await markers()).toHaveLength(stateful ? 1 : 0);
+        if (stateful) {
+          await worker.settle(workerId, assignment.assignmentId, {
+            ...result(assignment),
+            status: 'rejected',
+            error: 'not executed',
+          });
+          expect(await markers()).toHaveLength(0);
+        }
+      });
+    }
+    test('settlement wins before close and commits despite caller abort', async () => {
+      const { controller, completion, assignment, finalizations } =
+        await start();
+      const entered = barrier();
+      const resume = barrier();
+      redis.eval = (async (...args: Parameters<Redis['eval']>) => {
+        if (
+          String(args[0]).includes(
+            'local settlement = redis.call(\'GET\', KEYS[2])',
+          )
+        ) {
+          entered.release();
+          await resume.promise;
+        }
+        return originalEval(...args);
+      }) as Redis['eval'];
+      controller.abort();
+      await entered.promise;
+      try {
+        await worker.settle(
+          workerId,
+          assignment.assignmentId,
+          result(assignment),
+        );
+      } finally {
+        resume.release();
+      }
+      await expect(completion).resolves.toEqual(result(assignment));
+      expect(finalizations).toEqual(['fulfilled']);
+      expect(await markers()).toHaveLength(0);
+      await expect(
+        worker.settle(workerId, assignment.assignmentId, result(assignment)),
+      ).resolves.toBeUndefined();
+    });
+    for (const failure of ['abort', 'timeout', 'error'] as const) {
+      test(`a poll ${failure} still closes fulfillment`, async () => {
+        const entered = barrier();
+        let intercept = false;
+        redis.get = ((key: string) => {
+          if (intercept && key.endsWith(':settlement')) {
+            entered.release();
+            return failure === 'error'
+              ? Promise.reject(new Error('poll unavailable'))
+              : new Promise<never>(() => {});
+          }
+          return originalGet(key);
+        }) as Redis['get'];
+        const { controller, completion, assignment } = await start();
+        intercept = true;
+        await entered.promise;
+        if (failure === 'abort') controller.abort();
+        const messages = {
+          abort: 'deadline',
+          error: 'poll unavailable',
+          timeout: 'poll timed out',
+        };
+        await expect(completion).rejects.toThrow(messages[failure]);
+        redis.get = originalGet;
+        await expect(
+          worker.settle(workerId, assignment.assignmentId, result(assignment)),
+        ).rejects.toMatchObject({ code: 'ASSIGNMENT_EXPIRED' });
+        expect(await markers()).toHaveLength(1);
+      });
+    }
+    test('an unconfirmed close preserves the workspace fence', async () => {
+      const { controller, completion } = await start();
+      redis.eval = ((...args: Parameters<Redis['eval']>) => {
+        if (
+          String(args[0]).includes(
+            'local settlement = redis.call(\'GET\', KEYS[2])',
+          )
+        )
+          return new Promise<never>(() => {});
+        return originalEval(...args);
+      }) as Redis['eval'];
+      controller.abort();
+      await expect(completion).rejects.toThrow(
+        'Bridge settlement close timed out',
+      );
+      expect(await markers()).toHaveLength(1);
+      expect(
+        await redis.get('codeapi:bridge:v1:worker:settlement-race:lock'),
+      ).not.toBeNull();
+    });
+  });
+}

--- a/service/src/bridge/store.ts
+++ b/service/src/bridge/store.ts
@@ -796,12 +796,7 @@ export class RedisBridgeStore {
           args.finalize == null
             ? settlement
             : await args.finalize(settlement, registration);
-        await this.commitPendingWorkspace(
-          assignment,
-          settlement,
-          args.deadlineAtMs,
-          args.signal,
-        );
+        await this.commitPendingWorkspace(assignment, settlement);
         resultCommitted = true;
         return result;
       } catch (error) {
@@ -1450,22 +1445,30 @@ export class RedisBridgeStore {
     deadlineAtMs: number,
     signal: AbortSignal,
   ): Promise<CodeBridgeSettlement> {
-    while (!signal.aborted && Date.now() < deadlineAtMs) {
-      const raw = await boundedCommand(
-        this.redis.get(settlementKey(assignment.assignmentId)),
-        Math.max(
-          1,
-          Math.min(this.redisCommandTimeoutMs, deadlineAtMs - Date.now()),
-        ),
-        'Bridge settlement poll',
-        signal,
-      );
-      if (raw != null) return JSON.parse(raw) as CodeBridgeSettlement;
-      await delay(POLL_INTERVAL_MS, signal);
+    let pollError: unknown;
+    try {
+      while (!signal.aborted && Date.now() < deadlineAtMs) {
+        const raw = await boundedCommand(
+          this.redis.get(settlementKey(assignment.assignmentId)),
+          Math.max(
+            1,
+            Math.min(this.redisCommandTimeoutMs, deadlineAtMs - Date.now()),
+          ),
+          'Bridge settlement poll',
+          signal,
+        );
+        if (raw != null) return JSON.parse(raw) as CodeBridgeSettlement;
+        await delay(POLL_INTERVAL_MS, signal);
+      }
+    } catch (error) {
+      // A failed/aborted poll does not cancel Redis work. Arbitrate with
+      // settlement before returning an error, even when the caller is gone.
+      pollError = error;
     }
     const closeKeys = [
       assignmentKey(assignment.assignmentId),
       settlementKey(assignment.assignmentId),
+      assignmentDeadlineKey(assignment.assignmentId),
     ];
     if (assignment.runtimeSessionId !== undefined) {
       closeKeys.push(
@@ -1475,10 +1478,14 @@ export class RedisBridgeStore {
         ),
       );
     }
+    // The deadline key is also the fulfillment gate checked by settle().
+    // Keep acknowledged assignment metadata for late clean rejection recovery,
+    // but atomically revoke fulfillment when no settlement has won yet.
     const closeScript = [
       'local settlement = redis.call(\'GET\', KEYS[2])',
       'if settlement then return settlement end',
-      'if #KEYS == 3 and redis.call(\'GET\', KEYS[3]) == ARGV[1] then return nil end',
+      'redis.call(\'DEL\', KEYS[3])',
+      'if #KEYS == 4 and redis.call(\'GET\', KEYS[4]) == ARGV[1] then return nil end',
       'redis.call(\'DEL\', KEYS[1])',
       'return nil',
     ].join('\n');
@@ -1494,6 +1501,9 @@ export class RedisBridgeStore {
     );
     if (finalSettlement != null) {
       return JSON.parse(String(finalSettlement)) as CodeBridgeSettlement;
+    }
+    if (pollError != null && !signal.aborted && Date.now() < deadlineAtMs) {
+      throw pollError;
     }
     throw new BridgeStoreError(
       'ASSIGNMENT_EXPIRED',
@@ -1619,8 +1629,6 @@ export class RedisBridgeStore {
   private async commitPendingWorkspace(
     assignment: StoredAssignment,
     settlement: AnyCodeBridgeSettlement,
-    deadlineAtMs: number,
-    signal: AbortSignal,
   ): Promise<void> {
     if (
       assignment.runtimeSessionId === undefined ||
@@ -1646,12 +1654,10 @@ export class RedisBridgeStore {
           ),
           assignment.assignmentId,
         ),
-        Math.max(
-          1,
-          Math.min(this.redisCommandTimeoutMs, deadlineAtMs - Date.now()),
-        ),
+        // Once settlement wins, caller cancellation must not prevent its
+        // workspace commit. Redis availability still has a bounded budget.
+        this.redisCommandTimeoutMs,
         'Bridge workspace commit',
-        signal,
       ),
     );
     if (committed !== 1) {


### PR DESCRIPTION
I fixed a race where dispatch could report expiration while a worker subsequently committed fulfillment, leaving a stateful workspace fenced and making retries unsafe. Closes #87.

- Revoke the existing Redis fulfillment gate atomically when the final settlement read finds no winner.
- Route aborted and failed polls through the same close operation, retaining fences when Redis cannot confirm closure.
- Commit accepted workspace results with an independent bounded Redis timeout after caller cancellation.
- Preserve late clean-rejection recovery and idempotent settlement retries without changing the worker protocol or Redis key format.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Confirmed both core regression tests fail against unmodified main and pass with the fix.
- Passed the 54 existing bridge store tests and seven new race cases against ioredis-mock.
- Passed the seven new cases against a disposable Redis 8.4 server using separate dispatcher and worker connections: `BRIDGE_TEST_REDIS_URL=redis://127.0.0.1:16387 bun test src/bridge/settlement-race.test.ts` from `service`.
- Built the service successfully with `bun run build` (existing bundler warnings).
- Linted the new test file; the store file has pre-existing lint violations outside the changed code.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
