### PR TITLE
fix(code): support declared Node engine range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,12 @@ jobs:
         run: bun run test
 
   code-package-tests:
-    name: Code Package Tests
+    name: Code Package Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20.11.0', '22.21.0', '24.16.0']
     defaults:
       run:
         working-directory: packages/code
@@ -135,9 +139,7 @@ jobs:
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          # The suite fails 47 worker tests on Node 22 despite the package's
-          # ">=20.11" engines range, so CI pins the version it is green on.
-          node-version: 24.16.0
+          node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: packages/code/package-lock.json
 

--- a/packages/code/src/worker.ts
+++ b/packages/code/src/worker.ts
@@ -1647,7 +1647,6 @@ export class BridgeWorker {
       signal?.addEventListener('abort', abortRequest, { once: true });
     }
     const timeout = setTimeout(abortRequest, timeoutMs);
-    timeout.unref?.();
     try {
       return await this.request<T>(url, body, controller.signal);
     } finally {


### PR DESCRIPTION
The `@librechat/code` package declares Node `>=20.11`, but its worker request deadline used an unreferenced timer. On Node 20 and 22, a stalled transport could therefore let the event loop finish before the deadline aborted the request, cancelling the worker suite and weakening the runtime deadline guarantee.

Keep the deadline timer referenced until the request settles, and run the code-package suite on Node 20.11.0, 22.21.0, and 24.16.0 so the published engine range stays covered.

Validation:
- `npm run build`
- worker suite: 54/54 passing on Node 20.11.0
- focused stalled-reset regression passing on Node 20.19.5, 22.21.0, and 24.16.0
- full local package suite reaches 316 passing tests on all three installed versions; two Linux mount-table cases remain non-runnable on macOS and are covered by the Linux CI matrix

Closes #133
