### PR TITLE
fix: preserve terminal bridge failures and recovery guidance

### DIFF
--- a/service/src/sandbox-backend/remote-bridge.test.ts
+++ b/service/src/sandbox-backend/remote-bridge.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 
-import type { SandboxExecuteContext, SandboxTransportRequest } from './types';
+import type { SandboxBackendErrorCode, SandboxExecuteContext, SandboxTransportRequest } from './types';
+import { SandboxBackendError } from './types';
+import { publicExecutionFailure } from '../utils';
 import type { RedisBridgeStore } from '../bridge/store';
 
 import { BridgeStoreError } from '../bridge/store';
@@ -70,6 +72,63 @@ describe('RemoteBridgeSandboxBackend', () => {
 
     await expect(backend.execute(request(), context())).rejects.toMatchObject({
       code: 'BRIDGE_WORKER_UNAUTHORIZED',
+    });
+  });
+
+  const failures = {
+    WORKER_OFFLINE: ['BRIDGE_WORKER_OFFLINE', true, 503, 'Code environment is offline'],
+    WORKER_UNAUTHORIZED: ['BRIDGE_WORKER_UNAUTHORIZED', false, 403, 'Code environment is not authorized for this tenant'],
+    WORKER_BUSY: ['BRIDGE_WORKER_BUSY', false, 409, 'Code environment is busy'],
+    ASSIGNMENT_EXPIRED: ['BRIDGE_DEADLINE_EXCEEDED', false, 504, 'Code environment execution timed out'],
+    ASSIGNMENT_FENCED: ['BRIDGE_ASSIGNMENT_FENCED', false, 409, 'Code environment assignment is fenced; inspect the execution before retrying'],
+    ASSIGNMENT_NOT_FOUND: ['BRIDGE_ASSIGNMENT_NOT_FOUND', false, 409, 'Code environment assignment is no longer available; inspect the execution before retrying'],
+    WORKER_FENCED: ['BRIDGE_WORKER_FENCED', false, 409, 'Code environment worker changed during execution; inspect the execution before retrying'],
+    WORKER_QUARANTINED: ['BRIDGE_WORKER_QUARANTINED', false, 409, 'Code environment is quarantined; recover the worker before retrying'],
+    WORKSPACE_QUARANTINED: ['BRIDGE_WORKSPACE_QUARANTINED', false, 409, 'Code environment workspace is quarantined; reset the workspace before retrying'],
+    WORKER_MISMATCH: ['BRIDGE_WORKER_MISMATCH', false, 409, 'Code environment does not support this execution; select a compatible worker'],
+    ASSIGNMENT_INVALID: ['BRIDGE_ASSIGNMENT_INVALID', false, 400, 'Code environment assignment is invalid'],
+    RESULT_INVALID: ['BRIDGE_RESULT_INVALID', false, 502, 'Code environment returned an invalid result'],
+  } satisfies Record<BridgeStoreError['code'], [SandboxBackendErrorCode, boolean, number, string]>;
+
+  for (const [storeCode, [code, transient, status, message]] of Object.entries(failures)) {
+    test(`preserves ${storeCode} recovery through the backend and public response`, async () => {
+      const cause = new BridgeStoreError(storeCode as BridgeStoreError['code'],
+        'worker vm-private at redis.internal\nprivate tenant-secret');
+      const store = {
+        dispatch: async (): ReturnType<RedisBridgeStore['dispatch']> => { throw cause; },
+      } satisfies Pick<RedisBridgeStore, 'dispatch'>;
+      const backend = new RemoteBridgeSandboxBackend(store, 'default-vm');
+      const error: unknown = await backend.execute(request(), context()).catch((failure: unknown) => failure);
+      expect(error).toBeInstanceOf(SandboxBackendError);
+      if (!(error instanceof SandboxBackendError)) throw new Error('Expected backend failure');
+      expect(error).toMatchObject({ code, transient, message: cause.message });
+      expect(error.cause).toMatchObject({ message: cause.message });
+      // The worker carries only the code/message through BullMQ, not transient.
+      const failure = publicExecutionFailure(new Error(`${error.code}: ${error.message}`));
+      expect(failure).toEqual({ status, body: { error: code.toLowerCase(), message } });
+      expect(JSON.stringify(failure)).not.toContain('vm-private');
+      expect(JSON.stringify(failure)).not.toContain('redis.internal');
+      expect(JSON.stringify(failure)).not.toContain('tenant-secret');
+    });
+  }
+
+  test('preserves failures that are not bridge store errors', async () => {
+    const cause = new Error('result finalization failed');
+    const backend = new RemoteBridgeSandboxBackend({
+      dispatch: async (): ReturnType<RedisBridgeStore['dispatch']> => { throw cause; },
+    }, 'default-vm');
+    await expect(backend.execute(request(), context())).rejects.toBe(cause);
+  });
+
+  test('keeps a rejected settlement non-transient', async () => {
+    const backend = new RemoteBridgeSandboxBackend({
+      dispatch: async (): ReturnType<RedisBridgeStore['dispatch']> => ({
+        protocolVersion: 1, generation: 1, leaseToken: 'a'.repeat(32),
+        incarnationId: 'incarnation-00000001', status: 'rejected', error: 'sandbox rejected execution',
+      }),
+    }, 'default-vm');
+    await expect(backend.execute(request(), context())).rejects.toMatchObject({
+      code: 'BRIDGE_EXECUTION_FAILED', transient: false,
     });
   });
 

--- a/service/src/sandbox-backend/remote-bridge.ts
+++ b/service/src/sandbox-backend/remote-bridge.ts
@@ -1,5 +1,6 @@
 import type {
   SandboxBackend,
+  SandboxBackendErrorCode,
   SandboxExecuteContext,
   SandboxRawResponse,
   SandboxTransportRequest,
@@ -10,6 +11,23 @@ import { env } from '../config';
 import { bridgeStore } from '../bridge';
 import { BridgeStoreError } from '../bridge/store';
 import { SandboxBackendError } from './types';
+
+// Every store failure needs an explicit recovery classification. New store
+// codes must not silently fall through to a retryable worker outage.
+const bridgeErrorCodes = {
+  WORKER_OFFLINE: 'BRIDGE_WORKER_OFFLINE',
+  WORKER_UNAUTHORIZED: 'BRIDGE_WORKER_UNAUTHORIZED',
+  WORKER_BUSY: 'BRIDGE_WORKER_BUSY',
+  ASSIGNMENT_EXPIRED: 'BRIDGE_DEADLINE_EXCEEDED',
+  ASSIGNMENT_FENCED: 'BRIDGE_ASSIGNMENT_FENCED',
+  ASSIGNMENT_NOT_FOUND: 'BRIDGE_ASSIGNMENT_NOT_FOUND',
+  WORKER_FENCED: 'BRIDGE_WORKER_FENCED',
+  WORKER_QUARANTINED: 'BRIDGE_WORKER_QUARANTINED',
+  WORKSPACE_QUARANTINED: 'BRIDGE_WORKSPACE_QUARANTINED',
+  WORKER_MISMATCH: 'BRIDGE_WORKER_MISMATCH',
+  ASSIGNMENT_INVALID: 'BRIDGE_ASSIGNMENT_INVALID',
+  RESULT_INVALID: 'BRIDGE_RESULT_INVALID',
+} satisfies Record<BridgeStoreError['code'], SandboxBackendErrorCode>;
 
 export class RemoteBridgeSandboxBackend implements SandboxBackend {
   readonly name = 'remote-bridge' as const;
@@ -63,32 +81,11 @@ export class RemoteBridgeSandboxBackend implements SandboxBackend {
       return settlement.result as SandboxRawResponse;
     } catch (error) {
       if (!(error instanceof BridgeStoreError)) throw error;
-      if (error.code === 'WORKER_UNAUTHORIZED') {
-        throw new SandboxBackendError(
-          'BRIDGE_WORKER_UNAUTHORIZED',
-          error.message,
-          error,
-        );
-      }
-      if (error.code === 'WORKER_BUSY') {
-        throw new SandboxBackendError(
-          'BRIDGE_WORKER_BUSY',
-          error.message,
-          error,
-        );
-      }
-      if (error.code === 'ASSIGNMENT_EXPIRED') {
-        throw new SandboxBackendError(
-          'BRIDGE_DEADLINE_EXCEEDED',
-          error.message,
-          error,
-        );
-      }
       throw new SandboxBackendError(
-        'BRIDGE_WORKER_OFFLINE',
+        bridgeErrorCodes[error.code],
         error.message,
         error,
-        true,
+        error.code === 'WORKER_OFFLINE',
       );
     }
   }

--- a/service/src/sandbox-backend/types.ts
+++ b/service/src/sandbox-backend/types.ts
@@ -78,13 +78,21 @@ export type SandboxBackendErrorCode =
   | 'BRIDGE_WORKER_BUSY'
   | 'BRIDGE_EXECUTION_FAILED'
   | 'BRIDGE_DEADLINE_EXCEEDED'
+  | 'BRIDGE_ASSIGNMENT_FENCED'
+  | 'BRIDGE_ASSIGNMENT_NOT_FOUND'
+  | 'BRIDGE_WORKER_FENCED'
+  | 'BRIDGE_WORKER_QUARANTINED'
+  | 'BRIDGE_WORKSPACE_QUARANTINED'
+  | 'BRIDGE_WORKER_MISMATCH'
+  | 'BRIDGE_ASSIGNMENT_INVALID'
+  | 'BRIDGE_RESULT_INVALID'
   | 'MICROVM_LAUNCH_FAILED'
   | 'MICROVM_LAUNCH_THROTTLED'
   | 'MICROVM_UNHEALTHY'
   | 'MICROVM_FENCED'
   | 'MICROVM_DEADLINE_EXCEEDED';
 
-/** Lambda-only failure modes; the worker prefixes messages with the code so
+/** Typed sandbox backend failure modes; the worker prefixes messages with the code so
  *  the router can map them (e.g. RUNTIME_SESSION_BUSY -> 409). Axios errors
  *  from the sandbox POST itself are rethrown raw by every backend. */
 export class SandboxBackendError extends Error {

--- a/service/src/utils.ts
+++ b/service/src/utils.ts
@@ -1,5 +1,66 @@
 import axios from 'axios';
 import type { AxiosError } from 'axios';
+import type { SandboxBackendErrorCode } from './sandbox-backend/types';
+
+// Keep the public response exhaustive too: a new terminal backend code must
+// not silently become an availability-related 503 after crossing BullMQ.
+const bridgePublicFailures: Partial<Record<string, { status: number; message: string }>> = {
+  BRIDGE_WORKER_UNAUTHORIZED: {
+    status: 403,
+    message: 'Code environment is not authorized for this tenant',
+  },
+  BRIDGE_WORKER_OFFLINE: {
+    status: 503,
+    message: 'Code environment is offline',
+  },
+  BRIDGE_WORKER_BUSY: {
+    status: 409,
+    message: 'Code environment is busy',
+  },
+  BRIDGE_EXECUTION_FAILED: {
+    status: 502,
+    message: 'Code environment execution failed',
+  },
+  BRIDGE_DEADLINE_EXCEEDED: {
+    status: 504,
+    message: 'Code environment execution timed out',
+  },
+  BRIDGE_ASSIGNMENT_FENCED: {
+    status: 409,
+    message: 'Code environment assignment is fenced; inspect the execution before retrying',
+  },
+  BRIDGE_ASSIGNMENT_NOT_FOUND: {
+    status: 409,
+    message: 'Code environment assignment is no longer available; inspect the execution before retrying',
+  },
+  BRIDGE_WORKER_FENCED: {
+    status: 409,
+    message: 'Code environment worker changed during execution; inspect the execution before retrying',
+  },
+  BRIDGE_WORKER_QUARANTINED: {
+    status: 409,
+    message: 'Code environment is quarantined; recover the worker before retrying',
+  },
+  BRIDGE_WORKSPACE_QUARANTINED: {
+    status: 409,
+    message: 'Code environment workspace is quarantined; reset the workspace before retrying',
+  },
+  BRIDGE_WORKER_MISMATCH: {
+    status: 409,
+    message: 'Code environment does not support this execution; select a compatible worker',
+  },
+  BRIDGE_ASSIGNMENT_INVALID: {
+    status: 400,
+    message: 'Code environment assignment is invalid',
+  },
+  BRIDGE_RESULT_INVALID: {
+    status: 502,
+    message: 'Code environment returned an invalid result',
+  },
+} satisfies Record<
+  Extract<SandboxBackendErrorCode, `BRIDGE_${string}`>,
+  { status: number; message: string }
+>;
 
 export function applySystemReplacements(input: string): string {
   return input;
@@ -135,13 +196,15 @@ export function publicExecutionFailure(error: unknown): { status: number; body: 
   );
   if (backendMatch) {
     const code = backendMatch[1];
+    const bridgeFailure = bridgePublicFailures[code];
+    if (bridgeFailure != null) {
+      return {
+        status: bridgeFailure.status,
+        body: { error: code.toLowerCase(), message: bridgeFailure.message },
+      };
+    }
     const statuses: Record<string, number> = {
       RUNTIME_SESSION_BUSY: 409,
-      BRIDGE_WORKER_UNAUTHORIZED: 403,
-      BRIDGE_WORKER_OFFLINE: 503,
-      BRIDGE_WORKER_BUSY: 409,
-      BRIDGE_EXECUTION_FAILED: 502,
-      BRIDGE_DEADLINE_EXCEEDED: 504,
       SESSION_INPUT_TOO_LARGE: 413,
       SESSION_INPUT_UNAVAILABLE: 422,
       SESSION_INPUT_SOURCE_FAILED: 502,
@@ -152,11 +215,6 @@ export function publicExecutionFailure(error: unknown): { status: number; body: 
     const status = statuses[code] ?? (sessionInputFailure ? 500 : 503);
     const publicMessages: Record<string, string> = {
       RUNTIME_SESSION_BUSY: 'Runtime session is busy',
-      BRIDGE_WORKER_UNAUTHORIZED: 'Code environment is not authorized for this tenant',
-      BRIDGE_WORKER_OFFLINE: 'Code environment is offline',
-      BRIDGE_WORKER_BUSY: 'Code environment is busy',
-      BRIDGE_EXECUTION_FAILED: 'Code environment execution failed',
-      BRIDGE_DEADLINE_EXCEEDED: 'Code environment execution timed out',
       MICROVM_LAUNCH_FAILED: 'Sandbox launch failed',
       MICROVM_LAUNCH_THROTTLED: 'Sandbox capacity is temporarily unavailable',
       MICROVM_UNHEALTHY: 'Sandbox runtime is unavailable',


### PR DESCRIPTION
I fixed terminal bridge failures being reported as transient worker outages. Quarantined, mismatched, and fenced executions now retain distinct non-transient backend codes and return HTTP 409 with recovery guidance instead of an offline 503. Closes #86.

- Map every bridge-store error explicitly, keeping only `WORKER_OFFLINE` transient and preserving existing authorization, busy, and deadline behavior.
- Carry terminal codes through the worker's BullMQ error format into sanitized public responses with workspace reset, worker recovery, or execution inspection guidance.
- Require exhaustive backend and public mappings at compile time so new codes cannot silently inherit availability semantics.
- Preserve rejected-settlement behavior, raw non-store errors, and private diagnostic messages in internal errors without leaking them in public responses.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Passed `bun test service/src/sandbox-backend/remote-bridge.test.ts service/src/utils.test.ts`: 49 tests, including all 12 store error codes through backend classification and the public error mapper.
- Confirmed the eight terminal-code regression cases fail with the unmodified backend from `main`.
- Built the service successfully with `bun run build`; existing diagnostics are in unrelated files.
- Passed lint for the changed test and types files; verified the production files' existing lint findings are unchanged from `main`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
