### PR TITLE
fix: honor timeout caps on plain execution requests

### DIFF
--- a/service/openapi.yml
+++ b/service/openapi.yml
@@ -138,6 +138,17 @@ components:
         - code
         - lang
       properties:
+        timeout:
+          type: number
+          nullable: true
+          minimum: 0
+          exclusiveMinimum: true
+          description: >-
+            Optional runtime cap in milliseconds. Positive finite values are
+            rounded up to whole milliseconds and clamped to JOB_TIMEOUT, then
+            to the sandbox's effective language runtime limit. Omitted or null
+            values preserve the worker's runtime default. This caps execution,
+            not queueing or request transport time.
         code:
           type: string
         lang:

--- a/service/src/service/exec-timeout.test.ts
+++ b/service/src/service/exec-timeout.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from 'bun:test';
+import { resolve } from 'path';
+
+test('/exec validates timeout before enqueue and forwards its cap to both language queues', async () => {
+  // Isolate infrastructure mocks; exercise the real router, timeout policy,
+  // payload builder, and security preparation without Redis or a sandbox.
+  const probe = Bun.spawn([process.execPath, '-e', `
+    import { mock } from 'bun:test';
+    import assert from 'node:assert/strict';
+    const passthrough = (_req, _res, next) => next();
+    mock.module('./src/middleware/auth', () => ({ sessionAuth: passthrough }));
+    mock.module('./src/middleware/limits', () => ({
+      executionLimiter: passthrough, uploadLimiter: passthrough,
+      downloadLimiter: passthrough, fetchLimiter: passthrough,
+    }));
+    mock.module('./src/lifecycle', () => ({
+      checkServiceStartUp: () => false, checkServiceShutDown: () => false,
+    }));
+    let writes = 0;
+    let submitted = [];
+    const queue = (name) => ({ add: async (_type, data) => {
+      submitted.push({ name, data });
+      return { waitUntilFinished: async () => ({ ok: true }), remove: async () => {} };
+    }});
+    mock.module('./src/queue', () => ({
+      pyQueue: queue('python'), otherQueue: queue('other'),
+      pyQueueEvents: {}, otherQueueEvents: {}, queueNames: { python: 'python', other: 'other' },
+      connection: { set: async () => { writes++; return 'OK'; } },
+    }));
+    const { env } = await import('./src/config');
+    env.JOB_TIMEOUT = 15000;
+    env.RUNTIME_SESSION_MODE = 'stateless';
+    env.SANDBOX_BACKEND = 'http';
+    env.HARDENED_SANDBOX_MODE = false;
+    env.EGRESS_GRANT_SECRET = '';
+    env.EXECUTION_MANIFEST_SECRET = '';
+    const { default: router } = await import('./src/service/router');
+    const handler = router.stack.find(layer => layer.route?.path === '/exec').route.stack.at(-1).handle;
+    async function request(lang, timeout) {
+      submitted = [];
+      writes = 0;
+      const req = {
+        body: { code: 'print(1)', lang, timeout }, headers: {}, header: () => undefined, on: () => {},
+        codeApiPrincipal: { userId: 'user', tenantId: 'tenant', principalSource: 'none' },
+        codeApiAuthContext: { userId: 'user', tenantId: 'tenant' },
+      };
+      const res = { status(code) { this.statusCode = code; return this; }, json(body) { this.body = body; return this; } };
+      await handler(req, res);
+      return res;
+    }
+    for (const lang of ['py', 'bash']) {
+      for (const [input, expected] of [[1000, 1000], [1000.1, 1001], [0.1, 1], [999999, 15000], [null, undefined], [undefined, undefined]]) {
+        const res = await request(lang, input);
+        assert.equal(res.statusCode, 200, JSON.stringify(res.body));
+        assert.equal(submitted.length, 1);
+        assert.equal(submitted[0].name, lang === 'py' ? 'python' : 'other');
+        assert.equal(submitted[0].data.payload.run_timeout, expected);
+        if (expected === undefined) assert.equal('run_timeout' in submitted[0].data.payload, false);
+      }
+    }
+    for (const input of [0, -1, '1000', true, {}, [], NaN, Infinity]) {
+      const res = await request('py', input);
+      assert.equal(res.statusCode, 400);
+      assert.match(res.body.error, /timeout must be a positive number of milliseconds/);
+      assert.equal(submitted.length, 0);
+      assert.equal(writes, 0, 'invalid timeout must not register a session');
+    }
+    console.log('EXEC_TIMEOUT_OK');
+  `], { cwd: resolve(__dirname, '../..'), stdout: 'pipe', stderr: 'pipe' });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    probe.exited, new Response(probe.stdout).text(), new Response(probe.stderr).text(),
+  ]);
+  expect(exitCode, `${stdout}\n${stderr}`).toBe(0);
+  expect(stdout).toContain('EXEC_TIMEOUT_OK');
+}, 15000);

--- a/service/src/service/router.ts
+++ b/service/src/service/router.ts
@@ -25,7 +25,7 @@ import { Jobs, Languages } from '../enum';
 import { FileRefAuthorizationError, authorizeRequestedFiles } from './file-authorization';
 import { createUploadSessionRegistrar } from './upload-session';
 import { recordSessionOwnership } from '../session-ownership';
-import { prepareSandboxJobSecurity } from '../sandbox-egress';
+import { normalizeProgrammaticTimeoutMs, prepareSandboxJobSecurity } from '../sandbox-egress';
 import {
   BridgeWorkerSelectionError,
   CODEAPI_BRIDGE_WORKER_HEADER,
@@ -147,6 +147,14 @@ router.post('/exec', executionLimiter, async (req: t.AuthenticatedRequest, res) 
     return res.status(400).json({ error: `Unsupported language: ${rawLang}` });
   }
 
+  // An omitted cap keeps the worker's existing language-specific default.
+  let timeout: number | undefined;
+  try {
+    if (body.timeout != null) timeout = normalizeProgrammaticTimeoutMs(body.timeout);
+  } catch (error) {
+    return res.status(400).json({ error: (error as Error).message });
+  }
+
   let bridgeWorkerId: string | undefined;
   try {
     const bridgeSelection = resolveBridgeWorkerSelection({
@@ -250,6 +258,7 @@ router.post('/exec', executionLimiter, async (req: t.AuthenticatedRequest, res) 
       isPyPlot,
       session_id,
     });
+    if (timeout != null) rawPayload.run_timeout = timeout;
     const sandboxSecurity = prepareSandboxJobSecurity({
       req,
       executionId: execution_id,

--- a/service/src/types/service.ts
+++ b/service/src/types/service.ts
@@ -133,6 +133,8 @@ export type ExecuteResponse = {
 };
 
 export interface RequestBody {
+  /** Optional positive runtime cap in milliseconds, clamped to JOB_TIMEOUT. */
+  timeout?: number;
   code: string;
   lang: string;
   args?: string[];


### PR DESCRIPTION
## Summary

I fixed plain `/exec` requests dropping the timeout already forwarded by programmatic tools when no tools are selected.

- Validate explicit timeouts using the same policy as `/exec/programmatic`: accept positive finite milliseconds, round up, and clamp to `JOB_TIMEOUT`.
- Set the sandbox payload's `run_timeout` before security preparation and queue submission for both Python and non-Python execution.
- Preserve the existing worker default when timeout is omitted or null.
- Reject invalid timeouts with HTTP 400 before session registration or queue submission.

Fixes danny-avila/agents#492. Depends on #148: merge and deploy that sandbox change first, then deploy this service change. Older services work with updated sandboxes; older sandboxes can reject forwarded caps above their local limit. No client changes are needed.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- Ran `cd service && bun test ./src/service/exec-timeout.test.ts ./src/egress-grant.test.ts`: 25 tests passed.
- Confirmed the new route regression fails against the original handler.
- Exercised real route, payload, and timeout logic with isolated infrastructure mocks, including both language queues, clamping, rounding, omission, and invalid inputs.
- Ran `git diff --check`.
- Ran `tsc --noEmit`; its existing diagnostics match the untouched baseline exactly. No new typecheck errors.

### **Test Configuration**:

Bun 1.3.13 on macOS; route tests mock Redis, queues, lifecycle checks, and middleware. They do not require a live sandbox.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
