### PR TITLE
🪟 fix: Preserve Preview Authentication on First Navigation

### DIFF
--- a/docs/lambda-microvm/README.md
+++ b/docs/lambda-microvm/README.md
@@ -232,7 +232,10 @@ Content-Type: application/json
 ```
 
 `GET /v1/hosted-apps/:app_id?runtime_session_hint=...` returns status and a
-fresh five-minute `preview_url`; `DELETE` on the same resource terminates the
+fresh five-minute `preview_url`; the authorization response loads a minimal
+same-origin handoff page before opening the app so the first request includes
+the host-only `SameSite=Strict` preview cookie even when LibreChat is on another
+site. `DELETE` on the same resource terminates the
 lease. A revision is immutable. Retrying the identical spec reasserts the
 resident process; changing code or launch settings requires a new revision and
 captures a new exact checkpoint. An ambiguous provider launch is replayed only

--- a/service/src/hosted-app/preview-gateway.test.ts
+++ b/service/src/hosted-app/preview-gateway.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import type { Response } from 'express';
+import { sendHostedAppPreviewAuthorizationHandoff } from './preview-gateway';
+
+describe('hosted app preview authorization handoff', () => {
+  test('ends the cross-site redirect chain before starting a same-origin navigation', () => {
+    const headers = new Map<string, string>();
+    let status: number | undefined;
+    let type: string | undefined;
+    let body: string | undefined;
+    let redirects = 0;
+    const response = {
+      setHeader(name: string, value: string) {
+        headers.set(name.toLowerCase(), value);
+        return this;
+      },
+      status(value: number) {
+        status = value;
+        return this;
+      },
+      type(value: string) {
+        type = value;
+        return this;
+      },
+      send(value: string) {
+        body = value;
+        return this;
+      },
+      redirect() {
+        redirects += 1;
+        return this;
+      },
+    } as unknown as Response;
+
+    sendHostedAppPreviewAuthorizationHandoff(response, 'signed.token/value', 300);
+
+    expect(status).toBe(200);
+    expect(type).toBe('html');
+    expect(redirects).toBe(0);
+    expect(headers.get('cache-control')).toBe('no-store');
+    expect(headers.has('location')).toBe(false);
+    expect(headers.get('set-cookie')).toBe(
+      '__Host-codeapi-app=signed.token%2Fvalue; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=300',
+    );
+    expect(body).toContain('<script>location.replace("/")</script>');
+    expect(body).toContain('<meta http-equiv="refresh" content="0;url=/">');
+    expect(body).not.toContain('__codeapi/authorize');
+    expect(body).not.toContain('token');
+  });
+});

--- a/service/src/hosted-app/preview-gateway.ts
+++ b/service/src/hosted-app/preview-gateway.ts
@@ -49,6 +49,40 @@ function reject(res: Response, status: number, message: string): Response {
   return res.status(status).type('text/plain').send(message);
 }
 
+/**
+ * End the cross-site navigation before loading the app. A SameSite=Strict
+ * cookie set on a cross-site HTTP redirect can remain excluded for the whole
+ * redirect chain. Loading this small document first makes its navigation to
+ * `/` originate from the preview site while keeping the cookie Strict.
+ */
+export function sendHostedAppPreviewAuthorizationHandoff(
+  res: Response,
+  sessionToken: string,
+  maxAge: number,
+): Response {
+  res.setHeader('Set-Cookie', [
+    `${COOKIE_NAME}=${encodeURIComponent(sessionToken)}`,
+    'Path=/',
+    'HttpOnly',
+    'Secure',
+    'SameSite=Strict',
+    `Max-Age=${maxAge}`,
+  ].join('; '));
+  res.setHeader('Cache-Control', 'no-store');
+  return res.status(200).type('html').send([
+    '<!doctype html>',
+    '<html><head>',
+    '<meta charset="utf-8">',
+    '<meta name="referrer" content="no-referrer">',
+    '<meta http-equiv="refresh" content="0;url=/">',
+    '<title>Opening preview</title>',
+    '</head><body>',
+    '<script>location.replace("/")</script>',
+    '<p><a href="/">Continue to preview</a></p>',
+    '</body></html>',
+  ].join(''));
+}
+
 export async function hostedAppPreviewGateway(
   req: Request,
   res: Response,
@@ -111,16 +145,7 @@ export async function hostedAppPreviewGateway(
         expiresAt,
       }, previewKey());
       const maxAge = Math.max(1, Math.floor((expiresAt - Date.now()) / 1_000));
-      res.setHeader('Set-Cookie', [
-        `${COOKIE_NAME}=${encodeURIComponent(sessionToken)}`,
-        'Path=/',
-        'HttpOnly',
-        'Secure',
-        'SameSite=Strict',
-        `Max-Age=${maxAge}`,
-      ].join('; '));
-      res.setHeader('Cache-Control', 'no-store');
-      res.redirect(303, '/');
+      sendHostedAppPreviewAuthorizationHandoff(res, sessionToken, maxAge);
       return;
     }
 


### PR DESCRIPTION
## Summary

I fixed hosted-app previews failing on their first navigation from a different site. The authorization exchange now completes as a document load before the app navigation, allowing the existing Strict cookie to accompany the first app request.

- Replace the authorization endpoint's HTTP `303` with a non-cacheable HTML handoff page.
- Start the app navigation from the preview origin with `location.replace("/")` and a meta-refresh fallback.
- Preserve the host-only, HttpOnly, Secure, and `SameSite=Strict` cookie boundary.
- Keep the signed authorization token out of the handoff body and subsequent app URL.
- Document the first-navigation behavior.

Fixes #142. No dependencies or protocol changes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- Ran `cd service && bun test ./src/hosted-app/preview-gateway.test.ts ./src/hosted-app/preview-access.test.ts ./src/hosted-app/proxy-policy.test.ts`: 8 tests passed.
- Confirmed the new regression fails against the original redirect implementation.
- Ran a headless Chrome cross-site navigation canary over HTTPS: the old `303` omitted the Strict cookie on the first `/` request, while both the script handoff and JavaScript-disabled meta-refresh fallback included it on that request.
- Verified the authorization response returns HTTP 200 with no `Location`, emits the unchanged Strict cookie attributes, starts a same-origin navigation, and contains no authorization path or token.
- Ran `git diff --check`.

### **Test Configuration**:

Bun 1.3.13 and Google Chrome on macOS. The committed regression exercises the redirect-chain response contract without a live MicroVM; a local two-site HTTPS canary validates browser cookie behavior. CI runs the complete service suite.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
