### PR TITLE
fix: preserve required native sandbox environment names

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -86,6 +86,12 @@ policy: an allowed destination can receive workspace data. The normalized
 allowlist is included in the worker policy digest. Tool approval hooks remain
 the user-facing allow/deny boundary for each invocation.
 
+The native sandbox preserves standard `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`,
+and `NO_PROXY` names (including lowercase forms), plus Windows process and profile
+variables on Windows. SRT remains responsible for the final sandbox environment
+and can replace proxy values with its filtered proxy endpoints. This does not
+expand the allowed domains or expose unrelated inherited credentials.
+
 ### GitHub authentication
 
 The native BYOM worker can provide Git HTTPS authentication without exposing a

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -34,6 +34,7 @@ function fakeManager(
     beforeWrap?: () => Promise<void>;
     appendGitSafeDirectory?: boolean;
     inheritedGitEnvironment?: Record<string, string>;
+    wrappedEnvironment?: NodeJS.ProcessEnv;
   } = {},
 ) {
   let config: SandboxRuntimeConfig | undefined;
@@ -72,6 +73,7 @@ function fakeManager(
         env: {
           PATH: process.env.PATH,
           ...gitEnvironment,
+          ...options.wrappedEnvironment,
           ...(credentialSeenDuringWrap
             ? {
                 LIBRECHAT_CODE_TEST_CREDENTIAL:
@@ -146,6 +148,99 @@ test('initializes SRT with a default-deny network and scrubbed worker credential
   assert.ok(denied?.includes('lc_api_token'));
   await sandbox.close();
   assert.equal(fake.reset, true);
+});
+
+const proxyEnvironment = {
+  HTTP_PROXY: 'http://upstream.invalid:8080',
+  HTTPS_PROXY: 'http://upstream.invalid:8080',
+  ALL_PROXY: 'socks5://upstream.invalid:1080',
+  NO_PROXY: 'upstream.internal',
+  http_proxy: 'http://upstream.invalid:8080',
+  https_proxy: 'http://upstream.invalid:8080',
+  all_proxy: 'socks5://upstream.invalid:1080',
+  no_proxy: 'upstream.internal',
+};
+const windowsEnvironment = {
+  SYSTEMROOT: 'C:\\Windows',
+  SystemRoot: 'C:\\Windows',
+  SYSTEMDRIVE: 'C:',
+  windir: 'C:\\Windows',
+  ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+  PATHEXT: '.COM;.EXE;.BAT;.CMD',
+  TEMP: 'C:\\Temp',
+  Temp: 'C:\\Temp',
+  TMP: 'C:\\Temp',
+  USERPROFILE: 'C:\\Users\\sandbox',
+  HOMEDRIVE: 'C:',
+  HOMEPATH: '\\Users\\sandbox',
+  APPDATA: 'C:\\Users\\sandbox\\AppData\\Roaming',
+  LOCALAPPDATA: 'C:\\Users\\sandbox\\AppData\\Local',
+};
+
+for (const platform of ['darwin', 'linux', 'win32'] as const) {
+  test(`preserves required ${platform} environment names without allowing credentials`, async (t) => {
+    const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+    t.after(() => rm(root, { recursive: true, force: true }));
+    const fake = fakeManager();
+    const credentials = {
+      LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
+      LIBRECHAT_CODE_HTTP_PROXY: 'worker-secret',
+      AWS_SECRET_ACCESS_KEY: 'aws-secret',
+      GITHUB_TOKEN: 'github-secret',
+      HTTP_PROXY_TOKEN: 'proxy-secret',
+      CUSTOM_PROXY: 'proxy-secret',
+      SYSTEMROOT_TOKEN: 'runtime-secret',
+      NODE_OPTIONS: '--require /host/private.js',
+      LD_PRELOAD: '/host/private.so',
+    };
+    const sandbox = new NativeSrtWorkspaceCommandSandbox({
+      workspaceRoot: root, platform, allowedDomains: ['github.com'],
+      environment: {
+        ...proxyEnvironment, ...windowsEnvironment, ...credentials,
+        HtTp_PrOxY: 'http://mixed-case.invalid:8080',
+        PATH: '/usr/bin', LC_ALL: 'C.UTF-8',
+      },
+      manager: fake.manager,
+    });
+    t.after(() => sandbox.close());
+    await sandbox.prepare();
+    const denied = new Set(fake.config?.credentials?.envVars
+      ?.filter(({ mode }) => mode === 'deny').map(({ name }) => name));
+    for (const name of [...Object.keys(proxyEnvironment), 'PATH', 'LC_ALL']) {
+      assert.equal(denied.has(name), false, `${name} must remain available`);
+    }
+    for (const name of Object.keys(windowsEnvironment)) {
+      assert.equal(denied.has(name), platform !== 'win32', `${name} must be platform-specific`);
+    }
+    assert.equal(denied.has('HtTp_PrOxY'), platform !== 'win32');
+    for (const name of Object.keys(credentials)) {
+      assert.equal(denied.has(name), true, `${name} must remain denied`);
+    }
+    assert.deepEqual(fake.config?.network.allowedDomains, ['github.com']);
+    assert.equal(fake.config?.network.strictAllowlist, true);
+  });
+}
+
+test('uses SRT proxy values without restoring inherited proxies or credentials', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const wrappedEnvironment = {
+    HTTP_PROXY: 'http://localhost:3128', HTTPS_PROXY: 'http://localhost:3128',
+    ALL_PROXY: 'http://localhost:3128', NO_PROXY: 'localhost',
+  };
+  const fake = fakeManager({ wrappedEnvironment });
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    environment: { ...proxyEnvironment, GITHUB_TOKEN: 'host-secret' },
+    manager: fake.manager,
+  });
+  t.after(() => sandbox.close());
+  const result = await sandbox.execute({
+    ...request, maxOutputBytes: 256,
+    command: 'printf "%s|%s|%s|%s|%s" "$HTTP_PROXY" "$HTTPS_PROXY" "$ALL_PROXY" "$NO_PROXY" "${GITHUB_TOKEN-unset}"',
+  });
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout, `${Object.values(wrappedEnvironment).join('|')}|unset`);
 });
 
 test('masks a host credential for only its injection host and restores the parent environment', async (t) => {

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -48,6 +48,36 @@ const SAFE_CHILD_ENV_NAMES = new Set([
   'USER',
 ]);
 
+// Preserve the conventional proxy names, not arbitrary *_PROXY variables.
+// SRT owns their final values and may replace them with its filtered proxy.
+const PROXY_CHILD_ENV_NAMES = new Set([
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'ALL_PROXY',
+  'NO_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'all_proxy',
+  'no_proxy',
+]);
+
+// Windows resolves these names case-insensitively. Keep the exception
+// platform-specific so similarly named POSIX variables remain denied.
+const WINDOWS_CHILD_ENV_NAMES = new Set([
+  'SYSTEMROOT',
+  'SYSTEMDRIVE',
+  'WINDIR',
+  'COMSPEC',
+  'PATHEXT',
+  'TEMP',
+  'TMP',
+  'USERPROFILE',
+  'HOMEDRIVE',
+  'HOMEPATH',
+  'APPDATA',
+  'LOCALAPPDATA',
+]);
+
 let hostEnvironmentMutationQueue: Promise<void> = Promise.resolve();
 
 const TRUSTED_GIT_ENVIRONMENT = {
@@ -148,7 +178,7 @@ function boundedUtf8(buffer: Buffer, budget: number): string {
   return '';
 }
 
-function safeEnvironmentNames(
+function deniedEnvironmentNames(
   environment: NodeJS.ProcessEnv,
   platform: NodeJS.Platform,
 ): string[] {
@@ -157,7 +187,10 @@ function safeEnvironmentNames(
       const normalized = platform === 'win32' ? name.toUpperCase() : name;
       return (
         normalized.startsWith('LIBRECHAT_CODE_') ||
-        (!SAFE_CHILD_ENV_NAMES.has(normalized) && !normalized.startsWith('LC_'))
+        (!SAFE_CHILD_ENV_NAMES.has(normalized) &&
+          !PROXY_CHILD_ENV_NAMES.has(normalized) &&
+          !(platform === 'win32' && WINDOWS_CHILD_ENV_NAMES.has(normalized)) &&
+          !normalized.startsWith('LC_'))
       );
     })
     .sort();
@@ -272,7 +305,7 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
           mode: 'deny' as const,
         })),
         envVars: [
-          ...safeEnvironmentNames(this.environment, this.platform)
+          ...deniedEnvironmentNames(this.environment, this.platform)
             .filter((name) => {
               const normalized = normalizedEnvironmentName(
                 name,


### PR DESCRIPTION
I corrected the native sandbox credential-deny policy so it preserves standard proxy environment names and Windows process/runtime names instead of classifying them as unrelated credentials. Closes #127.

- Preserve exact uppercase and lowercase HTTP, HTTPS, ALL, and NO proxy names.
- Preserve Windows process, temporary-directory, and profile names only on Windows, using its existing case-insensitive matching.
- Continue denying worker tokens, cloud credentials, similarly named credential variables, and process-injection variables.
- Keep SRT's returned environment authoritative; never copy inherited proxy values or credentials back into the spawned command.
- Document the environment policy and rename the deny-list helper to reflect what it returns.

The pinned SRT 0.0.75 already reapplies generated proxy variables after deny processing on POSIX and builds a separate Windows sandbox profile environment. Those protections mitigate the reported symptoms today. This change corrects our deny-list policy; the tests establish policy behavior, not a reproduced native Windows startup failure.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- Passed `npm run build` in `packages/code` with Node 24.16.0.
- Passed `node --test dist/native-sandbox.test.js dist/github.test.js`: 30 tests.
- Confirmed all three new platform policy tests fail against unmodified `main`.
- Covered exact proxy names, Windows casing, POSIX case sensitivity, credential-deny preservation, domain-policy preservation, and spawned-child use of SRT proxy values.
- Used injected platform values for Windows policy tests; native Windows startup was not exercised on this macOS host.
- Passed `git diff --check`; the package has no lint script.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
