### PR TITLE
fix: clean sandbox state on pre-spawn exits

### DIFF
--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -552,3 +552,100 @@ test('maps platform-native exit statuses into the bridge protocol range', async 
   const result = await sandbox.execute(request);
   assert.equal(result.exitCode, 1);
 });
+
+test('cleans allocated command state exactly once on every execution exit', async (t) => {
+  for (const outcome of [
+    'abort-before-spawn',
+    'spawn-throw',
+    'close',
+    'error',
+    'abort-after-spawn',
+    'timeout',
+    'wrap-throw',
+  ] as const) {
+    for (const cleanupThrows of [false, true]) {
+      await t.test(`${outcome}, cleanup throws: ${cleanupThrows}`, async (t) => {
+        const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+        t.after(() => rm(root, { recursive: true, force: true }));
+        const controller = new AbortController();
+        let cleanupCalls = 0;
+        let spawnCalls = 0;
+        let allocated = false;
+        const fake = fakeManager({
+          async beforeWrap() {
+            if (outcome === 'wrap-throw') throw new Error('wrap failed');
+            allocated = true;
+            if (outcome === 'abort-before-spawn') controller.abort();
+          },
+        });
+        fake.manager.cleanupAfterCommand = () => {
+          cleanupCalls += 1;
+          assert.equal(allocated, true);
+          allocated = false;
+          if (cleanupThrows) throw new Error('cleanup failed');
+        };
+        const sandbox = new NativeSrtWorkspaceCommandSandbox({
+          workspaceRoot: root,
+          manager: fake.manager,
+          spawnCommand() {
+            spawnCalls += 1;
+            assert.equal(allocated, true);
+            if (outcome === 'spawn-throw') throw new Error('spawn failed');
+            const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+            let closeQueued = false;
+            const close = () => {
+              if (!closeQueued) {
+                closeQueued = true;
+                queueMicrotask(() => child.emit('close', null, 'SIGKILL'));
+              }
+              return true;
+            };
+            Object.assign(child, {
+              stdin: new PassThrough(),
+              stdout: new PassThrough(),
+              stderr: new PassThrough(),
+              pid: undefined,
+              kill: close,
+            });
+            queueMicrotask(() => {
+              assert.equal(cleanupCalls, 0);
+              if (outcome === 'error') {
+                child.emit('error', new Error('spawn failed'));
+              } else if (outcome === 'abort-after-spawn') {
+                controller.abort();
+              } else if (outcome === 'close') {
+                child.emit('close', 0, null);
+              }
+            });
+            return child;
+          },
+        });
+        const execution = sandbox.execute(
+          { ...request, timeoutMs: 10 },
+          controller.signal,
+        );
+        if (outcome === 'close' || outcome === 'timeout') {
+          const result = await execution;
+          assert.equal(result.exitCode, outcome === 'close' ? 0 : null);
+          assert.equal(result.timedOut, outcome === 'timeout');
+        } else {
+          await assert.rejects(execution, (error: unknown) =>
+            error instanceof WorkspaceToolError &&
+            error.code === (outcome.startsWith('abort')
+              ? 'EXECUTION_ABORTED'
+              : 'COMMAND_UNAVAILABLE') &&
+            error.mutationMayHaveCommitted === (outcome === 'abort-after-spawn'),
+          );
+        }
+        assert.equal(
+          spawnCalls,
+          outcome === 'abort-before-spawn' || outcome === 'wrap-throw' ? 0 : 1,
+        );
+        assert.equal(cleanupCalls, outcome === 'wrap-throw' ? 0 : 1);
+        assert.equal(allocated, false);
+        await sandbox.close();
+        assert.equal(fake.reset, true);
+      });
+    }
+  }
+});

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -380,13 +380,22 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
         'COMMAND_UNAVAILABLE',
       );
     }
-    if (signal?.aborted) {
-      throw new WorkspaceToolError(
-        'Workspace command execution aborted',
-        'EXECUTION_ABORTED',
-      );
+    try {
+      if (signal?.aborted) {
+        throw new WorkspaceToolError(
+          'Workspace command execution aborted',
+          'EXECUTION_ABORTED',
+        );
+      }
+      return await this.runWrapped(request, wrapped, cwd, commandId, signal);
+    } finally {
+      // A successful wrap owns command state even when no child is spawned.
+      try {
+        this.manager.cleanupAfterCommand();
+      } catch {
+        // Cleanup is retried by close(); command settlement must still finish.
+      }
     }
-    return await this.runWrapped(request, wrapped, cwd, commandId, signal);
   }
 
   private async withTemporaryHostEnvironment<T>(
@@ -488,11 +497,6 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
         const cleanup = (): void => {
           clearTimeout(timer);
           signal?.removeEventListener('abort', abort);
-          try {
-            this.manager.cleanupAfterCommand();
-          } catch {
-            // Cleanup is retried by close(); command settlement must still finish.
-          }
         };
         child.once('error', () => {
           if (settled) return;


### PR DESCRIPTION
## Summary

I moved per-command SRT cleanup into a `finally` block after successful wrapping so cancellation before spawn and synchronous spawn failures release command state immediately. Fixes #128.

- Guarantee one cleanup attempt before execution settles, including success, child errors, cancellation, and timeout.
- Preserve command results and mutation flags when cleanup itself throws; retain shutdown reset as the fallback.
- Add deterministic failure-injection coverage for both reported leaks and the surrounding lifecycle exits.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I reproduced both missing-cleanup failures before applying the fix, then ran:

```sh
npm run build --prefix packages/code
node --test packages/code/dist/native-sandbox.test.js packages/code/dist/workspace.test.js
git diff --check
```

Result: 91 passed, 1 skipped, 0 failed. Tests exercise both successful and throwing cleanup for seven lifecycle outcomes.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
