### PR TITLE
fix: restore macOS private storage with native ACL verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,22 @@ jobs:
       - name: Tests
         run: npm test
 
+  macos-storage-tests:
+    name: macOS Storage ACL Tests
+    runs-on: macos-14
+    defaults:
+      run:
+        working-directory: packages/code
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24.16.0
+      - run: npm ci
+      - run: npm run build
+      - name: Native ACL and credential lifecycle tests
+        run: node --test dist/macos-storage.test.js dist/private-storage.test.js dist/storage.test.js dist/github.test.js
+
   lambda-microvm-provisioning:
     name: Lambda MicroVM Provisioning
     runs-on: ubuntu-latest

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -39,7 +39,8 @@ Credential and quarantine storage supports macOS and Linux (including WSL2).
 On macOS, native descriptor-based ACL calls remove inherited ACLs from new
 credential/state files before writing secrets and verify the result. Reads reject
 ACL-exposed identities and GitHub App keys; ancestor checks reject ACL write
-grants that could permit replacement. Existing sharing ACLs on parent directories
+grants and inheritable allow entries before any child is created. Removing an
+ACL after creation cannot revoke descriptors opened while the grant existed. Existing sharing ACLs on parent directories
 are never silently removed. Default application-owned workspace directories have
 their ACLs removed and modes restricted to `0700`.
 

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -35,13 +35,20 @@ LIBRECHAT_CODE_SANDBOX_ENDPOINT=http://127.0.0.1:2000/api/v2 \
 librechat-code run
 ```
 
-Credential and quarantine storage currently requires Linux (including WSL2),
-where ownership and POSIX mode/ACL-mask checks can establish owner-only access.
-Native Windows and macOS fail closed before pairing-code redemption, credential
-loads, or storage mutations because their extended ACLs cannot yet be verified.
-Use storage on a native Linux filesystem, not a Windows drive under `/mnt`.
-Support for these platforms requires a native ACL verifier; `chmod` alone is
-not sufficient.
+Credential and quarantine storage supports macOS and Linux (including WSL2).
+On macOS, native descriptor-based ACL calls remove inherited ACLs from new
+credential/state files before writing secrets and verify the result. Reads reject
+ACL-exposed identities and GitHub App keys; ancestor checks reject ACL write
+grants that could permit replacement. Existing sharing ACLs on parent directories
+are never silently removed. Default application-owned workspace directories have
+their ACLs removed and modes restricted to `0700`.
+
+macOS requires the packaged Koffi native dependency (prebuilt for Apple Silicon
+and Intel); no Python interpreter or local compiler is needed with those builds.
+If it cannot load or ACL inspection fails, storage fails closed before pairing.
+Native Windows remains explicitly unsupported until DACL removal and verification
+are implemented. Use WSL2 with storage on a native Linux filesystem, not a Windows
+drive under `/mnt`. Linux retains ownership and POSIX mode/ACL-mask checks.
 
 Every storage ancestor, including intermediate symlink entries and targets, must
 be owned by this account or root and must not allow group/other writes unless
@@ -132,8 +139,8 @@ read only by the trusted worker, which mints and refreshes short-lived
 installation tokens. A personal access token is supported as a fallback with
 `LIBRECHAT_CODE_GITHUB_TOKEN`, but the GitHub App is the safer default because
 its repository access and permissions can be narrowly installed and revoked.
-Native Windows and macOS credential storage are unavailable until native ACL
-verification is implemented; use Linux or WSL2. This also applies to GitHub App
+Native Windows credential storage is unavailable until native DACL removal and
+verification are implemented; use macOS, Linux, or WSL2. This also applies to GitHub App
 private keys.
 
 Git receives authentication through process-scoped `GIT_CONFIG_*` variables.

--- a/packages/code/package-lock.json
+++ b/packages/code/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/sandbox-runtime": "0.0.75"
+        "@anthropic-ai/sandbox-runtime": "0.0.75",
+        "koffi": "3.2.1"
       },
       "bin": {
         "librechat-code": "dist/cli.js"
@@ -40,6 +41,294 @@
         "node": ">=20.11.0"
       }
     },
+    "node_modules/@koromix/koffi-android-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-android-arm64/-/koffi-android-arm64-3.2.1.tgz",
+      "integrity": "sha512-1pJQ4jnZlUJduK9u9DC5CGy3aOgDUPvIXpNb6syV3+Dh5Q/ugezAIGCqvY+w+1mgXsve0pd0NVvJRjdZNHQ6MA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-android-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-android-x64/-/koffi-android-x64-3.2.1.tgz",
+      "integrity": "sha512-HH40xGh3gVQifjOBnhwT2tECC0lL1lYe+nxHvWNSzxDIyQNcVPXg38ta7vuONRFpD+uIrw7fqGYLzbZIagkVcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.2.1.tgz",
+      "integrity": "sha512-Vj4h+xcjc5+Cn0DhPHjgRX4omKAv96Kehtcd+1YgYuY2W7FvQn9vS+3SmzVwhC5Qmg9bIwUZObYQ8T/4hBqQqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.2.1.tgz",
+      "integrity": "sha512-gFCWxNBTZIvxo1p+PURWfsy2Ctj5FGnVVs1f03lTLhBvmxEto70pdIiFztdFLDFkAJ1pmtQmruRKapeK+E8YPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.2.1.tgz",
+      "integrity": "sha512-qj+f1s2e6vULaUG1cdlTcCXmunCq2t+rjxku1+esaMIqVnHpOwj0QzPuInG0AFdXjwBNQhyVR/HpDj8daEwwsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-ia32": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.2.1.tgz",
+      "integrity": "sha512-6olHb1Qfgai0jjs6ddlDDD0ZfsCxy7SPi8rMRpuYQWH0qhgtyQu82hw5b1p7z+TJ0zZP3ZeQQ6l+U/MlM1ICHQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.2.1.tgz",
+      "integrity": "sha512-Dikhw1ySYNVMkmeFvFVjnU5Wdk6mffNoOjJxm9bTG96vg7OlemylxqdEven47R1YJ3yzNVJn/MlQ207ORWfi2w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm/-/koffi-linux-arm-3.2.1.tgz",
+      "integrity": "sha512-OfwUwZylidq95wQKp6ClInULrfB2giu7dqM6Rhe0zAe6lES5I2SXNw15T9+GnRHk3/9hKT2XZ37OZLaKSyWNLA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.2.1.tgz",
+      "integrity": "sha512-K+cGUL5iBcDqxmsocrjmlASqDf24gc7artbVW3PewG2c9AqwC63lezgwvB85Nx4lZAQjB6zIFHh9A7t1yGbwhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-ia32": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.2.1.tgz",
+      "integrity": "sha512-rxj6UYjU1qd98gxNQOSCdLpc5cPRi5Giq9rNd3jnGuSNIyMkwa6Dxw4cUjmhIBCYESMJtmNt5NWnJp5u9wTfYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-loong64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.2.1.tgz",
+      "integrity": "sha512-aHhnHzkPRmT/IHDlGvESJ/Bs32m8N6UE6Ab6kMeJzgk74IN8af2m/81/wZJtybR1M2UxCV4NmlVNUYQQvSAO3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-riscv64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.2.1.tgz",
+      "integrity": "sha512-qtQBsjbm3LiirLJvajWmKkNb7ARk7fvJVXdftJ7NtAnF3Xw8EbDvrtvmvtNI1yLPlYcBmlzCCD71hwhWYk0SIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.2.1.tgz",
+      "integrity": "sha512-c7hw7Qs/r5gnFRTQLcbifBwRU7wiocj+2pVuDQ5Ahb3r36SZmupmgYbTWcLvTW+hul1jd7SKRV0d14ZJq/tvSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-ia32": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.2.1.tgz",
+      "integrity": "sha512-mmY8fY8LQ/CB52+h3yrMYmVyoxzW3x08S0yI6VNfHWdfU6yJtZkKCbhjmQCYMrWbYKC4gMvwZwCywIGPAkLyeA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.2.1.tgz",
+      "integrity": "sha512-k4ig6aAPbFSRATOIIOfdf/KtlOGH4SVls6L9fy0QnTxRJYvY2oSltTsQtBDANgEQldlq8Kl5WnpRa1VSibP4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.2.1.tgz",
+      "integrity": "sha512-cTWBJGK//pDMeKQJE/79Aq9MiOAF4H8QyLZHSQ9IWm8czOfwjG4J1AhsQ9DjI9KFOykH77hhnpmQTGVMIubGig==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-ia32": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.2.1.tgz",
+      "integrity": "sha512-Z50EM6TAZ7CFyMmyX6thv8eNpJchqe9eenhibSIy2Eq/FQYF76gU2VK/LEoaF46L8hfC7TpTp9b10MvReHEyFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.2.1.tgz",
+      "integrity": "sha512-ZmZNiBO6bkOSh3QNzgfvb1cMY0yMobn6ZQrSMqbAce21qyYL8niIbyipz9N/PIRDciGhsV0wUxnZsxIO+yWsHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
     "node_modules/@pondwader/socks5-server": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@pondwader/socks5-server/-/socks5-server-1.0.10.tgz",
@@ -63,6 +352,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.2.1.tgz",
+      "integrity": "sha512-0qE3lZ8jllRqPN4Ob6Ajl7c2bJSJDhQWuKLGP5hIEpHLllJWv1ydHFMhHmHc5p/W9GticKVDbYzZd7TBoQ4CZg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      },
+      "optionalDependencies": {
+        "@koromix/koffi-android-arm64": "3.2.1",
+        "@koromix/koffi-android-x64": "3.2.1",
+        "@koromix/koffi-darwin-arm64": "3.2.1",
+        "@koromix/koffi-darwin-x64": "3.2.1",
+        "@koromix/koffi-freebsd-arm64": "3.2.1",
+        "@koromix/koffi-freebsd-ia32": "3.2.1",
+        "@koromix/koffi-freebsd-x64": "3.2.1",
+        "@koromix/koffi-linux-arm": "3.2.1",
+        "@koromix/koffi-linux-arm64": "3.2.1",
+        "@koromix/koffi-linux-ia32": "3.2.1",
+        "@koromix/koffi-linux-loong64": "3.2.1",
+        "@koromix/koffi-linux-riscv64": "3.2.1",
+        "@koromix/koffi-linux-x64": "3.2.1",
+        "@koromix/koffi-openbsd-ia32": "3.2.1",
+        "@koromix/koffi-openbsd-x64": "3.2.1",
+        "@koromix/koffi-win32-arm64": "3.2.1",
+        "@koromix/koffi-win32-ia32": "3.2.1",
+        "@koromix/koffi-win32-x64": "3.2.1"
       }
     },
     "node_modules/node-forge": {

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -60,6 +60,7 @@
     "node": ">=20.11"
   },
   "dependencies": {
-    "@anthropic-ai/sandbox-runtime": "0.0.75"
+    "@anthropic-ai/sandbox-runtime": "0.0.75",
+    "koffi": "3.2.1"
   }
 }

--- a/packages/code/src/github.ts
+++ b/packages/code/src/github.ts
@@ -2,7 +2,7 @@ import { constants } from 'node:fs';
 import { createHash, createPrivateKey, sign } from 'node:crypto';
 import { open } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { assertPrivateStorageAncestors, assertPrivateStorageSupported } from './private-storage.js';
+import { assertPrivateStorageAcl, assertPrivateStorageAncestors, assertPrivateStorageSupported } from './private-storage.js';
 
 export const GITHUB_CREDENTIAL_ENV_NAME = 'LIBRECHAT_CODE_GITHUB_AUTHORIZATION';
 export const GITHUB_ALLOWED_DOMAINS = [
@@ -69,6 +69,7 @@ async function readPrivateKey(path: string): Promise<string> {
         'GitHub App private key must not be accessible by group or other users',
       );
     }
+    await assertPrivateStorageAcl(handle, path);
     return await handle.readFile('utf8');
   } finally {
     await handle.close();

--- a/packages/code/src/identity-mount.ts
+++ b/packages/code/src/identity-mount.ts
@@ -1,4 +1,4 @@
-import { open, realpath } from 'node:fs/promises';
+import { lstat, open, realpath } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 
 import { BridgeProtocolError } from './protocol.js';
@@ -30,6 +30,19 @@ export function identityIsMountPoint(mountinfo: string, entryPath: string): bool
 export async function assertIdentityIsNotMountPoint(path: string): Promise<void> {
   // Resolve the parent, not the leaf: rename replaces a leaf symlink itself.
   const entryPath = join(await realpath(dirname(path)), basename(path));
+  if (process.platform === 'darwin') {
+    const metadata = await lstat(path).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return undefined;
+      throw error;
+    });
+    // A missing entry cannot be mounted; rename replaces a symlink itself.
+    if (metadata === undefined || metadata.isSymbolicLink()) return;
+    const { macOsMountPoint } = await import('./macos-storage.js');
+    if (await realpath(macOsMountPoint(entryPath)) === entryPath) {
+      throw new BridgeProtocolError(`Bridge identity path ${path} is a mount point and cannot be atomically replaced.`);
+    }
+    return;
+  }
   let content: string;
   try {
     const handle = await open('/proc/self/mountinfo', 'r');

--- a/packages/code/src/macos-storage.test.ts
+++ b/packages/code/src/macos-storage.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
-import fs, { chmod, mkdtemp, mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import fs, { chmod, mkdtemp, mkdir, open, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import { syncBuiltinESMExports } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -25,10 +25,10 @@ async function grant(path: string, permissions: string): Promise<void> {
 }
 
 // Real kernel ACLs: chmod(0600) alone leaves these grants effective.
-test('macOS removes inherited ACLs before publishing identity and quarantine state', mac, async t => {
+test('macOS removes inherited deny ACLs before publishing identity and quarantine state', mac, async t => {
   const root = await mkdtemp(join(tmpdir(), 'macos-acl-'));
   t.after(() => rm(root, { recursive: true, force: true }));
-  await grant(root, 'read,readattr,readextattr,readsecurity,file_inherit,directory_inherit');
+  await exec('/bin/chmod', ['+a', 'everyone deny read,file_inherit,directory_inherit,only_inherit', root]);
   let guardedWrites = 0;
   const originalOpen = fs.open;
   fs.open = (async (...args: Parameters<typeof fs.open>) => {
@@ -131,4 +131,36 @@ test('macOS checks mount status without procfs', mac, async () => {
   const { macOsMountPoint } = await import('./macos-storage.js');
   assert.equal(macOsMountPoint('/'), '/');
   assert.throws(() => macOsMountPoint('/nonexistent-macos-acl-test'), /Cannot verify macOS identity mount/);
+});
+
+
+test('macOS rejects inheritable allow ACLs before creating any storage inode', mac, async t => {
+  for (const inheritance of ['file_inherit', 'directory_inherit', 'file_inherit,only_inherit']) {
+    await t.test(inheritance, async t => {
+      const root = await mkdtemp(join(tmpdir(), 'macos-inherited-acl-'));
+      t.after(() => rm(root, { recursive: true, force: true }));
+      const existing = join(root, 'existing.json');
+      await saveBridgeIdentity(existing, identity);
+      await chmod(root, 0o755);
+      await grant(root, `read,search,${inheritance}`);
+      let creates = 0;
+      const originalOpen = fs.open;
+      fs.open = (async (...args: Parameters<typeof fs.open>) => {
+        if (args[1] === 'wx') creates += 1;
+        return originalOpen(...args);
+      }) as typeof fs.open;
+      syncBuiltinESMExports();
+      t.after(() => { fs.open = originalOpen; syncBuiltinESMExports(); });
+      const path = join(root, 'nested', 'identity.json');
+      for (const action of [
+        () => assertIdentityPathIsPrivate(path),
+        () => assertIdentityPathIsPrivate(existing),
+        () => saveBridgeIdentity(path, identity),
+        () => saveWorkspaceMutationQuarantine(path, quarantine),
+        () => ensurePrivateWorkspaceDirectory(join(root, 'workspace')),
+      ]) await assert.rejects(action(), /macOS ACL grants/);
+      assert.equal(creates, 0);
+      assert.deepEqual(await readdir(root), ['existing.json']);
+    });
+  }
 });

--- a/packages/code/src/macos-storage.test.ts
+++ b/packages/code/src/macos-storage.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import fs, { chmod, mkdtemp, mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { syncBuiltinESMExports } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import test from 'node:test';
+import { assertPrivateStorageAcl, assertPrivateStorageAncestors, removePrivateStorageAcl } from './private-storage.js';
+import { assertIdentityPathIsPrivate, saveBridgeIdentity, loadBridgeIdentity,
+  saveWorkspaceMutationQuarantine, loadWorkspaceMutationQuarantine,
+  clearWorkspaceMutationQuarantine, ensurePrivateWorkspaceDirectory } from './storage.js';
+import { GitHubAppCredentialProvider } from './github.js';
+
+const exec = promisify(execFile);
+const mac = { skip: process.platform !== 'darwin' };
+const identity = { protocolVersion: 1 as const, workerId: 'worker',
+  codeApiUrl: 'https://example.com', credential: 'secret', privateKey: 'private',
+  publicKey: 'public', expiresAt: '2099-01-01T00:00:00Z' };
+const quarantine = { version: 1 as const, workerId: 'worker', workspaceId: 'primary',
+  ownerId: 'owner', reason: 'uncertain', quarantinedAt: '2026-01-01T00:00:00Z' };
+
+async function grant(path: string, permissions: string): Promise<void> {
+  await exec('/bin/chmod', ['+a', `everyone allow ${permissions}`, path]);
+}
+
+// Real kernel ACLs: chmod(0600) alone leaves these grants effective.
+test('macOS removes inherited ACLs before publishing identity and quarantine state', mac, async t => {
+  const root = await mkdtemp(join(tmpdir(), 'macos-acl-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await grant(root, 'read,readattr,readextattr,readsecurity,file_inherit,directory_inherit');
+  let guardedWrites = 0;
+  const originalOpen = fs.open;
+  fs.open = (async (...args: Parameters<typeof fs.open>) => {
+    const handle = await originalOpen(...args);
+    if (args[1] === 'wx') {
+      const write = handle.writeFile.bind(handle);
+      handle.writeFile = async (...values) => {
+        await assertPrivateStorageAcl(handle, String(args[0]));
+        guardedWrites += 1;
+        return write(...values);
+      };
+    }
+    return handle;
+  }) as typeof fs.open;
+  syncBuiltinESMExports();
+  t.after(() => { fs.open = originalOpen; syncBuiltinESMExports(); });
+  const path = join(root, 'identity.json');
+  const reservation = await assertIdentityPathIsPrivate(path);
+  assert.equal(await readFile(path, 'utf8'), '');
+  await saveBridgeIdentity(path, identity);
+  await reservation.release();
+  assert.deepEqual(await loadBridgeIdentity(path), identity);
+  const marker = join(root, 'quarantine.json');
+  await saveWorkspaceMutationQuarantine(marker, quarantine);
+  assert.deepEqual(await loadWorkspaceMutationQuarantine(marker), quarantine);
+  for (const file of [path, marker]) {
+    const listing = await exec('/bin/ls', ['-lde', file]);
+    assert.doesNotMatch(listing.stdout, /\n\s*0:/);
+  }
+  // Re-pairing exercises native mount verification and sibling publication.
+  await (await assertIdentityPathIsPrivate(path)).release();
+  await clearWorkspaceMutationQuarantine(marker, 'owner');
+  assert.equal(guardedWrites, 2);
+  const workspace = join(root, 'workspace');
+  await mkdir(workspace);
+  await grant(workspace, 'read,write,delete');
+  await ensurePrivateWorkspaceDirectory(workspace);
+  assert.doesNotMatch((await exec('/bin/ls', ['-lde', workspace])).stdout, /\n\s*0:/);
+});
+
+test('macOS refuses exposed 0600 identities, quarantine markers, and GitHub keys', mac, async t => {
+  const root = await mkdtemp(join(tmpdir(), 'macos-acl-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const path = join(root, 'identity.json');
+  const marker = join(root, 'quarantine.json');
+  await saveBridgeIdentity(path, identity);
+  await saveWorkspaceMutationQuarantine(marker, quarantine);
+  for (const file of [path, marker]) {
+    await grant(file, 'read');
+    await chmod(file, 0o600);
+  }
+  await assert.rejects(loadBridgeIdentity(path), /macOS ACL grants/);
+  await assert.rejects(assertIdentityPathIsPrivate(path), /macOS ACL grants/);
+  await assert.rejects(loadWorkspaceMutationQuarantine(marker), /macOS ACL grants/);
+  let fetched = false;
+  const provider = new GitHubAppCredentialProvider({
+    appId: '1', installationId: '1', privateKeyPath: path,
+    fetch: async () => { fetched = true; throw new Error('unexpected fetch'); },
+  });
+  await assert.rejects(provider.getCredential(), /macOS ACL grants/);
+  assert.equal(fetched, false);
+  assert.equal(await readFile(path, 'utf8'), `${JSON.stringify(identity, null, 2)}\n`);
+});
+
+test('macOS rejects ACL-writable ancestors and accepts deny-only home-style ACLs', mac, async t => {
+  const root = await mkdtemp(join(tmpdir(), 'macos-acl-'));
+  t.after(async () => {
+    await exec('/bin/chmod', ['-N', root]);
+    await rm(root, { recursive: true, force: true });
+  });
+  await exec('/bin/chmod', ['+a', 'everyone deny delete', root]);
+  await assertPrivateStorageAncestors(root);
+  await grant(root, 'add_file,delete_child');
+  await chmod(root, 0o700);
+  await assert.rejects(assertIdentityPathIsPrivate(join(root, 'identity.json')), /macOS ACL grants/);
+});
+
+test('macOS ACL checks and removal operate on the held inode after path replacement', mac, async t => {
+  const root = await mkdtemp(join(tmpdir(), 'macos-acl-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const path = join(root, 'file');
+  await writeFile(path, '', { mode: 0o600 });
+  await grant(path, 'read');
+  const handle = await open(path, 'r');
+  try {
+    await rename(path, join(root, 'old'));
+    await writeFile(path, '', { mode: 0o600 });
+    await assert.rejects(assertPrivateStorageAcl(handle, path), /macOS ACL grants/);
+    await removePrivateStorageAcl(handle, path);
+    await assertPrivateStorageAcl(handle, path);
+  } finally {
+    await handle.close();
+  }
+  await assert.rejects(assertPrivateStorageAcl(handle, path), /Cannot verify macOS/);
+  await assert.rejects(removePrivateStorageAcl(handle, path), /Cannot verify macOS/);
+});
+
+
+test('macOS checks mount status without procfs', mac, async () => {
+  const { macOsMountPoint } = await import('./macos-storage.js');
+  assert.equal(macOsMountPoint('/'), '/');
+  assert.throws(() => macOsMountPoint('/nonexistent-macos-acl-test'), /Cannot verify macOS identity mount/);
+});

--- a/packages/code/src/macos-storage.ts
+++ b/packages/code/src/macos-storage.ts
@@ -6,6 +6,8 @@ const ACL_TYPE_EXTENDED = 0x100;
 const ACL_EXTENDED_ALLOW = 1;
 const ACL_EXTENDED_DENY = 2;
 const ACL_NEXT_ENTRY = -1;
+const ACL_ENTRY_FILE_INHERIT = 1 << 5;
+const ACL_ENTRY_DIRECTORY_INHERIT = 1 << 6;
 const lib = koffi.load('/usr/lib/libSystem.B.dylib');
 const getAcl = lib.func('void *acl_get_fd_np(int fd, int type)');
 const setAcl = lib.func('int acl_set_fd_np(int fd, void *acl, int type)');
@@ -14,7 +16,10 @@ const freeAcl = lib.func('int acl_free(void *acl)');
 const getEntry = lib.func('int acl_get_entry(void *acl, int index, _Out_ void **entry)');
 const getTag = lib.func('int acl_get_tag_type(void *entry, _Out_ int *tag)');
 const getMask = lib.func('int acl_get_permset_mask_np(void *entry, _Out_ uint64_t *mask)');
-// Only read/list, search/execute, and metadata reads are safe on ancestors.
+const getFlags = lib.func('int acl_get_flagset_np(void *entry, _Out_ void **flags)');
+const getFlag = lib.func('int acl_get_flag_np(void *flags, int flag)');
+// Only non-inheritable read/list, search/execute, and metadata reads are safe.
+// Removing an inherited grant after open cannot revoke an attacker's held fd.
 const ANCESTOR_READ_PERMISSIONS = (1 << 1) | (1 << 3) | (1 << 7) | (1 << 9) | (1 << 11);
 
 function unavailable(): never {
@@ -38,9 +43,14 @@ export function verifyMacOsAcl(fd: number, path: string, directory = false, empt
       }
       const tag = [0];
       const mask = [0];
-      if (getTag(entry[0], tag) !== 0 || getMask(entry[0], mask) !== 0) unavailable();
+      const flags = [null];
+      if (getTag(entry[0], tag) !== 0 || getMask(entry[0], mask) !== 0 ||
+        getFlags(entry[0], flags) !== 0) unavailable();
+      const fileInherit = getFlag(flags[0], ACL_ENTRY_FILE_INHERIT);
+      const directoryInherit = getFlag(flags[0], ACL_ENTRY_DIRECTORY_INHERIT);
+      if (fileInherit < 0 || directoryInherit < 0) unavailable();
       if (empty || (tag[0] !== ACL_EXTENDED_DENY &&
-        (tag[0] !== ACL_EXTENDED_ALLOW || !directory ||
+        (tag[0] !== ACL_EXTENDED_ALLOW || !directory || fileInherit || directoryInherit ||
           (BigInt(mask[0]) & ~BigInt(ANCESTOR_READ_PERMISSIONS)) !== 0n))) {
         throw new BridgeProtocolError(
           `macOS ACL grants access beyond owner-only storage at ${path}. ` +

--- a/packages/code/src/macos-storage.ts
+++ b/packages/code/src/macos-storage.ts
@@ -1,0 +1,84 @@
+import koffi from 'koffi';
+import { BridgeProtocolError } from './protocol.js';
+
+// Darwin sys/acl.h. Use the held descriptor, never /dev/fd path metadata.
+const ACL_TYPE_EXTENDED = 0x100;
+const ACL_EXTENDED_ALLOW = 1;
+const ACL_EXTENDED_DENY = 2;
+const ACL_NEXT_ENTRY = -1;
+const lib = koffi.load('/usr/lib/libSystem.B.dylib');
+const getAcl = lib.func('void *acl_get_fd_np(int fd, int type)');
+const setAcl = lib.func('int acl_set_fd_np(int fd, void *acl, int type)');
+const initAcl = lib.func('void *acl_init(int count)');
+const freeAcl = lib.func('int acl_free(void *acl)');
+const getEntry = lib.func('int acl_get_entry(void *acl, int index, _Out_ void **entry)');
+const getTag = lib.func('int acl_get_tag_type(void *entry, _Out_ int *tag)');
+const getMask = lib.func('int acl_get_permset_mask_np(void *entry, _Out_ uint64_t *mask)');
+// Only read/list, search/execute, and metadata reads are safe on ancestors.
+const ANCESTOR_READ_PERMISSIONS = (1 << 1) | (1 << 3) | (1 << 7) | (1 << 9) | (1 << 11);
+
+function unavailable(): never {
+  throw new BridgeProtocolError('Cannot verify macOS storage ACLs on the opened object; use a local filesystem with ACL support.');
+}
+
+export function verifyMacOsAcl(fd: number, path: string, directory = false, empty = false): void {
+  const acl = getAcl(fd, ACL_TYPE_EXTENDED);
+  if (acl == null) {
+    // On a valid descriptor Darwin reports ENOENT when no extended ACL exists.
+    if (koffi.errno() === koffi.os.errno.ENOENT) return;
+    unavailable();
+  }
+  try {
+    for (let index = 0; ; index = ACL_NEXT_ENTRY) {
+      const entry = [null];
+      if (getEntry(acl, index, entry) !== 0) {
+        // Darwin uses EINVAL at end of the ACL (unlike Linux's zero result).
+        if (koffi.errno() === koffi.os.errno.EINVAL) return;
+        unavailable();
+      }
+      const tag = [0];
+      const mask = [0];
+      if (getTag(entry[0], tag) !== 0 || getMask(entry[0], mask) !== 0) unavailable();
+      if (empty || (tag[0] !== ACL_EXTENDED_DENY &&
+        (tag[0] !== ACL_EXTENDED_ALLOW || !directory ||
+          (BigInt(mask[0]) & ~BigInt(ANCESTOR_READ_PERMISSIONS)) !== 0n))) {
+        throw new BridgeProtocolError(
+          `macOS ACL grants access beyond owner-only storage at ${path}. ` +
+          'Remove the sharing ACL before using this path. If a credential was exposed, revoke it and pair again.',
+        );
+      }
+    }
+  } finally {
+    freeAcl(acl);
+  }
+}
+
+export function removeMacOsAcl(fd: number, path: string): void {
+  const acl = initAcl(0);
+  if (acl == null) unavailable();
+  try {
+    if (setAcl(fd, acl, ACL_TYPE_EXTENDED) !== 0) unavailable();
+  } finally {
+    freeAcl(acl);
+  }
+  verifyMacOsAcl(fd, path, false, true);
+}
+
+// Darwin's statfs64 layout is identical on arm64 and x86_64 (sys/mount.h).
+const Statfs = koffi.struct({
+  bsize: 'uint32_t', iosize: 'int32_t',
+  blocks: 'uint64_t', bfree: 'uint64_t', bavail: 'uint64_t',
+  files: 'uint64_t', ffree: 'uint64_t', fsid: 'int32_t[2]',
+  owner: 'uint32_t', type: 'uint32_t', flags: 'uint32_t', subtype: 'uint32_t',
+  typename: 'char[16]', mountpoint: 'char[1024]', source: 'char[1024]',
+  flagsExt: 'uint32_t', reserved: 'uint32_t[7]',
+});
+const statfs = lib.func('statfs64', 'int', ['str', koffi.out(koffi.pointer(Statfs))]);
+
+export function macOsMountPoint(path: string): string {
+  const result: { mountpoint?: string } = {};
+  if (statfs(path, result) !== 0 || !result.mountpoint?.startsWith('/')) {
+    throw new BridgeProtocolError('Cannot verify macOS identity mount status.');
+  }
+  return result.mountpoint;
+}

--- a/packages/code/src/private-storage.test.ts
+++ b/packages/code/src/private-storage.test.ts
@@ -15,7 +15,7 @@ const identity = { protocolVersion: 1 as const, workerId: 'worker',
 const quarantine = { version: 1 as const, workerId: 'worker', workspaceId: 'primary',
   reason: 'uncertain mutation', quarantinedAt: '2026-01-01T00:00:00Z' };
 
-for (const unsupported of ['win32', 'darwin', 'freebsd']) {
+for (const unsupported of ['win32', 'freebsd']) {
   test(`${unsupported} refuses storage before creation, reads, or deletion`, async t => {
     const root = await mkdtemp(join(tmpdir(), 'private-storage-'));
     t.after(() => rm(root, { recursive: true, force: true }));
@@ -39,7 +39,7 @@ for (const unsupported of ['win32', 'darwin', 'freebsd']) {
 test('GitHub App credentials also reject unsupported ACL verification before signing or fetching', async t => {
   const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
   t.after(() => Object.defineProperty(process, 'platform', platform));
-  Object.defineProperty(process, 'platform', { ...platform, value: 'darwin' });
+  Object.defineProperty(process, 'platform', { ...platform, value: 'freebsd' });
   let fetched = false;
   const provider = new GitHubAppCredentialProvider({
     appId: '1', installationId: '1', privateKeyPath: '/must-not-be-read',

--- a/packages/code/src/private-storage.ts
+++ b/packages/code/src/private-storage.ts
@@ -1,20 +1,41 @@
-import { lstat, readlink } from 'node:fs/promises';
+import { lstat, open, readlink } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import type { FileHandle } from 'node:fs/promises';
 import { dirname, isAbsolute } from 'node:path';
 
 import { BridgeProtocolError } from './protocol.js';
 
-/** Linux POSIX ACL masks are reflected in group mode bits. macOS extended
- * ACLs and Windows DACLs are not: chmod/stat alone cannot establish privacy.
- * Fail before creating files, reading credentials, or redeeming pairing codes
- * until a native verifier can inspect the actual opened object's ACLs.
- */
+/** Linux exposes POSIX ACL masks in mode bits; macOS needs native ACL calls. */
 export function assertPrivateStorageSupported(): void {
-  if (process.platform !== 'linux' || process.getuid === undefined) {
+  if (!['linux', 'darwin'].includes(process.platform) || process.getuid === undefined) {
     throw new BridgeProtocolError(
       'Owner-only storage ACL verification is unavailable on this platform. ' +
-      'Worker credentials, GitHub App keys, and quarantine state require Linux ' +
-      '(including WSL2) with storage on a native Linux filesystem, not /mnt.',
+      'Native Windows is unsupported until DACL removal and verification are implemented. ' +
+      'Use macOS or Linux (including WSL2 with a native Linux filesystem, not /mnt).',
     );
+  }
+}
+
+async function macOsStorage() {
+  try {
+    return await import('./macos-storage.js');
+  } catch {
+    throw new BridgeProtocolError('macOS ACL verification is unavailable: reinstall @librechat/code with its Koffi native dependency.');
+  }
+}
+
+export async function assertPrivateStorageAcl(
+  handle: FileHandle, path: string, directory = false,
+): Promise<void> {
+  if (process.platform === 'darwin') {
+    (await macOsStorage()).verifyMacOsAcl(handle.fd, path, directory);
+  }
+}
+
+/** Only application-owned files/directories may have their ACLs removed. */
+export async function removePrivateStorageAcl(handle: FileHandle, path: string): Promise<void> {
+  if (process.platform === 'darwin') {
+    (await macOsStorage()).removeMacOsAcl(handle.fd, path);
   }
 }
 
@@ -54,6 +75,18 @@ export async function assertPrivateStorageAncestors(
       continue;
     }
     if (metadata.isDirectory()) {
+      if (process.platform === 'darwin') {
+        const handle = await open(current, constants.O_RDONLY | constants.O_NOFOLLOW);
+        try {
+          const opened = await handle.stat();
+          if (opened.dev !== metadata.dev || opened.ino !== metadata.ino) {
+            throw new BridgeProtocolError(`Storage directory changed during ACL verification: ${current}`);
+          }
+          await assertPrivateStorageAcl(handle, current, true);
+        } finally {
+          await handle.close();
+        }
+      }
       const mode = metadata.mode & 0o7777;
       if ((mode & 0o022) !== 0 && (mode & 0o1000) === 0) {
         throw new BridgeProtocolError(

--- a/packages/code/src/storage.ts
+++ b/packages/code/src/storage.ts
@@ -8,11 +8,12 @@ import {
   rm,
   stat,
 } from 'node:fs/promises';
+import type { FileHandle } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 
 import { BRIDGE_PROTOCOL_VERSION, BridgeProtocolError } from './protocol.js';
-import { assertPrivateStorageAncestors, assertPrivateStorageSupported } from './private-storage.js';
+import { assertPrivateStorageAcl, removePrivateStorageAcl, assertPrivateStorageAncestors, assertPrivateStorageSupported } from './private-storage.js';
 
 import { assertIdentityIsNotMountPoint } from './identity-mount.js';
 
@@ -160,28 +161,6 @@ export function defaultWorkspaceQuarantinePath(
   );
 }
 
-/**
- * Verify a path really is owner-only. `chmod` reports success without effect on
- * mounts that do not implement POSIX permissions - notably WSL2 DrvFs
- * (`/mnt/<drive>`), where the result stays world-accessible - so a credential
- * that cannot be protected must fail closed rather than appear protected.
- *
- * Symlinks are resolved: a link's own mode is always `0777` and ignored by the
- * kernel, so the file the bytes live in is what counts.
- *
- * Linux POSIX ACL masks are reflected in group mode bits. Platforms whose
- * ACLs cannot be verified are rejected at the storage entry points.
- */
-async function groupOrOtherAccessMode(
-  path: string,
-): Promise<number | undefined> {
-  if (process.platform === 'win32') return undefined;
-  /* Resolve symlinks: the bytes live at the target, and a link's own mode is
-   * always 0777 and ignored by the kernel. */
-  const mode = (await stat(path)).mode & 0o777;
-  return (mode & 0o077) === 0 ? undefined : mode;
-}
-
 /** Publishing replaces the entry itself; reading also follows its target. */
 async function assertWriteContainerPrivate(path: string): Promise<void> {
   await assertPrivateStorageAncestors(dirname(path), true);
@@ -238,24 +217,31 @@ async function readGuardedFile(
       const mode = stats.mode & 0o777;
       if ((mode & 0o077) !== 0) throw new BridgeProtocolError(exposed(mode.toString(8)));
     }
+    await assertPrivateStorageAcl(handle, path);
     return await handle.readFile('utf8');
   } finally {
     await handle.close();
   }
 }
 
-async function assertOwnerOnlyPath(
-  path: string,
-  reportedPath: string = path,
-): Promise<void> {
-  const mode = await groupOrOtherAccessMode(path);
-  if (mode === undefined) return;
-  throw new BridgeProtocolError(
-    `Cannot restrict ${reportedPath} to owner-only access (mode ${mode.toString(8)}). ` +
-      'Filesystems that ignore POSIX permissions, such as Windows drives mounted ' +
-      'under /mnt, cannot protect worker credentials or workspaces. Use a path on a ' +
-      'native Linux filesystem.',
-  );
+async function assertOwnerOnlyFile(handle: FileHandle, path: string): Promise<void> {
+  const mode = (await handle.stat()).mode & 0o777;
+  if ((mode & 0o077) !== 0) {
+    throw new BridgeProtocolError(
+      `Cannot restrict ${path} to owner-only access (mode ${mode.toString(8)}). ` +
+      'Use a native macOS or Linux filesystem that enforces permissions, not a Windows drive under /mnt.',
+    );
+  }
+  await assertPrivateStorageAcl(handle, path);
+}
+
+async function assertOwnerOnlyPath(path: string): Promise<void> {
+  const handle = await open(path, 'r');
+  try {
+    await assertOwnerOnlyFile(handle, path);
+  } finally {
+    await handle.close();
+  }
 }
 
 export async function ensurePrivateWorkspaceDirectory(
@@ -272,7 +258,14 @@ export async function ensurePrivateWorkspaceDirectory(
   /* This directory is application-owned by contract; a pre-existing one under
    * another account lets that owner alter workspace inputs and results. */
   await assertOwnedByWorker(path);
-  await chmod(path, 0o700);
+  const directory = await open(path, 'r');
+  try {
+    await removePrivateStorageAcl(directory, path);
+    await directory.chmod(0o700);
+    await assertPrivateStorageAcl(directory, path);
+  } finally {
+    await directory.close();
+  }
   await assertOwnerOnlyPath(path);
 }
 
@@ -333,7 +326,14 @@ export interface IdentityPathReservation {
 async function assertSiblingPublishable(path: string): Promise<void> {
   const probePath = `${path}.${randomBytes(8).toString('hex')}.probe`;
   try {
-    await (await open(probePath, 'wx', 0o600)).close();
+    const probe = await open(probePath, 'wx', 0o600);
+    try {
+      await removePrivateStorageAcl(probe, path);
+      await probe.chmod(0o600);
+      await assertOwnerOnlyFile(probe, path);
+    } finally {
+      await probe.close();
+    }
   } catch (error) {
     throw new BridgeProtocolError(
       `Cannot create a temporary file beside ${path} (${
@@ -363,8 +363,9 @@ export async function assertIdentityPathIsPrivate(
     const reserved = await open(path, 'wx', 0o600);
     try {
       created = true;
+      await removePrivateStorageAcl(reserved, path);
       await reserved.chmod(0o600);
-      await assertOwnerOnlyPath(path);
+      await assertOwnerOnlyFile(reserved, path);
       reservedInode = (await reserved.stat({ bigint: true })).ino;
     } finally {
       await reserved.close();
@@ -423,8 +424,9 @@ export async function saveBridgeIdentity(
   try {
     const file = await open(temporaryPath, 'wx', 0o600);
     try {
+      await removePrivateStorageAcl(file, path);
       await file.chmod(0o600);
-      await assertOwnerOnlyPath(temporaryPath, path);
+      await assertOwnerOnlyFile(file, path);
       await file.writeFile(`${JSON.stringify(identity, null, 2)}\n`, 'utf8');
       await file.sync();
     } finally {
@@ -465,8 +467,9 @@ export async function saveWorkspaceMutationQuarantine(
   const file = await open(path, 'wx', 0o600);
   try {
     try {
+      await removePrivateStorageAcl(file, path);
       await file.chmod(0o600);
-      await assertOwnerOnlyPath(path);
+      await assertOwnerOnlyFile(file, path);
       await assertWriteContainerPrivate(path);
       await file.writeFile(`${JSON.stringify(record, null, 2)}\n`, 'utf8');
       await file.sync();
@@ -500,7 +503,7 @@ export async function loadWorkspaceMutationQuarantine(
       (mode) =>
         `Workspace quarantine ${path} is accessible beyond its owner (mode ${mode}). ` +
         'Another local account could clear or forge it. Keep worker state on a ' +
-        'native Linux filesystem.',
+        'native macOS or Linux filesystem.',
     );
     await assertReadPathPrivate(path);
   } catch (error) {
@@ -566,7 +569,7 @@ export async function loadBridgeIdentity(
     (mode) =>
       `Bridge identity ${path} is accessible beyond its owner (mode ${mode}). ` +
       'Treat its private key as compromised: revoke the worker and pair again with an ' +
-      'identity path on a native Linux filesystem.',
+      'identity path on a native macOS or Linux filesystem.',
   );
   /* After the file's own verdict, so an exposed mode keeps its diagnosis. */
   await assertReadPathPrivate(path);


### PR DESCRIPTION
## Summary

I restored macOS BYOM credential and quarantine storage after #138 by using native ACL APIs on open file descriptors, while keeping native Windows explicitly unsupported until DACL protection exists.

- Remove inherited ACLs from new identities, quarantine files, preflight probes, and application-owned workspace directories, then verify protection before writing secrets.
- Reject ACL-exposed credential reads, ACL-writable ancestors, and inheritable allow entries before child creation without modifying existing parent sharing rules.
- Verify GitHub App private keys through the same descriptor used to read them.
- Replace the macOS pairing preflight's Linux-only procfs dependency with native mount verification.
- Add pinned Koffi bindings, real macOS ACL regression tests, a macOS CI job, and platform-support documentation.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

I ran the package build and native macOS tests on Apple Silicon:

```sh
npm run build --prefix packages/code
node --test packages/code/dist/macos-storage.test.js packages/code/dist/private-storage.test.js packages/code/dist/storage.test.js packages/code/dist/github.test.js
git diff --check
```

Result: 43 passed, 4 skipped because no chmod-ignoring filesystem was available. Real ACL fixtures verify inherited deny ACLs are removed before writes and inheritable allow ACLs block all child creation, exposed `0600` files fail closed, writable ancestors are rejected, and verification/removal stay bound to the opened inode after path replacement. Linux coverage runs in existing CI; native ACL coverage runs in the added macOS job.

I also ran the built CLI with a mocked pairing endpoint: macOS pairing persisted an identity, then an exposed ACL blocked re-pairing before any redemption request.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
