### PR TITLE
fix: clamp runtime timeout caps at the sandbox limit

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -109,3 +109,15 @@ curl -s http://localhost:2000/api/v2/execute \
   -H 'Content-Type: application/json' \
   -d '{"language":"python","version":"3.14.4","files":[{"content":"print(42)"}]}' | jq
 ```
+
+### Requested runtime caps
+
+`POST /api/v2/execute` treats `run_timeout` as an upper bound in milliseconds.
+A request above the effective runtime limit is clamped to that limit, including
+language and package overrides. Smaller caps are preserved, and omission uses
+the runtime default. Compile, CPU, and memory constraints retain their existing
+validation behavior.
+
+Roll out this sandbox behavior before enabling timeout forwarding in the
+service's plain `/exec` handler. Older sandboxes reject caps above their local
+runtime limit; older services remain compatible with updated sandboxes.

--- a/api/src/api/v2-timeout.test.ts
+++ b/api/src/api/v2-timeout.test.ts
@@ -50,7 +50,7 @@ test('caps execution at the effective language runtime limit without rejecting l
   Job.prototype.prime = async function () { observed.push(this.timeouts.run); };
   Job.prototype.execute = async function () { return {} as Awaited<ReturnType<Job['execute']>>; };
   Job.prototype.cleanup = async function () {};
-  for (const [input, expected] of [[25000, 15000], [15000, 15000], [1000, 1000], [null, 15000], [undefined, 15000]]) {
+  for (const [input, expected] of [[25000, 15000], [15000, 15000], [1000, 1000], [null, 15000], [undefined, 15000]] as const) {
     const response = await fetch(url, {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ language, version: '1.0.0', run_timeout: input, files: [{ name: 'main.txt', content: 'test' }] }),

--- a/api/src/api/v2-timeout.test.ts
+++ b/api/src/api/v2-timeout.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'bun:test';
+import express from 'express';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import type { Server } from 'http';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { config } from '../config';
+import { Job } from '../job';
+import { loadPackage } from '../runtime';
+import router from './v2';
+
+let server: Server;
+let url: string;
+let directory: string;
+const language = 'runtime-timeout-cap-test';
+const originalPrime = Job.prototype.prime;
+const originalExecute = Job.prototype.execute;
+const originalCleanup = Job.prototype.cleanup;
+const requireManifest = config.require_execution_manifest;
+const observed: number[] = [];
+
+beforeAll(async () => {
+  directory = await mkdtemp(join(tmpdir(), 'runtime-timeout-'));
+  await writeFile(join(directory, 'pkg-info.json'), JSON.stringify({
+    language, version: '1.0.0', aliases: [],
+    limit_overrides: { run_timeout: 15000, compile_timeout: 5000 },
+  }));
+  loadPackage(directory);
+  const app = express();
+  app.use(router);
+  await new Promise<void>((resolve) => { server = app.listen(0, '127.0.0.1', () => resolve()); });
+  const address = server.address();
+  url = `http://127.0.0.1:${typeof address === 'object' && address ? address.port : 0}/execute`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await rm(directory, { recursive: true, force: true });
+});
+afterEach(() => {
+  Job.prototype.prime = originalPrime;
+  Job.prototype.execute = originalExecute;
+  Job.prototype.cleanup = originalCleanup;
+  config.require_execution_manifest = requireManifest;
+  observed.length = 0;
+});
+
+test('caps execution at the effective language runtime limit without rejecting larger caller caps', async () => {
+  config.require_execution_manifest = false;
+  Job.prototype.prime = async function () { observed.push(this.timeouts.run); };
+  Job.prototype.execute = async function () { return {} as Awaited<ReturnType<Job['execute']>>; };
+  Job.prototype.cleanup = async function () {};
+  for (const [input, expected] of [[25000, 15000], [15000, 15000], [1000, 1000], [null, 15000], [undefined, 15000]]) {
+    const response = await fetch(url, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ language, version: '1.0.0', run_timeout: input, files: [{ name: 'main.txt', content: 'test' }] }),
+    });
+    expect(response.status, await response.text()).toBe(200);
+    expect(observed.at(-1)).toBe(expected);
+  }
+});
+
+test('invalid runtime types and compile limit violations still fail before priming', async () => {
+  config.require_execution_manifest = false;
+  Job.prototype.prime = async function () { observed.push(this.timeouts.run); };
+  for (const limits of [{ run_timeout: '1000' }, { run_timeout: -1 }, { compile_timeout: 6000 }]) {
+    const response = await fetch(url, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ language, version: '1.0.0', ...limits, files: [{ name: 'main.txt', content: 'test' }] }),
+    });
+    expect(response.status).toBe(400);
+  }
+  expect(observed).toEqual([]);
+});

--- a/api/src/api/v2-timeout.test.ts
+++ b/api/src/api/v2-timeout.test.ts
@@ -56,7 +56,7 @@ test('caps execution at the effective language runtime limit without rejecting l
       body: JSON.stringify({ language, version: '1.0.0', run_timeout: input, files: [{ name: 'main.txt', content: 'test' }] }),
     });
     expect(response.status, await response.text()).toBe(200);
-    expect(observed.at(-1)).toBe(expected);
+    expect(observed[observed.length - 1]).toBe(expected);
   }
 });
 

--- a/api/src/api/v2.ts
+++ b/api/src/api/v2.ts
@@ -253,7 +253,7 @@ function getJob(
   const {
     session_id, language, version, args, stdin, files,
     compile_memory_limit, run_memory_limit,
-    run_timeout, compile_timeout,
+    compile_timeout,
     run_cpu_time, compile_cpu_time,
     env_vars,
   } = body;
@@ -288,7 +288,12 @@ function getJob(
     throw { message: 'files must include at least one runnable source file' };
   }
 
-  validateConstraints(body, rt);
+  // A runtime timeout is a cap, not a request to exceed the runtime's own
+  // limit. Resolve it here, where language/package overrides are available.
+  const runTimeout = typeof body.run_timeout === 'number' && rt.timeouts.run > 0
+    ? Math.min(body.run_timeout, rt.timeouts.run)
+    : body.run_timeout;
+  validateConstraints({ ...body, run_timeout: runTimeout }, rt);
 
   /* Session mode is per-request opt-in: only run in the persistent workspace
    * when THIS request carried a valid X-Runtime-Session-Id. A headerless or
@@ -329,7 +334,7 @@ function getJob(
     stdin: stdin ?? '',
     files,
     timeouts: {
-      run: run_timeout ?? rt.timeouts.run,
+      run: runTimeout ?? rt.timeouts.run,
       compile: compile_timeout ?? rt.timeouts.compile,
     },
     cpu_times: {


### PR DESCRIPTION
## Summary

I made sandbox runtime timeouts honor both the caller's cap and the effective language limit. A 25-second request against a 15-second runtime now executes with a 15-second cap instead of failing validation.

- Clamp `run_timeout` where runtime and package overrides are available.
- Preserve smaller caps, omitted defaults, and existing compile/CPU/memory validation.
- Document the sandbox-first rollout required before #145 forwards plain `/exec` timeouts.

Prerequisite for #145 and danny-avila/agents#492. This change is independently useful for existing programmatic callers. Merge and deploy this sandbox change before the service change in #145.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

Ran `cd api && bun test src/api/v2-timeout.test.ts src/api/v2-files.test.ts src/api/v2-session-binding.test.ts`: 16 tests passed. Tests use the real HTTP route and runtime configuration, with sandbox process execution stubbed. They verify effective Job timeouts and rejection before priming. `git diff --check` passes.

### **Test Configuration**:

Bun 1.3.13 on macOS; runtime package override of 15,000 ms. Repository-wide TypeScript checking reports existing errors; CI covers the full API suite.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
