### PR TITLE
fix: reject identity mount targets before pairing

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -53,6 +53,14 @@ Use `--identity <path>` while pairing and
 `LIBRECHAT_CODE_IDENTITY_FILE=<path>` while running to override the identity
 file location.
 
+The identity file itself must not be a bind-mount target: saving a paired
+credential atomically replaces that entry. Mount its containing directory
+instead. Pairing preflight checks `/proc/self/mountinfo` before redeeming the
+one-time code and fails closed if mount information cannot be verified (including
+a mount table larger than 4 MiB). Existing identity reads remain supported.
+The check describes the current mount namespace; administrators must keep mount
+configuration stable during pairing.
+
 ## Native BYOM sandbox (default)
 
 The MVP command sandbox runs directly on the user's chosen laptop or VM. It

--- a/packages/code/src/identity-mount.test.ts
+++ b/packages/code/src/identity-mount.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs, { mkdtemp, readFile, readdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { syncBuiltinESMExports } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { identityIsMountPoint } from './identity-mount.js';
+import { assertIdentityPathIsPrivate, saveBridgeIdentity } from './storage.js';
+
+const rootMount = '1 0 8:1 / / rw - ext4 /dev/root rw\n';
+const encode = (path: string) => path.replace(/[\\ \t\n]/g, (char) =>
+  `\\${char.charCodeAt(0).toString(8).padStart(3, '0')}`,
+);
+const mount = (path: string) => `${rootMount}2 1 8:1 /source ${encode(path)} rw shared:1 - ext4 /dev/root rw\n`;
+const identity = {
+  protocolVersion: 1 as const, workerId: 'worker', codeApiUrl: 'https://code.example/v1',
+  credential: 'secret', expiresAt: '2099-01-01T00:00:00Z', publicKey: 'public', privateKey: 'private',
+};
+
+test('mount parsing detects same-device bind mounts and escaped path names', () => {
+  for (const path of ['/home/worker/key.json', '/home/worker/key with\tline\nbreak\\040']) {
+    assert.equal(identityIsMountPoint(mount(path), path), true);
+    assert.equal(identityIsMountPoint(mount(path), `${path}.sibling`), false);
+  }
+  assert.equal(identityIsMountPoint(mount('/home/worker'), '/home/worker/key.json'), false);
+  for (const invalid of ['', 'malformed\n', '1 0 8:1 / /bad\\999 rw - ext4 /dev/root rw\n']) {
+    assert.throws(() => identityIsMountPoint(invalid, '/key'), /malformed/);
+  }
+});
+
+test('preflight and direct saves refuse mounted destinations without altering them', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'identity-mount-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const path = join(root, 'identity.json');
+  const fixture = join(root, 'mountinfo');
+  await writeFile(path, 'existing credential', { mode: 0o600 });
+  await writeFile(fixture, mount(await realpath(path)));
+  const original = fs.open;
+  fs.open = ((path, ...args) => original(path === '/proc/self/mountinfo' ? fixture : path, ...args)) as typeof fs.open;
+  syncBuiltinESMExports();
+  t.after(() => { fs.open = original; syncBuiltinESMExports(); });
+  await assert.rejects(assertIdentityPathIsPrivate(path), /is a mount point/);
+  await assert.rejects(saveBridgeIdentity(path, identity), /is a mount point/);
+  assert.equal(await readFile(path, 'utf8'), 'existing credential');
+  assert.deepEqual((await readdir(root)).sort(), ['identity.json', 'mountinfo']);
+
+  // Parent aliases still name the mounted entry; a leaf link can be replaced.
+  const parentAlias = join(root, 'alias');
+  await symlink(root, parentAlias);
+  await assert.rejects(assertIdentityPathIsPrivate(join(parentAlias, 'identity.json')), /is a mount point/);
+  const leaf = join(root, 'leaf.json');
+  await symlink(path, leaf);
+  await assertIdentityPathIsPrivate(leaf);
+  await saveBridgeIdentity(leaf, identity);
+  assert.deepEqual(JSON.parse(await readFile(leaf, 'utf8')), identity);
+  assert.equal(await readFile(path, 'utf8'), 'existing credential');
+});
+
+test('unavailable, malformed, and oversized mount tables fail before reserving a new identity', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'identity-mount-info-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const fixture = join(root, 'mountinfo');
+  const path = join(root, 'identity.json');
+  const original = fs.open;
+  fs.open = ((path, ...args) => original(path === '/proc/self/mountinfo' ? fixture : path, ...args)) as typeof fs.open;
+  syncBuiltinESMExports();
+  t.after(() => { fs.open = original; syncBuiltinESMExports(); });
+  await assert.rejects(assertIdentityPathIsPrivate(path), /Cannot verify identity mount status/);
+  for (const content of ['bad', 'x'.repeat(4 * 1024 * 1024 + 1)]) {
+    await writeFile(fixture, content);
+    await assert.rejects(assertIdentityPathIsPrivate(path), /Cannot verify identity mount status/);
+  }
+  assert.deepEqual(await readdir(root), ['mountinfo']);
+});
+
+test('CLI refuses a mounted identity before redeeming the one-time pairing code', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'identity-mount-cli-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const path = join(root, 'identity.json');
+  const fixture = join(root, 'mountinfo');
+  const preload = join(root, 'preload.mjs');
+  await writeFile(path, 'existing credential', { mode: 0o600 });
+  await writeFile(fixture, mount(await realpath(path)));
+  await writeFile(preload, `
+import fs from 'node:fs/promises';
+import { syncBuiltinESMExports } from 'node:module';
+Object.defineProperty(process, 'platform', { value: 'linux' });
+const original = fs.open;
+fs.open = (path, ...args) => original(path === '/proc/self/mountinfo' ? ${JSON.stringify(fixture)} : path, ...args);
+syncBuiltinESMExports();
+globalThis.fetch = async () => { process.stderr.write('PAIRING_REQUEST_ATTEMPTED'); throw new Error('unexpected request'); };
+`);
+  const result = spawnSync(process.execPath, [
+    '--import', preload, new URL('./cli.js', import.meta.url).pathname,
+    'pair', 'https://code.example/v1', 'one-time-code', '--worker-id', 'worker', '--identity', path,
+  ], { encoding: 'utf8', timeout: 10_000 });
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stderr, /is a mount point/);
+  assert.doesNotMatch(result.stderr, /PAIRING_REQUEST_ATTEMPTED/);
+  assert.equal(await readFile(path, 'utf8'), 'existing credential');
+});

--- a/packages/code/src/identity-mount.ts
+++ b/packages/code/src/identity-mount.ts
@@ -1,0 +1,61 @@
+import { open, realpath } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+
+import { BridgeProtocolError } from './protocol.js';
+
+const MOUNTINFO_MAX_BYTES = 4 * 1024 * 1024;
+
+/** mountinfo describes this process's namespace, including same-device bind mounts. */
+export function identityIsMountPoint(mountinfo: string, entryPath: string): boolean {
+  const lines = mountinfo.trimEnd().split('\n');
+  let mounted = false;
+  for (const line of lines) {
+    const fields = line.split(' ');
+    const separator = fields.indexOf('-', 6);
+    const mountpoint = fields[4];
+    if (
+      separator < 6 || fields.length !== separator + 4 ||
+      !/^\d+$/.test(fields[0] ?? '') || !/^\d+$/.test(fields[1] ?? '') ||
+      !/^\d+:\d+$/.test(fields[2] ?? '') || !mountpoint?.startsWith('/') ||
+      /\\(?!040|011|012|134)/.test(mountpoint)
+    ) throw new BridgeProtocolError('Cannot verify identity mount status: malformed /proc/self/mountinfo');
+    const decoded = mountpoint.replace(/\\(040|011|012|134)/g, (_, octal: string) =>
+      String.fromCharCode(parseInt(octal, 8)),
+    );
+    if (decoded === entryPath) mounted = true;
+  }
+  return mounted;
+}
+
+export async function assertIdentityIsNotMountPoint(path: string): Promise<void> {
+  // Resolve the parent, not the leaf: rename replaces a leaf symlink itself.
+  const entryPath = join(await realpath(dirname(path)), basename(path));
+  let content: string;
+  try {
+    const handle = await open('/proc/self/mountinfo', 'r');
+    try {
+      const buffer = Buffer.alloc(MOUNTINFO_MAX_BYTES + 1);
+      let length = 0;
+      while (length < buffer.length) {
+        const { bytesRead } = await handle.read(buffer, length, buffer.length - length, null);
+        if (bytesRead === 0) break;
+        length += bytesRead;
+      }
+      if (length > MOUNTINFO_MAX_BYTES) throw new Error('mount table exceeds limit');
+      content = buffer.toString('utf8', 0, length);
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    throw new BridgeProtocolError(
+      'Cannot verify identity mount status: /proc/self/mountinfo must be readable ' +
+        'and no larger than 4 MiB. Use an environment with procfs available.',
+    );
+  }
+  if (identityIsMountPoint(content, entryPath)) {
+    throw new BridgeProtocolError(
+      `Bridge identity path ${path} is a mount point and cannot be atomically replaced. ` +
+        'Mount its containing directory instead, or choose an unmounted identity file.',
+    );
+  }
+}

--- a/packages/code/src/storage.ts
+++ b/packages/code/src/storage.ts
@@ -14,6 +14,8 @@ import { dirname, join, resolve } from 'node:path';
 import { BRIDGE_PROTOCOL_VERSION, BridgeProtocolError } from './protocol.js';
 import { assertPrivateStorageAncestors, assertPrivateStorageSupported } from './private-storage.js';
 
+import { assertIdentityIsNotMountPoint } from './identity-mount.js';
+
 import type { PairedBridgeWorkerIdentity } from './pairing.js';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -287,7 +289,10 @@ async function assertIdentityDestinationIsReplaceable(
   try {
     metadata = await lstat(path);
   } catch (error) {
-    if (isMissingPathError(error)) return;
+    if (isMissingPathError(error)) {
+      await assertIdentityIsNotMountPoint(path);
+      return;
+    }
     throw error;
   }
   if (metadata.isDirectory()) {
@@ -295,6 +300,7 @@ async function assertIdentityDestinationIsReplaceable(
       `Bridge identity path ${path} is a directory. Point --identity at a file.`,
     );
   }
+  await assertIdentityIsNotMountPoint(path);
   const uid = process.platform === 'win32' ? undefined : process.getuid?.();
   if (uid === undefined || uid === 0 || metadata.uid === uid) return;
   /* Ownership only blocks `rename` under the sticky bit, and owning the
@@ -412,6 +418,7 @@ export async function saveBridgeIdentity(
   await assertWriteContainerPrivate(path);
   await mkdir(dirname(path), { recursive: true, mode: 0o700 });
   await assertWriteContainerPrivate(path);
+  await assertIdentityDestinationIsReplaceable(path);
   const temporaryPath = `${path}.${randomBytes(8).toString('hex')}.tmp`;
   try {
     const file = await open(temporaryPath, 'wx', 0o600);


### PR DESCRIPTION
## Summary

I closed the bind-mount preflight gap from #135: a mounted identity file now fails before its one-time pairing code is redeemed, instead of failing with `EBUSY` when publishing the credential.

- Inspect the process's mount namespace, including same-device bind mounts and escaped mountpoint names.
- Reject mounted destination entries while preserving files inside mounted directories and replaceable leaf symlinks.
- Fail closed when mount information is unavailable, malformed, or larger than 4 MiB.
- Recheck direct identity saves and preserve existing credential reads.
- Document mounting the containing directory and keeping mount configuration stable during pairing.

Depends on #139 and #138. This PR targets #139's branch to keep the diff focused. Merge in order: #138, #139, then this PR. Together the three PRs address #135.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- Built with `npm --prefix packages/code run build`.
- Ran storage, GitHub, ancestor, and mount suites: 38 passed, 4 skipped because this host has no chmod-ignoring mount.
- Verified the CLI never calls `fetch` for a mounted destination and preserves its existing bytes.
- Exercised same-device mounts, escaped names, parent aliases, leaf symlinks, missing procfs, malformed data, and the read bound.
- Checked `git diff --check`.

### **Test Configuration**:

Node 24.16.0 on macOS, using a Linux platform override and mountinfo fixtures for focused local tests. These simulate mount metadata; they do not perform a real kernel bind mount. CI runs the complete package suite on Linux. Reproduce there with `npm --prefix packages/code test`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
