### PR TITLE
fix: validate every credential storage ancestor

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -43,6 +43,12 @@ Use storage on a native Linux filesystem, not a Windows drive under `/mnt`.
 Support for these platforms requires a native ACL verifier; `chmod` alone is
 not sufficient.
 
+Every storage ancestor, including intermediate symlink entries and targets, must
+be owned by this account or root and must not allow group/other writes unless
+protected by the sticky bit. A private directory inside a shared writable parent
+is insufficient: that parent can replace the directory. This also applies when
+loading GitHub App keys or clearing quarantine state.
+
 Use `--identity <path>` while pairing and
 `LIBRECHAT_CODE_IDENTITY_FILE=<path>` while running to override the identity
 file location.

--- a/packages/code/src/github.test.ts
+++ b/packages/code/src/github.test.ts
@@ -197,7 +197,7 @@ test('rejects a GitHub App key in a shared writable directory', async (t) => {
 
   await assert.rejects(
     provider.getCredential(),
-    /private key directory must not be writable/,
+    /writable by other accounts/,
   );
 });
 

--- a/packages/code/src/github.ts
+++ b/packages/code/src/github.ts
@@ -1,8 +1,8 @@
 import { constants } from 'node:fs';
 import { createHash, createPrivateKey, sign } from 'node:crypto';
-import { open, realpath, stat } from 'node:fs/promises';
+import { open } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { assertPrivateStorageSupported } from './private-storage.js';
+import { assertPrivateStorageAncestors, assertPrivateStorageSupported } from './private-storage.js';
 
 export const GITHUB_CREDENTIAL_ENV_NAME = 'LIBRECHAT_CODE_GITHUB_AUTHORIZATION';
 export const GITHUB_ALLOWED_DOMAINS = [
@@ -46,23 +46,7 @@ function assertPositiveIdentifier(name: string, value: string): void {
 
 async function readPrivateKey(path: string): Promise<string> {
   assertPrivateStorageSupported();
-  if (process.platform !== 'win32') {
-    const directory = await stat(await realpath(dirname(path)));
-    const uid = process.getuid?.();
-    if (uid !== undefined && directory.uid !== uid && directory.uid !== 0) {
-      throw new Error(
-        'GitHub App private key directory must be owned by this user or root',
-      );
-    }
-    const mode = directory.mode & 0o7777;
-    const protectedByStickyBit =
-      (mode & 0o1000) !== 0 && (directory.uid === uid || directory.uid === 0);
-    if ((mode & 0o022) !== 0 && !protectedByStickyBit) {
-      throw new Error(
-        'GitHub App private key directory must not be writable by group or other users',
-      );
-    }
-  }
+  await assertPrivateStorageAncestors(dirname(path));
 
   const handle = await open(
     path,

--- a/packages/code/src/private-storage.ts
+++ b/packages/code/src/private-storage.ts
@@ -1,3 +1,6 @@
+import { lstat, readlink } from 'node:fs/promises';
+import { dirname, isAbsolute } from 'node:path';
+
 import { BridgeProtocolError } from './protocol.js';
 
 /** Linux POSIX ACL masks are reflected in group mode bits. macOS extended
@@ -12,5 +15,58 @@ export function assertPrivateStorageSupported(): void {
       'Worker credentials, GitHub App keys, and quarantine state require Linux ' +
       '(including WSL2) with storage on a native Linux filesystem, not /mnt.',
     );
+  }
+}
+
+/**
+ * Walk from the trust root before touching a descendant. Checking only a
+ * canonical parent misses replaceable ancestors and symlink entries. Resolve
+ * links one component at a time so even intermediate link targets are checked.
+ * Other local accounts cannot replace a checked entry: its parent is either
+ * non-writable or sticky and the entry belongs to this account or root.
+ */
+export async function assertPrivateStorageAncestors(
+  path: string,
+  allowMissing = false,
+): Promise<void> {
+  assertPrivateStorageSupported();
+  const uid = process.getuid!();
+  let current = '/';
+  const pending = (isAbsolute(path) ? path : `${process.cwd()}/${path}`).split('/');
+  let links = 0;
+  while (true) {
+    const metadata = await lstat(current).catch((error: NodeJS.ErrnoException) => {
+      if (allowMissing && error.code === 'ENOENT') return undefined;
+      throw error;
+    });
+    if (metadata === undefined) return;
+    if (metadata.uid !== uid && metadata.uid !== 0) {
+      throw new BridgeProtocolError(
+        `${current} is owned by another account (uid ${metadata.uid}), ` +
+          `which can replace ${path}. Keep worker storage on paths this account or root owns.`,
+      );
+    }
+    if (metadata.isSymbolicLink()) {
+      if (++links > 40) throw new BridgeProtocolError(`Too many storage symlinks: ${path}`);
+      const target = await readlink(current);
+      current = isAbsolute(target) ? '/' : dirname(current);
+      pending.unshift(...target.split('/'));
+      continue;
+    }
+    if (metadata.isDirectory()) {
+      const mode = metadata.mode & 0o7777;
+      if ((mode & 0o022) !== 0 && (mode & 0o1000) === 0) {
+        throw new BridgeProtocolError(
+          `Directory ${current} is writable by other accounts (mode ${mode.toString(8)}), ` +
+            `so ${path} can be replaced even while owner-only.`,
+        );
+      }
+    } else if (pending.some((part) => part !== '' && part !== '.')) {
+      throw new BridgeProtocolError(`Storage ancestor must be a directory: ${current}`);
+    }
+    let next = pending.shift();
+    while (next === '' || next === '.') next = pending.shift();
+    if (next === undefined) return;
+    current = next === '..' ? dirname(current) : `${current === '/' ? '' : current}/${next}`;
   }
 }

--- a/packages/code/src/storage-ancestors.test.ts
+++ b/packages/code/src/storage-ancestors.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { GitHubAppCredentialProvider } from './github.js';
+import { assertPrivateStorageAncestors } from './private-storage.js';
+import {
+  assertIdentityPathIsPrivate, clearWorkspaceMutationQuarantine,
+  ensurePrivateWorkspaceDirectory, loadBridgeIdentity, loadWorkspaceMutationQuarantine,
+  saveBridgeIdentity, saveWorkspaceMutationQuarantine,
+} from './storage.js';
+
+const identity = {
+  protocolVersion: 1 as const, workerId: 'worker', codeApiUrl: 'https://code.example/v1',
+  credential: 'secret', expiresAt: '2099-01-01T00:00:00Z', publicKey: 'public', privateKey: 'private',
+};
+const marker = {
+  version: 1 as const, workerId: 'worker', workspaceId: 'workspace', ownerId: 'owner',
+  quarantinedAt: '2026-01-01T00:00:00Z', reason: 'uncertain result',
+};
+
+test('a writable ancestor blocks every storage operation before changing private descendants', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'storage-ancestors-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const parent = join(root, 'shared');
+  const privateDir = join(parent, 'private');
+  await mkdir(privateDir, { recursive: true, mode: 0o700 });
+  const credential = join(privateDir, 'identity.json');
+  const quarantine = join(privateDir, 'quarantine.json');
+  await saveBridgeIdentity(credential, identity);
+  await saveWorkspaceMutationQuarantine(quarantine, marker);
+  const reservation = await assertIdentityPathIsPrivate(join(privateDir, 'reserved.json'));
+  await chmod(parent, 0o777);
+  for (const operation of [
+    () => loadBridgeIdentity(credential),
+    () => saveBridgeIdentity(credential, identity),
+    () => assertIdentityPathIsPrivate(credential),
+    () => assertIdentityPathIsPrivate(join(privateDir, 'missing', 'identity.json')),
+    () => loadWorkspaceMutationQuarantine(quarantine),
+    () => loadWorkspaceMutationQuarantine(join(privateDir, 'absent.json')),
+    () => saveWorkspaceMutationQuarantine(join(privateDir, 'new.json'), marker),
+    () => clearWorkspaceMutationQuarantine(quarantine),
+    () => clearWorkspaceMutationQuarantine(quarantine, 'owner'),
+    () => ensurePrivateWorkspaceDirectory(join(privateDir, 'workspace')),
+    () => reservation.release(),
+  ]) await assert.rejects(operation(), /writable by other accounts/);
+  assert.deepEqual((await readdir(privateDir)).sort(), ['identity.json', 'quarantine.json', 'reserved.json']);
+  assert.deepEqual(JSON.parse(await readFile(credential, 'utf8')), identity);
+  assert.deepEqual(JSON.parse(await readFile(quarantine, 'utf8')), marker);
+
+  // A trusted sticky parent protects this account's private directory entry.
+  await chmod(parent, 0o1777);
+  assert.deepEqual(await loadBridgeIdentity(credential), identity);
+  await clearWorkspaceMutationQuarantine(quarantine, 'owner');
+  await reservation.release();
+});
+
+test('intermediate symlinks cannot hide replaceable entry or target ancestors', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'storage-links-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const shared = join(root, 'shared');
+  const privateDir = join(shared, 'private');
+  const safe = join(root, 'safe');
+  await mkdir(privateDir, { recursive: true, mode: 0o700 });
+  await mkdir(safe, { mode: 0o700 });
+  const file = join(safe, 'identity.json');
+  await saveBridgeIdentity(file, identity);
+  await symlink(safe, join(privateDir, 'alias'));
+  await symlink(join(privateDir, 'alias'), join(root, 'indirect'));
+  await symlink(privateDir, join(root, 'target'));
+  await chmod(shared, 0o777);
+  for (const path of [
+    join(privateDir, 'alias', 'identity.json'),
+    join(root, 'indirect', 'identity.json'),
+    join(root, 'target', 'missing.json'),
+    // Do not lexically normalize away a component the kernel traverses.
+    `${root}/indirect/../safe/identity.json`,
+  ]) await assert.rejects(assertIdentityPathIsPrivate(path), /writable by other accounts/);
+  await assert.rejects(loadBridgeIdentity(join(root, 'indirect', 'identity.json')), /writable by other accounts/);
+});
+
+test('a symlink owned by another account is rejected even under a trusted sticky parent', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'storage-link-owner-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const link = join(root, 'alias');
+  await symlink(root, link);
+  // Use a metadata fixture: changing real ownership requires administrator access.
+  const fs = await import('node:fs/promises');
+  const { syncBuiltinESMExports } = await import('node:module');
+  const original = fs.default.lstat;
+  t.after(() => { fs.default.lstat = original; syncBuiltinESMExports(); });
+  fs.default.lstat = (async (...args: Parameters<typeof original>) => {
+    const metadata = await original(...args);
+    if (String(args[0]).endsWith('/alias')) Object.defineProperty(metadata, 'uid', { value: process.getuid!() + 1000 });
+    return metadata;
+  }) as typeof original;
+  syncBuiltinESMExports();
+  await chmod(root, 0o1777);
+  await assert.rejects(assertPrivateStorageAncestors(link), /owned by another account/);
+});
+
+test('GitHub App keys reject writable ancestors before making a token request', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'github-ancestors-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const privateDir = join(root, 'private');
+  await mkdir(privateDir, { mode: 0o700 });
+  const path = join(privateDir, 'app.pem');
+  await writeFile(path, 'never read', { mode: 0o600 });
+  await chmod(root, 0o777);
+  let requested = false;
+  const provider = new GitHubAppCredentialProvider({
+    appId: '1', installationId: '2', privateKeyPath: path,
+    fetch: async () => { requested = true; throw new Error('unexpected request'); },
+  });
+  await assert.rejects(provider.getCredential(), /writable by other accounts/);
+  assert.equal(requested, false);
+});

--- a/packages/code/src/storage.ts
+++ b/packages/code/src/storage.ts
@@ -4,8 +4,6 @@ import {
   lstat,
   mkdir,
   open,
-  readFile,
-  realpath,
   rename,
   rm,
   stat,
@@ -14,7 +12,7 @@ import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 
 import { BRIDGE_PROTOCOL_VERSION, BridgeProtocolError } from './protocol.js';
-import { assertPrivateStorageSupported } from './private-storage.js';
+import { assertPrivateStorageAncestors, assertPrivateStorageSupported } from './private-storage.js';
 
 import type { PairedBridgeWorkerIdentity } from './pairing.js';
 
@@ -182,60 +180,13 @@ async function groupOrOtherAccessMode(
   return (mode & 0o077) === 0 ? undefined : mode;
 }
 
-/**
- * A `0600` file in a directory other accounts can write is not owner-only in
- * practice: they cannot read it, but they can unlink and substitute it, so a
- * swapped credential or a forged quarantine marker would be trusted. The sticky
- * bit counts as protection, which keeps shared `/tmp`-style parents usable. A
- * writable ancestor above a private directory could still have that directory
- * renamed out from under us, which is broader hardening than this addresses.
- *
- * Deliberately not applied to the registered workspace, which is the user's own
- * project directory and may legitimately be shared.
- */
-async function assertDirectoryNotSharedWritable(
-  directory: string,
-  path: string,
-): Promise<void> {
-  const metadata = await stat(directory);
-  const mode = metadata.mode & 0o7777;
-  const uid = process.getuid?.();
-  if (uid !== undefined && !isTrustedOwner(metadata.uid, uid)) {
-    throw new BridgeProtocolError(
-      `Directory ${directory} is owned by another account (uid ${metadata.uid}), ` +
-        `which can grant itself write access and replace ${path}. Keep worker ` +
-        'credentials in a directory this account owns.',
-    );
-  }
-  if ((mode & 0o022) === 0) return;
-  if ((mode & 0o1000) !== 0 && (metadata.uid === uid || metadata.uid === 0)) {
-    return;
-  }
-  throw new BridgeProtocolError(
-    `Directory ${directory} is writable by other accounts (mode ${mode.toString(8)}), ` +
-      `so ${path} can be replaced even while owner-only. Keep worker credentials ` +
-      'in a directory only this account can write.',
-  );
-}
-
-/** Publishing goes through `rename`, which replaces the named entry itself. */
+/** Publishing replaces the entry itself; reading also follows its target. */
 async function assertWriteContainerPrivate(path: string): Promise<void> {
-  if (process.platform === 'win32' || process.getuid === undefined) return;
-  await assertDirectoryNotSharedWritable(await realpath(dirname(path)), path);
+  await assertPrivateStorageAncestors(dirname(path), true);
 }
 
-/**
- * Reading follows the link, so both the entry and the file it names are trust
- * boundaries: a writable directory at either end allows a substitution.
- */
 async function assertReadPathPrivate(path: string): Promise<void> {
-  if (process.platform === 'win32' || process.getuid === undefined) return;
-  const entryDirectory = await realpath(dirname(path));
-  await assertDirectoryNotSharedWritable(entryDirectory, path);
-  const targetDirectory = dirname(await realpath(path));
-  if (targetDirectory !== entryDirectory) {
-    await assertDirectoryNotSharedWritable(targetDirectory, path);
-  }
+  await assertPrivateStorageAncestors(path);
 }
 
 /** Root is the trust root; anyone else holding a credential path is not. */
@@ -270,6 +221,7 @@ async function readGuardedFile(
   path: string,
   exposed: (mode: string) => string,
 ): Promise<string> {
+  await assertReadPathPrivate(path);
   const handle = await open(path, 'r');
   try {
     const stats = await handle.stat();
@@ -308,16 +260,18 @@ export async function ensurePrivateWorkspaceDirectory(
   path: string,
 ): Promise<void> {
   assertPrivateStorageSupported();
+  await assertWriteContainerPrivate(path);
   await mkdir(path, { recursive: true, mode: 0o700 });
+  await assertWriteContainerPrivate(path);
   const metadata = await lstat(path);
   if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
     throw new BridgeProtocolError('Default workspace path must be a directory');
   }
-  await chmod(path, 0o700);
-  await assertOwnerOnlyPath(path);
   /* This directory is application-owned by contract; a pre-existing one under
    * another account lets that owner alter workspace inputs and results. */
   await assertOwnedByWorker(path);
+  await chmod(path, 0o700);
+  await assertOwnerOnlyPath(path);
 }
 
 /**
@@ -389,7 +343,9 @@ export async function assertIdentityPathIsPrivate(
   path: string,
 ): Promise<IdentityPathReservation> {
   assertPrivateStorageSupported();
+  await assertWriteContainerPrivate(path);
   await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  await assertWriteContainerPrivate(path);
   await assertIdentityDestinationIsReplaceable(path);
   let created = false;
   let reservedInode: bigint | undefined;
@@ -431,6 +387,7 @@ export async function assertIdentityPathIsPrivate(
   return {
     async release(): Promise<void> {
       if (!created || reservedInode === undefined) return;
+      await assertWriteContainerPrivate(path);
       /* Only ever drop the placeholder this call made. A concurrent `pair`
        * may have published a real identity over the name since, and removing
        * that would destroy a credential whose code is already spent. */
@@ -452,7 +409,9 @@ export async function saveBridgeIdentity(
   identity: PairedBridgeWorkerIdentity,
 ): Promise<void> {
   assertPrivateStorageSupported();
+  await assertWriteContainerPrivate(path);
   await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  await assertWriteContainerPrivate(path);
   const temporaryPath = `${path}.${randomBytes(8).toString('hex')}.tmp`;
   try {
     const file = await open(temporaryPath, 'wx', 0o600);
@@ -493,7 +452,9 @@ export async function saveWorkspaceMutationQuarantine(
   record: WorkspaceMutationQuarantineRecord,
 ): Promise<void> {
   assertPrivateStorageSupported();
+  await assertWriteContainerPrivate(path);
   await ensureDurableDirectory(dirname(path));
+  await assertWriteContainerPrivate(path);
   const file = await open(path, 'wx', 0o600);
   try {
     try {
@@ -556,6 +517,7 @@ export async function clearWorkspaceMutationQuarantine(
   ownerId?: string,
 ): Promise<void> {
   assertPrivateStorageSupported();
+  await assertWriteContainerPrivate(path);
   if (ownerId != null) {
     const record = await loadWorkspaceMutationQuarantine(path);
     if (record == null || record.ownerId !== ownerId) {


### PR DESCRIPTION
## Summary

I closed the ancestor-replacement gap from #135: a private credential directory beneath a writable ancestor now fails validation before storage is trusted or changed.

- Walk every path component from the root, including intermediate symlink entries and targets, without normalizing away components the kernel traverses.
- Require trusted ownership and non-writable or sticky directories throughout the chain.
- Apply the same rule to identity preflight, saves, reads, reservation cleanup, quarantine state, default workspace creation, and GitHub App key parents.
- Preserve trusted sticky-directory support and existing credential formats.

Depends on #138 for the Linux-only ACL verification boundary. This PR targets its branch to keep the diff focused; merge #138 first. Bind-mount preflight is a separate follow-up for #135.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- Built with `npm --prefix packages/code run build`.
- Ran storage, GitHub, and ancestor regression suites: 34 passed, 4 skipped because this host has no chmod-ignoring mount.
- Ran platform fail-closed regressions: 5 passed.
- Checked `git diff --check`.

### **Test Configuration**:

Node 24.16.0 on macOS. Filesystem regression suites used a process-platform override to exercise the Linux mode policy locally; this is policy simulation, not native Linux verification. CI runs the package suite on Linux. Reproduce there with `npm --prefix packages/code test`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
