### PR TITLE
fix: fail closed when credential ACL verification is unavailable

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -35,6 +35,14 @@ LIBRECHAT_CODE_SANDBOX_ENDPOINT=http://127.0.0.1:2000/api/v2 \
 librechat-code run
 ```
 
+Credential and quarantine storage currently requires Linux (including WSL2),
+where ownership and POSIX mode/ACL-mask checks can establish owner-only access.
+Native Windows and macOS fail closed before pairing-code redemption, credential
+loads, or storage mutations because their extended ACLs cannot yet be verified.
+Use storage on a native Linux filesystem, not a Windows drive under `/mnt`.
+Support for these platforms requires a native ACL verifier; `chmod` alone is
+not sufficient.
+
 Use `--identity <path>` while pairing and
 `LIBRECHAT_CODE_IDENTITY_FILE=<path>` while running to override the identity
 file location.
@@ -104,8 +112,9 @@ read only by the trusted worker, which mints and refreshes short-lived
 installation tokens. A personal access token is supported as a fallback with
 `LIBRECHAT_CODE_GITHUB_TOKEN`, but the GitHub App is the safer default because
 its repository access and permissions can be narrowly installed and revoked.
-Native Windows currently requires token mode because the worker cannot
-reliably validate private-key ACLs there; use WSL2 for GitHub App mode.
+Native Windows and macOS credential storage are unavailable until native ACL
+verification is implemented; use Linux or WSL2. This also applies to GitHub App
+private keys.
 
 Git receives authentication through process-scoped `GIT_CONFIG_*` variables.
 The same isolated config supplies the standard Git LFS filters; hosts using LFS

--- a/packages/code/src/github.ts
+++ b/packages/code/src/github.ts
@@ -2,6 +2,7 @@ import { constants } from 'node:fs';
 import { createHash, createPrivateKey, sign } from 'node:crypto';
 import { open, realpath, stat } from 'node:fs/promises';
 import { dirname } from 'node:path';
+import { assertPrivateStorageSupported } from './private-storage.js';
 
 export const GITHUB_CREDENTIAL_ENV_NAME = 'LIBRECHAT_CODE_GITHUB_AUTHORIZATION';
 export const GITHUB_ALLOWED_DOMAINS = [
@@ -44,6 +45,7 @@ function assertPositiveIdentifier(name: string, value: string): void {
 }
 
 async function readPrivateKey(path: string): Promise<string> {
+  assertPrivateStorageSupported();
   if (process.platform !== 'win32') {
     const directory = await stat(await realpath(dirname(path)));
     const uid = process.getuid?.();

--- a/packages/code/src/private-storage.test.ts
+++ b/packages/code/src/private-storage.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { assertPrivateStorageSupported } from './private-storage.js';
+import { assertIdentityPathIsPrivate, saveBridgeIdentity, loadBridgeIdentity,
+  saveWorkspaceMutationQuarantine, loadWorkspaceMutationQuarantine,
+  clearWorkspaceMutationQuarantine, ensurePrivateWorkspaceDirectory } from './storage.js';
+import { GitHubAppCredentialProvider } from './github.js';
+
+const identity = { protocolVersion: 1 as const, workerId: 'worker',
+  codeApiUrl: 'https://example.com', credential: 'private', privateKey: 'private',
+  publicKey: 'public', expiresAt: '2099-01-01T00:00:00Z' };
+const quarantine = { version: 1 as const, workerId: 'worker', workspaceId: 'primary',
+  reason: 'uncertain mutation', quarantinedAt: '2026-01-01T00:00:00Z' };
+
+for (const unsupported of ['win32', 'darwin', 'freebsd']) {
+  test(`${unsupported} refuses storage before creation, reads, or deletion`, async t => {
+    const root = await mkdtemp(join(tmpdir(), 'private-storage-'));
+    t.after(() => rm(root, { recursive: true, force: true }));
+    const existing = join(root, 'existing.json');
+    await writeFile(existing, JSON.stringify(identity), { mode: 0o600 });
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    t.after(() => Object.defineProperty(process, 'platform', platform));
+    Object.defineProperty(process, 'platform', { ...platform, value: unsupported });
+    const path = join(root, 'missing', 'identity.json');
+    for (const action of [
+      () => assertIdentityPathIsPrivate(path), () => saveBridgeIdentity(path, identity),
+      () => loadBridgeIdentity(existing), () => saveWorkspaceMutationQuarantine(path, quarantine),
+      () => loadWorkspaceMutationQuarantine(path), () => clearWorkspaceMutationQuarantine(existing),
+      () => ensurePrivateWorkspaceDirectory(join(root, 'workspace')),
+    ]) await assert.rejects(action(), /ACL verification is unavailable/);
+    assert.deepEqual(await readdir(root), ['existing.json']);
+    assert.equal(await readFile(existing, 'utf8'), JSON.stringify(identity));
+  });
+}
+
+test('GitHub App credentials also reject unsupported ACL verification before signing or fetching', async t => {
+  const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  t.after(() => Object.defineProperty(process, 'platform', platform));
+  Object.defineProperty(process, 'platform', { ...platform, value: 'darwin' });
+  let fetched = false;
+  const provider = new GitHubAppCredentialProvider({
+    appId: '1', installationId: '1', privateKeyPath: '/must-not-be-read',
+    fetch: async () => { fetched = true; throw new Error('must not fetch'); },
+  });
+  await assert.rejects(provider.getCredential(), /ACL verification is unavailable/);
+  assert.equal(fetched, false);
+});
+
+test('Linux still requires an available ownership API', t => {
+  const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  const getuid = Object.getOwnPropertyDescriptor(process, 'getuid');
+  t.after(() => {
+    Object.defineProperty(process, 'platform', platform);
+    if (getuid) Object.defineProperty(process, 'getuid', getuid);
+    else delete process.getuid;
+  });
+  Object.defineProperty(process, 'platform', { ...platform, value: 'linux' });
+  Object.defineProperty(process, 'getuid', { configurable: true, value: undefined });
+  assert.throws(assertPrivateStorageSupported, /ACL verification is unavailable/);
+});

--- a/packages/code/src/private-storage.ts
+++ b/packages/code/src/private-storage.ts
@@ -1,0 +1,16 @@
+import { BridgeProtocolError } from './protocol.js';
+
+/** Linux POSIX ACL masks are reflected in group mode bits. macOS extended
+ * ACLs and Windows DACLs are not: chmod/stat alone cannot establish privacy.
+ * Fail before creating files, reading credentials, or redeeming pairing codes
+ * until a native verifier can inspect the actual opened object's ACLs.
+ */
+export function assertPrivateStorageSupported(): void {
+  if (process.platform !== 'linux' || process.getuid === undefined) {
+    throw new BridgeProtocolError(
+      'Owner-only storage ACL verification is unavailable on this platform. ' +
+      'Worker credentials, GitHub App keys, and quarantine state require Linux ' +
+      '(including WSL2) with storage on a native Linux filesystem, not /mnt.',
+    );
+  }
+}

--- a/packages/code/src/storage.ts
+++ b/packages/code/src/storage.ts
@@ -14,6 +14,7 @@ import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 
 import { BRIDGE_PROTOCOL_VERSION, BridgeProtocolError } from './protocol.js';
+import { assertPrivateStorageSupported } from './private-storage.js';
 
 import type { PairedBridgeWorkerIdentity } from './pairing.js';
 
@@ -168,12 +169,8 @@ export function defaultWorkspaceQuarantinePath(
  * Symlinks are resolved: a link's own mode is always `0777` and ignored by the
  * kernel, so the file the bytes live in is what counts.
  *
- * This reads POSIX mode bits, which is not the whole access story everywhere.
- * A Linux POSIX ACL surfaces its mask in the group bits and so is caught, but
- * a macOS extended ACL inherited from the parent directory is invisible here
- * and survives `chmod`, and Windows is exempt entirely. Establishing owner-only
- * storage on those needs real ACL inspection; until then this verifies what the
- * mode can express and nothing more.
+ * Linux POSIX ACL masks are reflected in group mode bits. Platforms whose
+ * ACLs cannot be verified are rejected at the storage entry points.
  */
 async function groupOrOtherAccessMode(
   path: string,
@@ -310,6 +307,7 @@ async function assertOwnerOnlyPath(
 export async function ensurePrivateWorkspaceDirectory(
   path: string,
 ): Promise<void> {
+  assertPrivateStorageSupported();
   await mkdir(path, { recursive: true, mode: 0o700 });
   const metadata = await lstat(path);
   if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
@@ -390,6 +388,7 @@ async function assertSiblingPublishable(path: string): Promise<void> {
 export async function assertIdentityPathIsPrivate(
   path: string,
 ): Promise<IdentityPathReservation> {
+  assertPrivateStorageSupported();
   await mkdir(dirname(path), { recursive: true, mode: 0o700 });
   await assertIdentityDestinationIsReplaceable(path);
   let created = false;
@@ -452,6 +451,7 @@ export async function saveBridgeIdentity(
   path: string,
   identity: PairedBridgeWorkerIdentity,
 ): Promise<void> {
+  assertPrivateStorageSupported();
   await mkdir(dirname(path), { recursive: true, mode: 0o700 });
   const temporaryPath = `${path}.${randomBytes(8).toString('hex')}.tmp`;
   try {
@@ -492,6 +492,7 @@ export async function saveWorkspaceMutationQuarantine(
   path: string,
   record: WorkspaceMutationQuarantineRecord,
 ): Promise<void> {
+  assertPrivateStorageSupported();
   await ensureDurableDirectory(dirname(path));
   const file = await open(path, 'wx', 0o600);
   try {
@@ -521,6 +522,7 @@ export async function saveWorkspaceMutationQuarantine(
 export async function loadWorkspaceMutationQuarantine(
   path: string,
 ): Promise<WorkspaceMutationQuarantineRecord | undefined> {
+  assertPrivateStorageSupported();
   /* A marker another account can rewrite is not a control: it could be cleared
    * to resume mutations, or forged to wedge the worker under a foreign owner. */
   let content: string;
@@ -553,6 +555,7 @@ export async function clearWorkspaceMutationQuarantine(
   path: string,
   ownerId?: string,
 ): Promise<void> {
+  assertPrivateStorageSupported();
   if (ownerId != null) {
     const record = await loadWorkspaceMutationQuarantine(path);
     if (record == null || record.ownerId !== ownerId) {
@@ -586,6 +589,7 @@ export async function assertWorkspaceMutationQuarantineOwner(
 export async function loadBridgeIdentity(
   path: string,
 ): Promise<PairedBridgeWorkerIdentity> {
+  assertPrivateStorageSupported();
   /* An identity written before this check, or by an older release, is still a
    * private key other local accounts can read. Refuse it rather than booting. */
   const content = await readGuardedFile(


### PR DESCRIPTION
I made credential and quarantine storage fail closed when owner-only ACL verification is unavailable. Native macOS and Windows now reject pairing preflight, identity reads/writes, and quarantine operations; Linux and WSL2 retain the existing ownership and mode/ACL-mask checks. This addresses the ACL portion of #135; ancestor replacement and bind-mounted destinations are separate follow-ups.

- Reject unsupported platforms before creating directories, reading credential bytes, deleting markers, or redeeming a pairing code.
- Apply the same guard to GitHub App private-key reads so that credential path cannot bypass the restriction.
- Document the deliberate compatibility restriction and Linux/WSL2 recovery path.

macOS `/dev/fd` inspection through `ls` does not report the underlying inode's ACL. I rejected that approach rather than accepting an unreliable clean verdict. Native support requires a verifier that can inspect the opened object's ACL.

## Change Type

- [x] Bug fix
- [x] Breaking change (native macOS/Windows credential persistence now fails closed)
- [x] Documentation update

## Testing

- Passed the package TypeScript build and five new unsupported-platform tests on macOS.
- Passed 30 existing storage/GitHub tests with four unavailable-fixture skips using a Linux-policy override on the macOS host; native Linux validation is delegated to CI.
- Verified unsupported-platform rejection leaves existing files intact and creates no new storage; GitHub rejection occurs before fetching a token.
- Passed `git diff --check`; this package has no lint script.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
