### PR TITLE
🧷 fix: Validate Private Storage Through Open Descriptors

### DIFF
--- a/packages/code/src/storage.test.ts
+++ b/packages/code/src/storage.test.ts
@@ -1,5 +1,17 @@
 import assert from 'node:assert/strict';
-import { chmod, mkdir, mkdtemp, open, readdir, rm, stat, symlink, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -137,6 +149,135 @@ test('paired identity is persisted atomically with owner-only permissions', asyn
 
     assert.deepEqual(await loadBridgeIdentity(path), identity);
     assert.equal((await stat(path)).mode & 0o777, 0o600);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('identity saves validate permissions on the open temporary file', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'librechat-code-save-race-'));
+  const path = join(directory, 'identity.json');
+  const displaced = join(directory, 'displaced.tmp');
+  const identity = {
+    protocolVersion: 1 as const,
+    workerId: 'vm-1',
+    codeApiUrl: 'https://code.example/v1',
+    credential: 'must-not-be-written',
+    expiresAt: new Date(Date.now() + 300_000).toISOString(),
+    publicKey: 'public-key',
+    privateKey: 'private-key',
+  };
+  try {
+    const probe = await open(directory, 'r');
+    const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+      chmod(mode: number): Promise<void>;
+    };
+    await probe.close();
+    const originalChmod = fileHandlePrototype.chmod;
+    let swapped = false;
+    t.mock.method(
+      fileHandlePrototype,
+      'chmod',
+      async function (this: FileHandle, mode: number) {
+        if (mode !== 0o600 || swapped) return originalChmod.call(this, mode);
+        swapped = true;
+        await originalChmod.call(this, 0o666);
+        const temporary = (await readdir(directory)).find((name) =>
+          name.endsWith('.tmp'),
+        );
+        assert.ok(temporary);
+        const temporaryPath = join(directory, temporary);
+        await rename(temporaryPath, displaced);
+        await writeFile(temporaryPath, 'owner-only decoy', { mode: 0o600 });
+      },
+    );
+
+    await assert.rejects(
+      saveBridgeIdentity(path, identity),
+      /Cannot restrict .*identity\.json.*mode 666/,
+    );
+    assert.equal(await readFile(displaced, 'utf8'), '');
+    assert.equal((await stat(displaced)).mode & 0o777, 0o666);
+    await assert.rejects(stat(path), { code: 'ENOENT' });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('pairing reservations validate permissions on the open destination', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'librechat-code-reserve-race-'));
+  const path = join(directory, 'identity.json');
+  const displaced = join(directory, 'displaced.json');
+  try {
+    const probe = await open(directory, 'r');
+    const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+      chmod(mode: number): Promise<void>;
+    };
+    await probe.close();
+    const originalChmod = fileHandlePrototype.chmod;
+    let swapped = false;
+    t.mock.method(
+      fileHandlePrototype,
+      'chmod',
+      async function (this: FileHandle, mode: number) {
+        if (mode !== 0o600 || swapped) return originalChmod.call(this, mode);
+        swapped = true;
+        await originalChmod.call(this, 0o666);
+        await rename(path, displaced);
+        await writeFile(path, 'owner-only decoy', { mode: 0o600 });
+      },
+    );
+
+    await assert.rejects(
+      assertIdentityPathIsPrivate(path),
+      /Cannot restrict .*identity\.json.*mode 666/,
+    );
+    assert.equal(await readFile(displaced, 'utf8'), '');
+    assert.equal((await stat(displaced)).mode & 0o777, 0o666);
+    await assert.rejects(stat(path), { code: 'ENOENT' });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('quarantine saves validate permissions on the open marker file', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'librechat-code-quarantine-race-'));
+  const path = join(directory, 'quarantine.json');
+  const displaced = join(directory, 'displaced.json');
+  const record = {
+    version: 1 as const,
+    workerId: 'vm-1',
+    workspaceId: 'primary',
+    quarantinedAt: new Date().toISOString(),
+    reason: 'must-not-be-written',
+  };
+  try {
+    const probe = await open(directory, 'r');
+    const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+      chmod(mode: number): Promise<void>;
+    };
+    await probe.close();
+    const originalChmod = fileHandlePrototype.chmod;
+    let swapped = false;
+    t.mock.method(
+      fileHandlePrototype,
+      'chmod',
+      async function (this: FileHandle, mode: number) {
+        if (mode !== 0o600 || swapped) return originalChmod.call(this, mode);
+        swapped = true;
+        await originalChmod.call(this, 0o666);
+        await rename(path, displaced);
+        await writeFile(path, 'owner-only decoy', { mode: 0o600 });
+      },
+    );
+
+    await assert.rejects(
+      saveWorkspaceMutationQuarantine(path, record),
+      /Cannot restrict .*quarantine\.json.*mode 666/,
+    );
+    assert.equal(await readFile(displaced, 'utf8'), '');
+    assert.equal((await stat(displaced)).mode & 0o777, 0o666);
+    await assert.rejects(stat(path), { code: 'ENOENT' });
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/packages/code/src/storage.ts
+++ b/packages/code/src/storage.ts
@@ -225,7 +225,15 @@ async function readGuardedFile(
 }
 
 async function assertOwnerOnlyFile(handle: FileHandle, path: string): Promise<void> {
-  const mode = (await handle.stat()).mode & 0o777;
+  const metadata = await handle.stat();
+  const self = process.getuid?.();
+  if (self !== undefined && !isTrustedOwner(metadata.uid, self)) {
+    throw new BridgeProtocolError(
+      `${path} is owned by another account (uid ${metadata.uid}), ` +
+        'which can rewrite it. Keep worker credentials on a path this account owns.',
+    );
+  }
+  const mode = metadata.mode & 0o777;
   if ((mode & 0o077) !== 0) {
     throw new BridgeProtocolError(
       `Cannot restrict ${path} to owner-only access (mode ${mode.toString(8)}). ` +


### PR DESCRIPTION
## Summary

I fixed the descriptor/path race in owner-only storage validation. Identity and quarantine writers now inspect the same open inode that receives sensitive bytes instead of resolving its pathname again after `chmod`.

- Validate ownership and mode through `FileHandle.stat()` after descriptor-based `chmod`.
- Apply descriptor validation to pairing reservations, atomic identity temporary files, and quarantine marker files.
- Preserve path-based checks for pre-existing paths and directories where no writer descriptor exists.
- Add name-swap regressions that replace the checked pathname with an owner-only decoy while leaving the open inode exposed.

Closes #134.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Built with `npm --prefix packages/code run build`.
- Ran the focused storage suite: 22 passed, 4 skipped because this host has no chmod-ignoring filesystem.
- Ran platform fail-closed tests: 5 passed.
- Verified identity, pairing-reservation, and quarantine name swaps are rejected before sensitive content is written.
- Checked `git diff --check`.

### **Test Configuration**:

Node 24.16.0 on macOS. The focused storage suite used the existing Linux policy and mountinfo fixtures because native macOS credential storage intentionally fails closed. CI provides native Linux coverage.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
