### PR TITLE
fix: bind GitHub App token requests to the enterprise host

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -158,8 +158,13 @@ authentication is configured. The worker identity, GitHub App key path, token
 source variables, and mutation-quarantine record remain denied to sandboxed
 commands.
 
-For GitHub Enterprise Server, set `LIBRECHAT_CODE_GITHUB_HOST` to its hostname
-and `LIBRECHAT_CODE_GITHUB_API_URL` to its HTTPS API base URL. GitHub
+For GitHub Enterprise Server, set `LIBRECHAT_CODE_GITHUB_HOST` to its hostname.
+App authentication defaults to `https://<host>/api/v3`; GitHub.com continues to
+use `https://api.github.com`. Set `LIBRECHAT_CODE_GITHUB_API_URL` to override
+the HTTPS API base URL, including a custom port or path. Its hostname must
+match the configured Git host (with `api.github.com` corresponding to
+`github.com`), and it must not contain credentials, a query, or a fragment.
+App token requests do not follow redirects. GitHub
 authentication currently requires the `native-srt` command sandbox. Every
 clone, commit, or push command still crosses LibreChat's tool-approval policy;
 the credential boundary does not grant approval by itself.

--- a/packages/code/src/cli.test.ts
+++ b/packages/code/src/cli.test.ts
@@ -371,3 +371,44 @@ test('CLI treats a whitespace-only file relay upstream as disabled', () => {
     /LIBRECHAT_CODE_(?:EXECUTION_MANIFEST_PUBLIC_KEY|FILE_RELAY_IMAGE) is required/,
   );
 });
+
+test('CLI host-only enterprise configuration sends App JWTs to GHES, never GitHub.com', async (t) => {
+  const { generateKeyPairSync } = await import('node:crypto');
+  const { mkdtemp, rm, writeFile } = await import('node:fs/promises');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const directory = await mkdtemp(join(tmpdir(), 'cli-ghes-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const privateKeyPath = join(directory, 'app.pem');
+  const preload = join(directory, 'fetch.mjs');
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  await writeFile(privateKeyPath, privateKey.export({ type: 'pkcs8', format: 'pem' }), { mode: 0o600 });
+  await writeFile(preload, `
+    globalThis.fetch = async (input) => {
+      console.error('GITHUB_REQUEST:' + String(input));
+      throw new Error('test stopped before network delivery');
+    };
+  `);
+  const result = spawnSync(process.execPath, [
+    '--import', preload, fileURLToPath(new URL('./cli.js', import.meta.url)),
+  ], {
+    encoding: 'utf8', timeout: 10000,
+    env: {
+      ...process.env,
+      LIBRECHAT_CODE_URL: 'http://127.0.0.1:1/v1',
+      LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
+      LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
+      LIBRECHAT_CODE_WORKER_DIR: directory,
+      LIBRECHAT_CODE_ALLOW_WORKSPACE_COMMANDS: 'true',
+      LIBRECHAT_CODE_GITHUB_TOKEN: undefined,
+      LIBRECHAT_CODE_GITHUB_APP_ID: '123',
+      LIBRECHAT_CODE_GITHUB_INSTALLATION_ID: '456',
+      LIBRECHAT_CODE_GITHUB_PRIVATE_KEY_FILE: privateKeyPath,
+      LIBRECHAT_CODE_GITHUB_HOST: 'GitHub.Example.Test',
+      LIBRECHAT_CODE_GITHUB_API_URL: undefined,
+    },
+  });
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stderr, /GITHUB_REQUEST:https:\/\/github\.example\.test\/api\/v3\/app\/installations\/456\/access_tokens/);
+  assert.doesNotMatch(result.stderr, /GITHUB_REQUEST:https:\/\/api\.github\.com/);
+});

--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -195,6 +195,7 @@ function githubCredentials(): {
         appId: appId!,
         installationId: installationId!,
         privateKeyPath: privateKeyPath!,
+        host,
         apiUrl,
       }),
     };

--- a/packages/code/src/github.test.ts
+++ b/packages/code/src/github.test.ts
@@ -229,3 +229,48 @@ test('allows the GitHub LFS object delivery hosts', () => {
   assert.ok(GITHUB_ALLOWED_DOMAINS.includes('*.githubusercontent.com'));
   assert.ok(GITHUB_ALLOWED_DOMAINS.includes('github-cloud.s3.amazonaws.com'));
 });
+
+test('App JWT requests use the resolved public or enterprise endpoint', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'github-endpoint-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const privateKeyPath = join(directory, 'app.pem');
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  await writeFile(privateKeyPath, privateKey.export({ type: 'pkcs8', format: 'pem' }), { mode: 0o600 });
+  for (const [host, apiUrl, expected] of [
+    [undefined, undefined, 'https://api.github.com'],
+    ['GitHub.COM', undefined, 'https://api.github.com'],
+    ['GitHub.Example.Test', undefined, 'https://github.example.test/api/v3'],
+    [undefined, 'https://github.example.test/api/v3/', 'https://github.example.test/api/v3'],
+    ['github.example.test', 'https://github.example.test:8443/custom/api/', 'https://github.example.test:8443/custom/api'],
+  ]) {
+    let calls = 0;
+    const provider = new GitHubAppCredentialProvider({
+      appId: '123', installationId: '456', privateKeyPath, host, apiUrl,
+      now: () => new Date('2030-01-01T00:00:00Z'),
+      fetch: async (input, init) => {
+        calls++;
+        assert.equal(String(input), `${expected}/app/installations/456/access_tokens`);
+        assert.equal(init?.method, 'POST');
+        assert.equal(init?.redirect, 'error');
+        assert.match(new Headers(init?.headers).get('authorization')!, /^Bearer eyJ/);
+        return new Response(JSON.stringify({ token: 'ghs_abcdefghijklmnopqrstuvwxyz', expires_at: '2030-01-01T01:00:00Z' }), { status: 201 });
+      },
+    });
+    await provider.getCredential();
+    await provider.getCredential();
+    assert.equal(calls, 1);
+  }
+});
+
+test('invalid or mismatched App endpoints are refused before any private key access', () => {
+  for (const apiUrl of [
+    'https://api.github.com', 'https://other.example.test/api/v3',
+    'http://github.example.test/api/v3', 'https://user:password@github.example.test/api/v3',
+    'https://github.example.test/api/v3?query=1', 'https://github.example.test/api/v3#fragment',
+  ]) {
+    assert.throws(() => new GitHubAppCredentialProvider({
+      appId: '123', installationId: '456', privateKeyPath: '/must-not-be-read',
+      host: 'github.example.test', apiUrl,
+    }), /must match|HTTPS URL without credentials|query or fragment/);
+  }
+});

--- a/packages/code/src/github.test.ts
+++ b/packages/code/src/github.test.ts
@@ -267,6 +267,7 @@ test('invalid or mismatched App endpoints are refused before any private key acc
     'https://api.github.com', 'https://other.example.test/api/v3',
     'http://github.example.test/api/v3', 'https://user:password@github.example.test/api/v3',
     'https://github.example.test/api/v3?query=1', 'https://github.example.test/api/v3#fragment',
+    'https://github.example.test/api/v3?', 'https://github.example.test/api/v3#',
   ]) {
     assert.throws(() => new GitHubAppCredentialProvider({
       appId: '123', installationId: '456', privateKeyPath: '/must-not-be-read',

--- a/packages/code/src/github.ts
+++ b/packages/code/src/github.ts
@@ -29,6 +29,8 @@ export interface GitHubAppCredentialProviderOptions {
   installationId: string;
   privateKeyPath: string;
   apiUrl?: string;
+  /** Git HTTPS hostname; non-public hosts default to the GHES /api/v3 base. */
+  host?: string;
   fetch?: typeof globalThis.fetch;
   now?: () => Date;
   platform?: NodeJS.Platform;
@@ -95,6 +97,7 @@ function createAppJwt(appId: string, privateKey: string, now: Date): string {
 
 export class GitHubAppCredentialProvider implements GitHubCredentialProvider {
   private cached?: GitHubCredential;
+  private readonly apiUrl: string;
 
   constructor(private readonly options: GitHubAppCredentialProviderOptions) {
     if ((options.platform ?? process.platform) === 'win32') {
@@ -107,14 +110,23 @@ export class GitHubAppCredentialProvider implements GitHubCredentialProvider {
       'GitHub App installation ID',
       options.installationId,
     );
-    if (options.apiUrl != null) {
-      const apiUrl = new URL(options.apiUrl);
-      if (apiUrl.protocol !== 'https:' || apiUrl.username || apiUrl.password) {
-        throw new Error(
-          'GitHub API URL must be an HTTPS URL without credentials',
-        );
-      }
+    const host = options.host == null ? undefined : normalizeGitHubHost(options.host);
+    const apiUrl = new URL(options.apiUrl ?? (
+      host != null && host !== 'github.com'
+        ? `https://${host}/api/v3`
+        : 'https://api.github.com'
+    ));
+    if (apiUrl.protocol !== 'https:' || apiUrl.username || apiUrl.password) {
+      throw new Error('GitHub API URL must be an HTTPS URL without credentials');
     }
+    if (apiUrl.search || apiUrl.hash) {
+      throw new Error('GitHub API URL must not contain a query or fragment');
+    }
+    const apiHost = apiUrl.hostname === 'api.github.com' ? 'github.com' : apiUrl.hostname;
+    if (host != null && host !== apiHost) {
+      throw new Error('LIBRECHAT_CODE_GITHUB_HOST must match the GitHub App API hostname');
+    }
+    this.apiUrl = apiUrl.href.replace(/\/+$/, '');
   }
 
   async getCredential(signal?: AbortSignal): Promise<GitHubCredential> {
@@ -127,15 +139,12 @@ export class GitHubAppCredentialProvider implements GitHubCredentialProvider {
     }
     const privateKey = await readPrivateKey(this.options.privateKeyPath);
     const jwt = createAppJwt(this.options.appId, privateKey, now);
-    const apiUrl = (this.options.apiUrl ?? 'https://api.github.com').replace(
-      /\/+$/,
-      '',
-    );
     const request = this.options.fetch ?? globalThis.fetch;
     const response = await request(
-      `${apiUrl}/app/installations/${this.options.installationId}/access_tokens`,
+      `${this.apiUrl}/app/installations/${this.options.installationId}/access_tokens`,
       {
         method: 'POST',
+        redirect: 'error',
         headers: {
           Accept: 'application/vnd.github+json',
           Authorization: `Bearer ${jwt}`,

--- a/packages/code/src/github.ts
+++ b/packages/code/src/github.ts
@@ -119,7 +119,7 @@ export class GitHubAppCredentialProvider implements GitHubCredentialProvider {
     if (apiUrl.protocol !== 'https:' || apiUrl.username || apiUrl.password) {
       throw new Error('GitHub API URL must be an HTTPS URL without credentials');
     }
-    if (apiUrl.search || apiUrl.hash) {
+    if (/[?#]/.test(apiUrl.href)) {
       throw new Error('GitHub API URL must not contain a query or fragment');
     }
     const apiHost = apiUrl.hostname === 'api.github.com' ? 'github.com' : apiUrl.hostname;


### PR DESCRIPTION
## Summary

I fixed host-only GitHub Enterprise Server configuration sending App token requests to GitHub.com while scoping Git credentials to the enterprise host.

- Pass the resolved Git host into the App credential provider and derive `https://<host>/api/v3` for enterprise hosts.
- Preserve `https://api.github.com` for GitHub.com and explicit HTTPS API overrides, including custom ports and paths.
- Validate host agreement before reading private keys and reject URL credentials, queries, fragments, and redirects.
- Freeze the validated endpoint for token refresh and retain token caching.
- Document enterprise endpoint defaults and override constraints.

Fixes #137. No dependent PRs or protocol changes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- Ran `npm --prefix packages/code run build`.
- Ran `cd packages/code && node --test dist/github.test.js dist/cli.test.js`: 29 tests passed.
- Confirmed the new host-only CLI regression fails with the original CLI wiring.
- Covered public defaults, enterprise host-only and URL-only configurations, mixed case, explicit ports/paths, caching, redirect policy, and invalid/mismatched endpoints.
- Ran `git diff --check`.

### **Test Configuration**:

Node 24.16.0 on macOS. Tests use real temporary private keys and native ACL checks, with token HTTP requests stubbed; no credentials are sent to an external host.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
