### PR TITLE
fix: continue bounded listings after skipped candidate windows

### DIFF
--- a/packages/code/src/workspace-listing.test.ts
+++ b/packages/code/src/workspace-listing.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import childProcess from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { syncBuiltinESMExports } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import test from 'node:test';
+
+import type { TestContext } from 'node:test';
+import type { ChildProcess } from 'node:child_process';
+import { BRIDGE_WORKSPACE_LIST_MAX_RESULTS } from './protocol.js';
+import { isWorkspaceToolResult, LocalWorkspaceTools, WorkspaceToolError } from './workspace.js';
+
+const request = {
+  protocolVersion: 1 as const,
+  operation: 'list_files' as const,
+  workspaceId: 'primary',
+  maxResults: 1,
+};
+const skippedPaths = Array.from(
+  { length: 2 * (BRIDGE_WORKSPACE_LIST_MAX_RESULTS + request.maxResults) + 5 },
+  (_, index) => `a-${String(index).padStart(4, '0')}`,
+);
+
+// Control candidate discovery independently of filesystem verification, as
+// files can vanish or be replaced by symlinks after rg has enumerated them.
+function candidateSource(t: TestContext, paths: string[], onScan?: (scan: number) => void) {
+  let scans = 0;
+  let cappedScans = 0;
+  t.mock.method(childProcess, 'spawn', (command: string, args: string[]) => {
+    assert.equal(command, 'rg');
+    assert.ok(args.includes('--no-follow'));
+    assert.ok(args.includes('--null'));
+    assert.ok(args.includes('--sort'));
+    scans += 1;
+    const child = new EventEmitter() as ChildProcess;
+    const stdout = new PassThrough();
+    let closed = false;
+    const close = () => {
+      if (closed) return;
+      closed = true;
+      queueMicrotask(() => child.emit('close', 0));
+    };
+    Object.assign(child, {
+      stdout,
+      kill: () => { cappedScans += 1; close(); return true; },
+    });
+    onScan?.(scans);
+    queueMicrotask(() => {
+      if (closed) return;
+      stdout.end(Buffer.from(`${paths.join('\0')}\0`));
+      close();
+    });
+    return child;
+  });
+  syncBuiltinESMExports();
+  t.after(() => {
+    t.mock.restoreAll();
+    syncBuiltinESMExports();
+  });
+  return { get scans() { return scans; }, get cappedScans() { return cappedScans; } };
+}
+
+async function workspace(t: TestContext) {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-list-windows-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const tools = await LocalWorkspaceTools.create({ workspaces: [{ id: 'primary', root }] });
+  return { root, tools };
+}
+
+for (const skippedKind of ['missing', 'symlink'] as const) {
+  test(`lists and paginates valid files after multiple windows of ${skippedKind} candidates`, async (t) => {
+    const { root, tools } = await workspace(t);
+    await writeFile(join(root, 'z-first.txt'), 'first');
+    await writeFile(join(root, 'z-last.txt'), 'last');
+    if (skippedKind === 'symlink') {
+      await Promise.all(skippedPaths.map(path => symlink('z-first.txt', join(root, path))));
+    }
+    const source = candidateSource(t, [...skippedPaths, 'z-first.txt', 'z-last.txt']);
+    const first = await tools.execute(request);
+    assert.equal(isWorkspaceToolResult(request, first, tools.capabilities), true);
+    assert.deepEqual(first, {
+      protocolVersion: 1, operation: 'list_files', workspaceId: 'primary',
+      paths: ['z-first.txt'], truncated: true, nextAfterPath: 'z-first.txt',
+    });
+    assert.equal(source.scans, 3);
+    assert.equal(source.cappedScans, 2, 'each full candidate window still stops rg');
+    const nextRequest = { ...request, afterPath: 'z-first.txt' };
+    const last = await tools.execute(nextRequest);
+    assert.equal(isWorkspaceToolResult(nextRequest, last, tools.capabilities), true);
+    assert.deepEqual(last, {
+      protocolVersion: 1, operation: 'list_files', workspaceId: 'primary',
+      paths: ['z-last.txt'], truncated: false,
+    });
+    assert.equal(source.scans, 4);
+  });
+}
+
+test('returns a complete empty page when successive skipped windows exhaust the listing', async (t) => {
+  const { tools } = await workspace(t);
+  const source = candidateSource(t, skippedPaths);
+  const result = await tools.execute(request);
+  assert.equal(isWorkspaceToolResult(request, result, tools.capabilities), true);
+  assert.deepEqual(result, {
+    protocolVersion: 1, operation: 'list_files', workspaceId: 'primary',
+    paths: [], truncated: false,
+  });
+  assert.equal(source.scans, 3);
+  assert.equal(source.cappedScans, 2);
+});
+
+test('successive candidate windows share the original listing deadline', async (t) => {
+  const { tools } = await workspace(t);
+  let now = Date.now();
+  t.mock.method(Date, 'now', () => now);
+  const source = candidateSource(t, skippedPaths, () => { now += 6_000; });
+  await assert.rejects(tools.execute(request), (error: unknown) =>
+    error instanceof WorkspaceToolError && error.code === 'LIST_TIMEOUT');
+  assert.equal(source.scans, 2, 'a later window must not reset the ten-second budget');
+});
+
+test('cancellation interrupts a later candidate window', async (t) => {
+  const { tools } = await workspace(t);
+  const controller = new AbortController();
+  const source = candidateSource(t, skippedPaths, scan => {
+    if (scan === 2) controller.abort();
+  });
+  await assert.rejects(tools.execute(request, controller.signal), (error: unknown) =>
+    error instanceof WorkspaceToolError && error.code === 'EXECUTION_ABORTED');
+  assert.equal(source.scans, 2);
+});

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -1157,202 +1157,213 @@ async function listWorkspaceFiles(
     .filter((segment) => segment.length > 0 && segment !== '.')
     .join('/');
   const requestedResultPath = normalizedRequestedResultPath || undefined;
-  const afterPath = request.afterPath;
+  let afterPath = request.afterPath;
 
-  const candidates: Array<{ filesystemPath: string; resultPath: string }> = [];
-  let truncated = false;
-  let pending: Buffer = Buffer.alloc(0);
-  let stoppedForLimit = false;
-  await new Promise<void>((resolvePromise, reject) => {
-    const args = [
-      '--files',
-      '--no-config',
-      '--no-follow',
-      '--no-messages',
-      '--sort',
-      'path',
-      '--null',
-    ];
-    if (portableCanonicalListPath !== '.') {
-      args.push(
-        '--glob',
-        canonicalTargetIsDirectory
-          ? `${portableCanonicalListPath}/**`
-          : portableCanonicalListPath,
-      );
-    }
-    args.push('--', '.');
-    const child = spawn(
-      'rg',
-      args,
-      { cwd: root, stdio: ['ignore', 'pipe', 'ignore'] },
-    );
-    let aborted = false;
-    let timedOut = false;
-    const abort = () => {
-      aborted = true;
-      child.kill();
-    };
-    signal?.addEventListener('abort', abort, { once: true });
-    if (signal?.aborted) abort();
-    const timeout = setTimeout(() => {
-      timedOut = true;
-      child.kill();
-    }, Math.max(0, deadline - Date.now()));
-    const cleanup = () => {
-      clearTimeout(timeout);
-      signal?.removeEventListener('abort', abort);
-    };
-    const pathDecoder = new TextDecoder('utf-8', {
-      fatal: true,
-      ignoreBOM: true,
-    });
-    const consumePath = (rawPath: Buffer) => {
-      if (rawPath.length === 0 || stoppedForLimit) return;
-      let path: string;
-      try {
-        path = pathDecoder.decode(rawPath);
-      } catch {
-        return;
+  for (;;) {
+    await withinListDeadline(Promise.resolve(), signal, deadline);
+    const candidates: Array<{ filesystemPath: string; resultPath: string }> = [];
+    let truncated = false;
+    let pending: Buffer = Buffer.alloc(0);
+    let stoppedForLimit = false;
+    await new Promise<void>((resolvePromise, reject) => {
+      const args = [
+        '--files',
+        '--no-config',
+        '--no-follow',
+        '--no-messages',
+        '--sort',
+        'path',
+        '--null',
+      ];
+      if (portableCanonicalListPath !== '.') {
+        args.push(
+          '--glob',
+          canonicalTargetIsDirectory
+            ? `${portableCanonicalListPath}/**`
+            : portableCanonicalListPath,
+        );
       }
-      if (!Buffer.from(path).equals(rawPath)) return;
-      if (candidates.length === maxResults + BRIDGE_WORKSPACE_LIST_MAX_RESULTS) {
-        truncated = true;
-        stoppedForLimit = true;
+      args.push('--', '.');
+      const child = spawn(
+        'rg',
+        args,
+        { cwd: root, stdio: ['ignore', 'pipe', 'ignore'] },
+      );
+      let aborted = false;
+      let timedOut = false;
+      const abort = () => {
+        aborted = true;
         child.kill();
-        return;
-      }
-      const portablePath = sep === '\\' ? path.split(sep).join('/') : path;
-      const normalizedPath = portablePath.startsWith('./')
-        ? portablePath.slice(2)
-        : portablePath;
-      const resultPath =
-        requestedResultPath == null
-          ? normalizedPath
-          : portableCanonicalListPath === '.'
-            ? `${requestedResultPath}/${normalizedPath}`
-            : normalizedPath === portableCanonicalListPath ||
-                normalizedPath.startsWith(`${portableCanonicalListPath}/`)
-              ? `${requestedResultPath}${normalizedPath.slice(portableCanonicalListPath.length)}`
-              : normalizedPath;
-      if (!isSafePortableRelativePath(resultPath)) return;
-      if (
-        afterPath !== undefined &&
-        comparePortableRelativePaths(resultPath, afterPath) <= 0
-      ) {
-        return;
-      }
-      candidates.push({ filesystemPath: normalizedPath, resultPath });
-    };
+      };
+      signal?.addEventListener('abort', abort, { once: true });
+      if (signal?.aborted) abort();
+      const timeout = setTimeout(() => {
+        timedOut = true;
+        child.kill();
+      }, Math.max(0, deadline - Date.now()));
+      const cleanup = () => {
+        clearTimeout(timeout);
+        signal?.removeEventListener('abort', abort);
+      };
+      const pathDecoder = new TextDecoder('utf-8', {
+        fatal: true,
+        ignoreBOM: true,
+      });
+      const consumePath = (rawPath: Buffer) => {
+        if (rawPath.length === 0 || stoppedForLimit) return;
+        let path: string;
+        try {
+          path = pathDecoder.decode(rawPath);
+        } catch {
+          return;
+        }
+        if (!Buffer.from(path).equals(rawPath)) return;
+        if (candidates.length === maxResults + BRIDGE_WORKSPACE_LIST_MAX_RESULTS) {
+          truncated = true;
+          stoppedForLimit = true;
+          child.kill();
+          return;
+        }
+        const portablePath = sep === '\\' ? path.split(sep).join('/') : path;
+        const normalizedPath = portablePath.startsWith('./')
+          ? portablePath.slice(2)
+          : portablePath;
+        const resultPath =
+          requestedResultPath == null
+            ? normalizedPath
+            : portableCanonicalListPath === '.'
+              ? `${requestedResultPath}/${normalizedPath}`
+              : normalizedPath === portableCanonicalListPath ||
+                  normalizedPath.startsWith(`${portableCanonicalListPath}/`)
+                ? `${requestedResultPath}${normalizedPath.slice(portableCanonicalListPath.length)}`
+                : normalizedPath;
+        if (!isSafePortableRelativePath(resultPath)) return;
+        if (
+          afterPath !== undefined &&
+          comparePortableRelativePaths(resultPath, afterPath) <= 0
+        ) {
+          return;
+        }
+        candidates.push({ filesystemPath: normalizedPath, resultPath });
+      };
 
-    child.stdout.on('data', (chunk: Buffer) => {
-      pending = pending.length === 0 ? chunk : Buffer.concat([pending, chunk]);
-      let delimiter = pending.indexOf(0);
-      while (delimiter >= 0) {
-        consumePath(pending.subarray(0, delimiter));
-        pending = pending.subarray(delimiter + 1);
-        delimiter = pending.indexOf(0);
-      }
-    });
-    child.once('error', () => {
-      cleanup();
-      reject(
-        new WorkspaceToolError(
-          'Workspace listing unavailable',
-          'LIST_UNAVAILABLE',
-        ),
-      );
-    });
-    child.once('close', (code) => {
-      cleanup();
-      consumePath(pending);
-      if (aborted) {
-        reject(
-          new WorkspaceToolError(
-            'Workspace tool execution aborted',
-            'EXECUTION_ABORTED',
-          ),
-        );
-      } else if (timedOut) {
-        reject(
-          new WorkspaceToolError('Workspace listing timed out', 'LIST_TIMEOUT'),
-        );
-      } else if (stoppedForLimit || code === 0 || code === 1) {
-        resolvePromise();
-      } else {
+      child.stdout.on('data', (chunk: Buffer) => {
+        pending = pending.length === 0 ? chunk : Buffer.concat([pending, chunk]);
+        let delimiter = pending.indexOf(0);
+        while (delimiter >= 0) {
+          consumePath(pending.subarray(0, delimiter));
+          pending = pending.subarray(delimiter + 1);
+          delimiter = pending.indexOf(0);
+        }
+      });
+      child.once('error', () => {
+        cleanup();
         reject(
           new WorkspaceToolError(
             'Workspace listing unavailable',
             'LIST_UNAVAILABLE',
           ),
         );
-      }
+      });
+      child.once('close', (code) => {
+        cleanup();
+        consumePath(pending);
+        if (aborted) {
+          reject(
+            new WorkspaceToolError(
+              'Workspace tool execution aborted',
+              'EXECUTION_ABORTED',
+            ),
+          );
+        } else if (timedOut) {
+          reject(
+            new WorkspaceToolError('Workspace listing timed out', 'LIST_TIMEOUT'),
+          );
+        } else if (stoppedForLimit || code === 0 || code === 1) {
+          resolvePromise();
+        } else {
+          reject(
+            new WorkspaceToolError(
+              'Workspace listing unavailable',
+              'LIST_UNAVAILABLE',
+            ),
+          );
+        }
+      });
     });
-  });
 
-  const paths: string[] = [];
-  const seenPaths = new Set<string>();
-  for (const candidate of candidates) {
-    let canonicalPath: string;
-    try {
-      canonicalPath = await withinListDeadline(
-        realpath(resolveWorkspacePath(root, candidate.filesystemPath)),
-        signal,
-        deadline,
-      );
-    } catch (error) {
-      if (error instanceof WorkspaceToolError) throw error;
+    const paths: string[] = [];
+    const seenPaths = new Set<string>();
+    for (const candidate of candidates) {
+      let canonicalPath: string;
+      try {
+        canonicalPath = await withinListDeadline(
+          realpath(resolveWorkspacePath(root, candidate.filesystemPath)),
+          signal,
+          deadline,
+        );
+      } catch (error) {
+        if (error instanceof WorkspaceToolError) throw error;
+        continue;
+      }
+      if (!isWithinRoot(root, canonicalPath)) {
+        continue;
+      }
+      const reportedPath = resolveWorkspacePath(root, candidate.resultPath);
+      try {
+        const reportedPathStat = await withinListDeadline(
+          lstat(reportedPath),
+          signal,
+          deadline,
+        );
+        if (reportedPathStat.isSymbolicLink()) continue;
+        const canonicalReportedPath = await withinListDeadline(
+          realpath(reportedPath),
+          signal,
+          deadline,
+        );
+        if (canonicalReportedPath !== canonicalPath) continue;
+      } catch (error) {
+        if (error instanceof WorkspaceToolError) throw error;
+        continue;
+      }
+      let regularFile = false;
+      try {
+        regularFile = (
+          await withinListDeadline(stat(canonicalPath), signal, deadline)
+        ).isFile();
+      } catch (error) {
+        if (error instanceof WorkspaceToolError) throw error;
+        continue;
+      }
+      if (!regularFile || seenPaths.has(candidate.resultPath)) continue;
+      if (paths.length === maxResults) {
+        truncated = true;
+        break;
+      }
+      seenPaths.add(candidate.resultPath);
+      paths.push(candidate.resultPath);
+    }
+
+    if (truncated && paths.length === 0) {
+      // A scan window can consist entirely of vanished files or symlinks.
+      // Advance the internal scan cursor, not the public page cursor, and
+      // keep the original deadline and per-window candidate limit.
+      afterPath = candidates[candidates.length - 1].resultPath;
       continue;
     }
-    if (!isWithinRoot(root, canonicalPath)) {
-      continue;
-    }
-    const reportedPath = resolveWorkspacePath(root, candidate.resultPath);
-    try {
-      const reportedPathStat = await withinListDeadline(
-        lstat(reportedPath),
-        signal,
-        deadline,
-      );
-      if (reportedPathStat.isSymbolicLink()) continue;
-      const canonicalReportedPath = await withinListDeadline(
-        realpath(reportedPath),
-        signal,
-        deadline,
-      );
-      if (canonicalReportedPath !== canonicalPath) continue;
-    } catch (error) {
-      if (error instanceof WorkspaceToolError) throw error;
-      continue;
-    }
-    let regularFile = false;
-    try {
-      regularFile = (
-        await withinListDeadline(stat(canonicalPath), signal, deadline)
-      ).isFile();
-    } catch (error) {
-      if (error instanceof WorkspaceToolError) throw error;
-      continue;
-    }
-    if (!regularFile || seenPaths.has(candidate.resultPath)) continue;
-    if (paths.length === maxResults) {
-      truncated = true;
-      break;
-    }
-    seenPaths.add(candidate.resultPath);
-    paths.push(candidate.resultPath);
+
+    return {
+      protocolVersion: BRIDGE_PROTOCOL_VERSION,
+      operation: 'list_files',
+      workspaceId: request.workspaceId,
+      paths,
+      truncated,
+      ...(truncated && paths.length > 0
+        ? { nextAfterPath: paths[paths.length - 1] }
+        : {}),
+    };
   }
-
-  return {
-    protocolVersion: BRIDGE_PROTOCOL_VERSION,
-    operation: 'list_files',
-    workspaceId: request.workspaceId,
-    paths,
-    truncated,
-    ...(truncated && paths.length > 0
-      ? { nextAfterPath: paths[paths.length - 1] }
-      : {}),
-  };
 }
 
 async function withinListDeadline<T>(
@@ -1360,6 +1371,9 @@ async function withinListDeadline<T>(
   signal: AbortSignal | undefined,
   deadline: number,
 ): Promise<T> {
+  // The filesystem operation has already started. Observe its rejection even
+  // when cancellation or the deadline prevents us from waiting for it.
+  void operation.catch(() => undefined);
   if (signal?.aborted) {
     throw new WorkspaceToolError(
       'Workspace tool execution aborted',


### PR DESCRIPTION
I fixed workspace listings that returned an empty, truncated page without a cursor after every candidate in a bounded scan window was skipped. Valid files after runs of vanished files or symlinks now remain reachable. Closes #131.

- Continue scanning successive bounded windows only when verification produces no valid result and discovery has more candidates.
- Advance an internal cursor past the verified window while deriving public continuation cursors only from returned files.
- Preserve the original ten-second deadline, cancellation handling, candidate cap, filesystem checks, and negotiated pagination contract across every window.
- Observe already-started filesystem rejections when a deadline or cancellation prevents waiting, avoiding unhandled rejection failures.

The large production diff is predominantly indentation of the existing scan and verification block inside the continuation loop; `git diff -w` isolates the behavioral changes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Passed `npm run build` in `packages/code`.
- Ran `node --test dist/workspace-listing.test.js dist/workspace.test.js`: 66 passed, one existing platform-dependent test skipped, zero failures.
- Confirmed all five new regression tests fail on unmodified `main` and pass with this change.
- Covered two complete skipped-candidate windows followed by valid files, continuation pagination, exhausted empty listings, cancellation in a later window, and a shared deadline using a controlled clock.
- Asserted candidate-window stops remain bounded and returned pages pass the negotiated result validator.
- Passed `git diff --check`; the package has no lint script.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
