### PR TITLE
🧾 fix: Log Workspace Tool HTTP Outcomes

### DIFF
--- a/service/src/api-server.ts
+++ b/service/src/api-server.ts
@@ -34,7 +34,7 @@ import { hostedAppPreviewGateway } from './hosted-app/preview-gateway';
 const { LOCAL_MODE: isLocalMode } = env;
 
 const app = express();
-app.use('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
+app.post('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
 app.disable('x-powered-by');
 app.set('trust proxy', 1);
 app.use(traceHttpRequest('codeapi.api.request'));

--- a/service/src/api-server.ts
+++ b/service/src/api-server.ts
@@ -20,6 +20,7 @@ import serviceRouter from './service/router';
 import programmaticRouter from './service/programmatic-router';
 import bridgeRouter from './bridge';
 import workspaceToolsRouter from './workspace-tools';
+import { workspaceToolOutcomeLogging } from './workspace-tools/outcome';
 import { connection } from './queue';
 import { metricsHandler } from './metrics';
 import { httpMetricsMiddleware } from './middleware/httpMetrics';
@@ -33,6 +34,7 @@ import { hostedAppPreviewGateway } from './hosted-app/preview-gateway';
 const { LOCAL_MODE: isLocalMode } = env;
 
 const app = express();
+app.use('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
 app.disable('x-powered-by');
 app.set('trust proxy', 1);
 app.use(traceHttpRequest('codeapi.api.request'));

--- a/service/src/hosted-app/preview-access.ts
+++ b/service/src/hosted-app/preview-access.ts
@@ -142,3 +142,12 @@ export function hostedAppPreviewAuthorizeUrl(
   origin.searchParams.set('token', token);
   return origin.toString();
 }
+
+export function hostedAppRequestHostname(host: string | undefined): string | undefined {
+  if (host == null || host.length === 0 || /[\s/@\\]/.test(host)) return undefined;
+  try {
+    return new URL(`http://${host}`).hostname;
+  } catch {
+    return undefined;
+  }
+}

--- a/service/src/hosted-app/preview-gateway.ts
+++ b/service/src/hosted-app/preview-gateway.ts
@@ -5,6 +5,7 @@ import { readRuntimeSessionRecord } from '../runtime-session/registry';
 import { HostedAppControlPlaneError } from './control-plane';
 import {
   hostedAppRuntimeIdFromHostname,
+  hostedAppRequestHostname,
   HostedAppPreviewAccessError,
   hostedAppPreviewOwnerBinding,
   signHostedAppPreviewAccess,
@@ -15,16 +16,6 @@ import { applyHostedAppPreviewSecurityHeaders } from './proxy-policy';
 
 const COOKIE_NAME = '__Host-codeapi-app';
 const PREVIEW_COOKIE_TTL_MS = 60 * 60_000;
-
-function rawHostname(req: Request): string | undefined {
-  const host = req.headers.host;
-  if (!host || /[\s/@\\]/.test(host)) return undefined;
-  try {
-    return new URL(`http://${host}`).hostname;
-  } catch {
-    return undefined;
-  }
-}
 
 function cookie(req: Request, name: string): string | undefined {
   for (const item of (req.headers.cookie ?? '').split(';')) {
@@ -55,7 +46,7 @@ export async function hostedAppPreviewGateway(
   next: NextFunction,
 ): Promise<void> {
   if (!env.HOSTED_APPS_ENABLED || !env.HOSTED_APP_PREVIEW_ORIGIN) return next();
-  const hostname = rawHostname(req);
+  const hostname = hostedAppRequestHostname(req.headers.host);
   const runtimeId = hostname
     ? hostedAppRuntimeIdFromHostname(hostname, env.HOSTED_APP_PREVIEW_ORIGIN)
     : undefined;

--- a/service/src/middleware/execution-profile.ts
+++ b/service/src/middleware/execution-profile.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
 import { env } from '../config';
+import { recordWorkspaceToolRejection } from '../workspace-tools/outcome';
 import {
   checkExecutionProfileExpectation,
   EXECUTION_PROFILE_HEADER,
@@ -48,5 +49,6 @@ export function executionProfileMiddleware(
       ? 'mismatch'
       : 'invalid',
   });
+  recordWorkspaceToolRejection(res, expectation.body.error);
   res.status(expectation.status).json(expectation.body);
 }

--- a/service/src/service-api.ts
+++ b/service/src/service-api.ts
@@ -7,6 +7,7 @@ import serviceRouter from './service/router';
 import programmaticRouter from './service/programmatic-router';
 import bridgeRouter from './bridge';
 import workspaceToolsRouter from './workspace-tools';
+import { workspaceToolOutcomeLogging } from './workspace-tools/outcome';
 import { connection } from './queue';
 import { env } from './config';
 import logger from './logger';
@@ -14,6 +15,7 @@ import hostedAppRouter from './hosted-app/router';
 import { hostedAppPreviewGateway } from './hosted-app/preview-gateway';
 
 const app = express();
+app.use('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
 app.disable('x-powered-by');
 app.set('trust proxy', 1);
 app.use(executionProfileMiddleware);

--- a/service/src/service-api.ts
+++ b/service/src/service-api.ts
@@ -15,7 +15,7 @@ import hostedAppRouter from './hosted-app/router';
 import { hostedAppPreviewGateway } from './hosted-app/preview-gateway';
 
 const app = express();
-app.use('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
+app.post('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
 app.disable('x-powered-by');
 app.set('trust proxy', 1);
 app.use(executionProfileMiddleware);

--- a/service/src/workspace-tools/outcome.ts
+++ b/service/src/workspace-tools/outcome.ts
@@ -1,6 +1,8 @@
 import type { RequestHandler, Response } from 'express';
 import type { WorkspaceToolRequest } from '../../../packages/code/src/protocol';
 import logger from '../logger';
+import { env } from '../config';
+import { hostedAppRequestHostname, hostedAppRuntimeIdFromHostname } from '../hosted-app/preview-access';
 
 interface WorkspaceToolOutcome {
   operation?: WorkspaceToolRequest['operation'];
@@ -60,7 +62,17 @@ export function getWorkspaceToolOutcome(res: Response): WorkspaceToolOutcome {
   return outcome;
 }
 
+export function recordWorkspaceToolRejection(res: Response, errorCode: string): void {
+  const outcome = outcomes.get(res);
+  if (outcome != null) outcome.errorCode = errorCode;
+}
+
+/** Classify raw Host like the preview gateway without moving the earlier profile guard. */
 export const workspaceToolOutcomeLogging: RequestHandler = (req, res, next): void => {
-  if (req.method === 'POST') getWorkspaceToolOutcome(res);
+  if (req.method !== 'POST') return next();
+  const hostname = hostedAppRequestHostname(req.headers.host);
+  if (env.HOSTED_APPS_ENABLED && env.HOSTED_APP_PREVIEW_ORIGIN && hostname != null &&
+    hostedAppRuntimeIdFromHostname(hostname, env.HOSTED_APP_PREVIEW_ORIGIN) != null) return next();
+  getWorkspaceToolOutcome(res);
   next();
 };

--- a/service/src/workspace-tools/outcome.ts
+++ b/service/src/workspace-tools/outcome.ts
@@ -1,0 +1,66 @@
+import type { RequestHandler, Response } from 'express';
+import type { WorkspaceToolRequest } from '../../../packages/code/src/protocol';
+import logger from '../logger';
+
+interface WorkspaceToolOutcome {
+  operation?: WorkspaceToolRequest['operation'];
+  workerId?: string;
+  errorCode?: string;
+  deadlineBudgetMs?: number;
+  dispatchDurationMs?: number;
+  dispatchPending: boolean;
+  flush: () => void;
+}
+
+const outcomes = new WeakMap<Response, WorkspaceToolOutcome>();
+const earlyErrorCodes: Record<number, string> = {
+  400: 'INVALID_REQUEST',
+  401: 'UNAUTHENTICATED',
+  403: 'AUTHORIZATION_REJECTED',
+  413: 'REQUEST_TOO_LARGE',
+  429: 'RATE_LIMITED',
+  500: 'INTERNAL_ERROR',
+};
+
+export function getWorkspaceToolOutcome(res: Response): WorkspaceToolOutcome {
+  const existing = outcomes.get(res);
+  if (existing != null) return existing;
+  const startedAt = performance.now();
+  let responseEndedAt: number | undefined;
+  let logged = false;
+  const outcome: WorkspaceToolOutcome = {
+    dispatchPending: false,
+    flush: (): void => {
+      if (logged || responseEndedAt == null || outcome.dispatchPending) return;
+      logged = true;
+      outcomes.delete(res);
+      const finished = res.writableFinished;
+      logger.log(finished && res.statusCode < 400 ? 'info' : 'warn', 'Workspace tool request completed', {
+        route: '/workspace-tools/execute',
+        operation: outcome.operation,
+        workerId: outcome.workerId,
+        status: finished ? res.statusCode : undefined,
+        outcome: finished ? 'completed' : 'disconnected',
+        errorCode: outcome.errorCode ?? (finished ? earlyErrorCodes[res.statusCode] : undefined),
+        durationMs: Math.round(responseEndedAt - startedAt),
+        dispatchDurationMs: outcome.dispatchDurationMs,
+        deadlineBudgetMs: outcome.deadlineBudgetMs,
+      });
+    },
+  };
+  const onResponseEnd = (): void => {
+    res.removeListener('finish', onResponseEnd);
+    res.removeListener('close', onResponseEnd);
+    responseEndedAt = performance.now();
+    outcome.flush();
+  };
+  outcomes.set(res, outcome);
+  res.once('finish', onResponseEnd);
+  res.once('close', onResponseEnd);
+  return outcome;
+}
+
+export const workspaceToolOutcomeLogging: RequestHandler = (req, res, next): void => {
+  if (req.method === 'POST') getWorkspaceToolOutcome(res);
+  next();
+};

--- a/service/src/workspace-tools/outcome.ts
+++ b/service/src/workspace-tools/outcome.ts
@@ -20,6 +20,7 @@ const earlyErrorCodes: Record<number, string> = {
   401: 'UNAUTHENTICATED',
   403: 'AUTHORIZATION_REJECTED',
   413: 'REQUEST_TOO_LARGE',
+  415: 'UNSUPPORTED_MEDIA_TYPE',
   429: 'RATE_LIMITED',
   500: 'INTERNAL_ERROR',
 };

--- a/service/src/workspace-tools/router.test.ts
+++ b/service/src/workspace-tools/router.test.ts
@@ -9,6 +9,8 @@ import logger from '../logger';
 import { env } from '../config';
 import { apiKeyAuth } from '../middleware/auth';
 import { workspaceToolOutcomeLogging } from './outcome';
+import { executionProfileMiddleware } from '../middleware/execution-profile';
+import { hostedAppPreviewGateway } from '../hosted-app/preview-gateway';
 import { applyPrincipal } from '../auth/principal';
 import { BridgeStoreError } from '../bridge/store';
 import { bridgeStoreStatus, createWorkspaceToolsRouter } from './router';
@@ -513,5 +515,50 @@ test.each(['auth', 'limit'] as const)('logs requests rejected by upstream %s mid
     env.LOCAL_MODE = originalLocalMode;
     if (originalProvider == null) delete process.env.CODEAPI_AUTH_PROVIDER;
     else process.env.CODEAPI_AUTH_PROVIDER = originalProvider;
+  }
+});
+
+test.each([
+  ['preview', undefined, 401, undefined],
+  ['preview', 'stateful', 409, undefined],
+  ['api', 'stateful', 409, 'execution_profile_mismatch'],
+  ['api', 'invalid', 400, 'invalid_execution_profile'],
+] as const)('classifies %s host traffic with expected profile %s', async (hostKind, expectedProfile, status, errorCode) => {
+  const saved = { enabled: env.HOSTED_APPS_ENABLED, origin: env.HOSTED_APP_PREVIEW_ORIGIN, profile: env.EXECUTION_PROFILE };
+  env.HOSTED_APPS_ENABLED = true;
+  env.HOSTED_APP_PREVIEW_ORIGIN = 'https://apps.example.test';
+  env.EXECUTION_PROFILE = 'default';
+  try {
+    const app = express();
+    app.use('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
+    app.use(executionProfileMiddleware);
+    app.use(hostedAppPreviewGateway);
+    app.use(json());
+    app.post('/v1/workspace-tools/execute', (_req, res) => { res.sendStatus(200); });
+    server = createServer(app);
+    await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (address == null || typeof address === 'string') throw new Error('Expected TCP listener');
+    const response = await fetch(`http://127.0.0.1:${address.port}/v1/workspace-tools/execute`, {
+      method: 'POST', headers: {
+        'Content-Type': 'application/json',
+        Host: hostKind === 'preview' ? `happ-${'a'.repeat(40)}.apps.example.test` : 'api.example.test',
+        ...(expectedProfile == null ? {} : { 'X-CodeAPI-Expected-Profile': expectedProfile }),
+      }, body: '{}',
+    });
+    await response.text();
+    expect(response.status).toBe(status);
+    if (hostKind === 'preview') {
+      expect(logSpy).not.toHaveBeenCalled();
+    } else {
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith('warn', 'Workspace tool request completed', expect.objectContaining({
+        status, errorCode, dispatchDurationMs: undefined,
+      }));
+    }
+  } finally {
+    env.HOSTED_APPS_ENABLED = saved.enabled;
+    env.HOSTED_APP_PREVIEW_ORIGIN = saved.origin;
+    env.EXECUTION_PROFILE = saved.profile;
   }
 });

--- a/service/src/workspace-tools/router.test.ts
+++ b/service/src/workspace-tools/router.test.ts
@@ -481,7 +481,7 @@ test.each(['auth', 'limit'] as const)('logs requests rejected by upstream %s mid
   process.env.CODEAPI_AUTH_PROVIDER = 'librechat-jwt';
   try {
     const app = express();
-    app.use('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
+    app.post('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
     app.use(json());
     if (stage === 'auth') app.use(apiKeyAuth);
     else app.use(rateLimitFactory({ windowMs: 60_000, max: 1 }));
@@ -530,7 +530,7 @@ test.each([
   env.EXECUTION_PROFILE = 'default';
   try {
     const app = express();
-    app.use('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
+    app.post('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
     app.use(executionProfileMiddleware);
     app.use(hostedAppPreviewGateway);
     app.use(json());
@@ -561,4 +561,49 @@ test.each([
     env.HOSTED_APP_PREVIEW_ORIGIN = saved.origin;
     env.EXECUTION_PROFILE = saved.profile;
   }
+});
+
+test.each([
+  ['POST', '/v1/workspace-tools/execute', true],
+  ['POST', '/v1/workspace-tools/execute/?attempt=1', true],
+  ['POST', '/v1/workspace-tools/execute/unknown', false],
+  ['POST', '/v1/workspace-tools/execute-extra', false],
+  ['GET', '/v1/workspace-tools/execute', false],
+] as const)('logs only workspace endpoint traffic: %s %s', async (method, path, shouldLog) => {
+  const app = express();
+  app.post('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
+  app.use((_req, res) => { res.sendStatus(401); });
+  server = createServer(app);
+  await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (address == null || typeof address === 'string') throw new Error('Expected TCP listener');
+  const response = await fetch(`http://127.0.0.1:${address.port}${path}`, { method });
+  await response.text();
+  expect(response.status).toBe(401);
+  expect(logSpy).toHaveBeenCalledTimes(shouldLog ? 1 : 0);
+});
+
+test.each([
+  ['unsupported encoding', 'application/json', 'unsupported', '{}', 415, 'UNSUPPORTED_MEDIA_TYPE'],
+  ['unsupported charset', 'application/json; charset=iso-8859-1', 'identity', '{}', 415, 'UNSUPPORTED_MEDIA_TYPE'],
+  ['invalid json', 'application/json', 'identity', '{', 400, 'INVALID_REQUEST'],
+  ['oversized json', 'application/json', 'identity', JSON.stringify({ content: 'x'.repeat(100) }), 413, 'REQUEST_TOO_LARGE'],
+] as const)('classifies parser rejection: %s', async (_scenario, contentType, encoding, body, status, errorCode) => {
+  const app = express();
+  app.post('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
+  app.use(json({ limit: 32 }));
+  app.post('/v1/workspace-tools/execute', (_req, res) => { res.sendStatus(200); });
+  server = createServer(app);
+  await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (address == null || typeof address === 'string') throw new Error('Expected TCP listener');
+  const response = await fetch(`http://127.0.0.1:${address.port}/v1/workspace-tools/execute`, {
+    method: 'POST', headers: { 'Content-Type': contentType, 'Content-Encoding': encoding }, body,
+  });
+  await response.text();
+  expect(response.status).toBe(status);
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy).toHaveBeenCalledWith('warn', 'Workspace tool request completed', expect.objectContaining({
+    status, errorCode, dispatchDurationMs: undefined, outcome: 'completed',
+  }));
 });

--- a/service/src/workspace-tools/router.test.ts
+++ b/service/src/workspace-tools/router.test.ts
@@ -3,17 +3,23 @@ import type { Server } from 'node:http';
 
 import { afterEach, beforeEach, expect, spyOn, test } from 'bun:test';
 import express, { json } from 'express';
+import rateLimitFactory from 'express-rate-limit';
 
 import logger from '../logger';
+import { env } from '../config';
+import { apiKeyAuth } from '../middleware/auth';
+import { workspaceToolOutcomeLogging } from './outcome';
 import { applyPrincipal } from '../auth/principal';
 import { BridgeStoreError } from '../bridge/store';
 import { bridgeStoreStatus, createWorkspaceToolsRouter } from './router';
 
 let server: Server | undefined;
+let logCompleted: ReturnType<typeof Promise.withResolvers<void>>;
 let logSpy: ReturnType<typeof spyOn<typeof logger, 'log'>>;
 
 beforeEach(() => {
-  logSpy = spyOn(logger, 'log').mockReturnValue(logger);
+  logCompleted = Promise.withResolvers<void>();
+  logSpy = spyOn(logger, 'log').mockImplementation(() => { logCompleted.resolve(); return logger; });
 });
 
 afterEach(() => {
@@ -170,6 +176,11 @@ test('dispatches an authenticated workspace tool request to the principal-bound 
   let dispatchArgs: Record<string, unknown> | undefined;
   const app = express();
   app.use(json());
+  app.use((_req, res, next) => {
+    const send = res.json.bind(res);
+    res.json = (body): typeof res => { setTimeout(() => send(body), 120); return res; };
+    next();
+  });
   app.use((req, _res, next) => {
     applyPrincipal(req, {
       userId: 'user-1',
@@ -231,6 +242,8 @@ test('dispatches an authenticated workspace tool request to the principal-bound 
   });
 
   expect(response.status).toBe(200);
+  const timing = Reflect.get(logSpy.mock.calls[0], 2) as { durationMs: number; dispatchDurationMs: number };
+  expect(timing.durationMs - timing.dispatchDurationMs).toBeGreaterThanOrEqual(100);
   expect(logSpy).toHaveBeenCalledTimes(1);
   expect(logSpy).toHaveBeenCalledWith(
     'info',
@@ -394,6 +407,7 @@ test('logs a disconnected dispatch once without inventing HTTP 200', async () =>
   const app = express();
   const started = Promise.withResolvers<void>();
   const closed = Promise.withResolvers<void>();
+  const settlementGate = Promise.withResolvers<void>();
   let dispatchAborted = false;
   let closeConnection = (): void => { throw new Error('connection not ready'); };
   app.use(json());
@@ -416,7 +430,7 @@ test('logs a disconnected dispatch once without inventing HTTP 200', async () =>
               'abort',
               () => {
                 dispatchAborted = true;
-                reject(new BridgeStoreError('ASSIGNMENT_EXPIRED', 'caller left'));
+                void settlementGate.promise.then(() => reject(new BridgeStoreError('ASSIGNMENT_EXPIRED', 'caller left')));
               },
               { once: true },
             );
@@ -441,15 +455,63 @@ test('logs a disconnected dispatch once without inventing HTTP 200', async () =>
   await expect(response).rejects.toThrow();
   await closed.promise;
   expect(dispatchAborted).toBe(true);
+  expect(logSpy).not.toHaveBeenCalled();
+  settlementGate.resolve();
+  await logCompleted.promise;
   expect(logSpy).toHaveBeenCalledTimes(1);
   expect(logSpy).toHaveBeenCalledWith(
     'warn',
     'Workspace tool request completed',
     expect.objectContaining({
       outcome: 'disconnected',
+      errorCode: 'ASSIGNMENT_EXPIRED',
       status: undefined,
       operation: 'list_files',
       workerId: 'user-worker',
     }),
   );
+});
+
+test.each(['auth', 'limit'] as const)('logs requests rejected by upstream %s middleware', async (stage) => {
+  const originalLocalMode = env.LOCAL_MODE;
+  const originalProvider = process.env.CODEAPI_AUTH_PROVIDER;
+  env.LOCAL_MODE = false;
+  process.env.CODEAPI_AUTH_PROVIDER = 'librechat-jwt';
+  try {
+    const app = express();
+    app.use('/v1/workspace-tools/execute', workspaceToolOutcomeLogging);
+    app.use(json());
+    if (stage === 'auth') app.use(apiKeyAuth);
+    else app.use(rateLimitFactory({ windowMs: 60_000, max: 1 }));
+    let reachedHandler = false;
+    app.post('/v1/workspace-tools/execute', (_req, res) => {
+      reachedHandler = true;
+      res.json({ ok: true });
+    });
+    server = createServer(app);
+    await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (address == null || typeof address === 'string') throw new Error('Expected TCP listener');
+    const request = (): Promise<Response> => fetch(`http://127.0.0.1:${address.port}/v1/workspace-tools/execute`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
+    });
+    if (stage === 'limit') {
+      await (await request()).text();
+      logSpy.mockClear();
+      reachedHandler = false;
+    }
+    const response = await request();
+    await response.text();
+    expect(response.status).toBe(stage === 'auth' ? 401 : 429);
+    expect(reachedHandler).toBe(false);
+    expect(logSpy.mock.calls.filter(([, message]) => message === 'Workspace tool request completed')).toHaveLength(1);
+    expect(logSpy).toHaveBeenCalledWith('warn', 'Workspace tool request completed', expect.objectContaining({
+      status: response.status, errorCode: stage === 'auth' ? 'UNAUTHENTICATED' : 'RATE_LIMITED',
+      dispatchDurationMs: undefined, outcome: 'completed',
+    }));
+  } finally {
+    env.LOCAL_MODE = originalLocalMode;
+    if (originalProvider == null) delete process.env.CODEAPI_AUTH_PROVIDER;
+    else process.env.CODEAPI_AUTH_PROVIDER = originalProvider;
+  }
 });

--- a/service/src/workspace-tools/router.test.ts
+++ b/service/src/workspace-tools/router.test.ts
@@ -242,7 +242,7 @@ test('dispatches an authenticated workspace tool request to the principal-bound 
   });
 
   expect(response.status).toBe(200);
-  const timing = Reflect.get(logSpy.mock.calls[0], 2) as { durationMs: number; dispatchDurationMs: number };
+  const timing = logSpy.mock.calls[0].at(-1) as { durationMs: number; dispatchDurationMs: number };
   expect(timing.durationMs - timing.dispatchDurationMs).toBeGreaterThanOrEqual(100);
   expect(logSpy).toHaveBeenCalledTimes(1);
   expect(logSpy).toHaveBeenCalledWith(

--- a/service/src/workspace-tools/router.test.ts
+++ b/service/src/workspace-tools/router.test.ts
@@ -1,18 +1,25 @@
 import { createServer } from 'node:http';
 import type { Server } from 'node:http';
 
-import { afterEach, expect, test } from 'bun:test';
+import { afterEach, beforeEach, expect, spyOn, test } from 'bun:test';
 import express, { json } from 'express';
 
+import logger from '../logger';
 import { applyPrincipal } from '../auth/principal';
 import { BridgeStoreError } from '../bridge/store';
 import { bridgeStoreStatus, createWorkspaceToolsRouter } from './router';
 
 let server: Server | undefined;
+let logSpy: ReturnType<typeof spyOn<typeof logger, 'log'>>;
+
+beforeEach(() => {
+  logSpy = spyOn(logger, 'log').mockReturnValue(logger);
+});
 
 afterEach(() => {
   server?.close();
   server = undefined;
+  logSpy.mockRestore();
 });
 
 test('maps invalid worker results to an upstream failure', () => {
@@ -66,6 +73,16 @@ test('rejects new workspace dispatches while the service is shutting down', asyn
 
   expect(response.status).toBe(503);
   expect(dispatched).toBe(false);
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy).toHaveBeenCalledWith(
+    'warn',
+    'Workspace tool request completed',
+    expect.objectContaining({
+      status: 503,
+      errorCode: 'SERVICE_SHUTTING_DOWN',
+      outcome: 'completed',
+    }),
+  );
 });
 
 test.each([
@@ -131,7 +148,22 @@ test.each([
   });
 
   expect(response.status).toBe(expectedStatus);
-  await expect(response.json()).resolves.toMatchObject({ code: errorCode });
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy).toHaveBeenCalledWith(
+    'warn',
+    'Workspace tool request completed',
+    expect.objectContaining({
+      status: expectedStatus,
+      errorCode,
+      operation: 'search_text',
+      workerId: 'user-worker',
+      dispatchDurationMs: expect.any(Number),
+      deadlineBudgetMs: 30_000,
+    }),
+  );
+  await expect(response.json()).resolves.toMatchObject({
+    code: errorCode,
+  });
 });
 
 test('dispatches an authenticated workspace tool request to the principal-bound worker', async () => {
@@ -199,6 +231,19 @@ test('dispatches an authenticated workspace tool request to the principal-bound 
   });
 
   expect(response.status).toBe(200);
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy).toHaveBeenCalledWith(
+    'info',
+    'Workspace tool request completed',
+    expect.objectContaining({
+      status: 200,
+      operation: 'read_file',
+      workerId: 'user-worker',
+      outcome: 'completed',
+    }),
+  );
+  expect(JSON.stringify(logSpy.mock.calls)).not.toContain('# LibreChat');
+  expect(JSON.stringify(logSpy.mock.calls)).not.toContain('tenant-1');
   await expect(response.json()).resolves.toMatchObject({
     operation: 'read_file',
     content: '# LibreChat',
@@ -209,4 +254,202 @@ test('dispatches an authenticated workspace tool request to the principal-bound 
     requireTenantBinding: true,
     request,
   });
+});
+
+test.each([
+  ['WORKER_UNAUTHORIZED', 403],
+  ['ASSIGNMENT_INVALID', 400],
+  ['RESULT_INVALID', 502],
+  ['ASSIGNMENT_EXPIRED', 504],
+  ['WORKER_OFFLINE', 503],
+  ['WORKER_BUSY', 503],
+  ['WORKER_MISMATCH', 409],
+] as const)('logs store rejection %s with actual HTTP %i', async (errorCode, expectedStatus) => {
+  const app = express();
+  app.use(json());
+  app.use((req, _res, next) => {
+    applyPrincipal(req, {
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      principalSource: 'librechat_jwt',
+      codeWorkerId: 'user-worker',
+    });
+    next();
+  });
+  app.use(
+    createWorkspaceToolsRouter({
+      backend: 'remote-bridge',
+      configuredWorkerId: 'user-worker',
+      dynamicWorkers: true,
+      timeoutMs: 300_000,
+      store: {
+        async dispatchWorkspaceTool() {
+          throw new BridgeStoreError(errorCode, 'private diagnostic details');
+        },
+      },
+    }),
+  );
+  server = createServer(app);
+  await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (address == null || typeof address === 'string') throw new Error('Expected TCP listener');
+  const response = await fetch(`http://127.0.0.1:${address.port}/workspace-tools/execute`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      protocolVersion: 1,
+      operation: 'list_files',
+      workspaceId: 'primary',
+    }),
+  });
+  expect(response.status).toBe(expectedStatus);
+  await response.text();
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy).toHaveBeenCalledWith(
+    'warn',
+    'Workspace tool request completed',
+    expect.objectContaining({
+      operation: 'list_files',
+      workerId: 'user-worker',
+      status: expectedStatus,
+      errorCode,
+      outcome: 'completed',
+      deadlineBudgetMs: 300_000,
+      dispatchDurationMs: expect.any(Number),
+    }),
+  );
+  expect(JSON.stringify(logSpy.mock.calls)).not.toContain('private diagnostic details');
+});
+
+test.each([
+  ['unauthenticated', 401, 'UNAUTHENTICATED'],
+  ['invalid request', 400, 'INVALID_WORKSPACE_TOOL_REQUEST'],
+  ['selection denied', 403, 'WORKER_SELECTION_REJECTED'],
+  ['invalid worker', 400, 'WORKER_SELECTION_REJECTED'],
+  ['no backend', 503, 'WORKSPACE_BACKEND_UNAVAILABLE'],
+] as const)('logs early %s without dispatching', async (scenario, status, errorCode) => {
+  const app = express();
+  app.use(json());
+  app.use((req, _res, next) => {
+    const workerId = scenario === 'invalid worker' ? 'bad/worker' : 'user-worker';
+    if (scenario !== 'unauthenticated')
+      applyPrincipal(req, {
+        userId: 'user-1',
+        tenantId: 'tenant-1',
+        principalSource: 'librechat_jwt',
+        codeWorkerId:
+          scenario === 'no backend' ? undefined : workerId,
+      });
+    next();
+  });
+  app.use(
+    createWorkspaceToolsRouter({
+      backend: scenario === 'no backend' ? 'http' : 'remote-bridge',
+      configuredWorkerId: 'user-worker',
+      dynamicWorkers: true,
+      store: {
+        async dispatchWorkspaceTool() {
+          throw new Error('Must not dispatch');
+        },
+      },
+    }),
+  );
+  server = createServer(app);
+  await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (address == null || typeof address === 'string') throw new Error('Expected TCP listener');
+  const response = await fetch(`http://127.0.0.1:${address.port}/workspace-tools/execute`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(scenario === 'selection denied' ? { 'X-LibreChat-Code-Worker-ID': 'forged-worker' } : {}),
+    },
+    body: JSON.stringify(
+      scenario === 'invalid request'
+        ? { operation: 'private-untrusted-operation' }
+        : {
+          protocolVersion: 1,
+          operation: 'list_files',
+          workspaceId: 'primary',
+        },
+    ),
+  });
+  expect(response.status).toBe(status);
+  await response.text();
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy).toHaveBeenCalledWith(
+    'warn',
+    'Workspace tool request completed',
+    expect.objectContaining({
+      status,
+      errorCode,
+      dispatchDurationMs: undefined,
+    }),
+  );
+  expect(JSON.stringify(logSpy.mock.calls)).not.toContain('forged-worker');
+  expect(JSON.stringify(logSpy.mock.calls)).not.toContain('private-untrusted-operation');
+});
+
+test('logs a disconnected dispatch once without inventing HTTP 200', async () => {
+  const app = express();
+  const started = Promise.withResolvers<void>();
+  const closed = Promise.withResolvers<void>();
+  let dispatchAborted = false;
+  let closeConnection = (): void => { throw new Error('connection not ready'); };
+  app.use(json());
+  app.use((req, res, next) => {
+    applyPrincipal(req, { userId: 'user-1', tenantId: 'tenant-1', principalSource: 'librechat_jwt', codeWorkerId: 'user-worker' });
+    closeConnection = (): void => { res.destroy(); };
+    res.once('close', () => closed.resolve());
+    next();
+  });
+  app.use(
+    createWorkspaceToolsRouter({
+      backend: 'remote-bridge',
+      configuredWorkerId: 'user-worker',
+      dynamicWorkers: true,
+      store: {
+        async dispatchWorkspaceTool({ signal }) {
+          started.resolve();
+          return await new Promise((_resolve, reject) => {
+            signal.addEventListener(
+              'abort',
+              () => {
+                dispatchAborted = true;
+                reject(new BridgeStoreError('ASSIGNMENT_EXPIRED', 'caller left'));
+              },
+              { once: true },
+            );
+          });
+        },
+      },
+    }),
+  );
+  server = createServer(app);
+  await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (address == null || typeof address === 'string') throw new Error('Expected TCP listener');
+  const controller = new AbortController();
+  const response = fetch(`http://127.0.0.1:${address.port}/workspace-tools/execute`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    signal: controller.signal,
+    body: JSON.stringify({ protocolVersion: 1, operation: 'list_files', workspaceId: 'primary' }),
+  });
+  await started.promise;
+  closeConnection();
+  await expect(response).rejects.toThrow();
+  await closed.promise;
+  expect(dispatchAborted).toBe(true);
+  expect(logSpy).toHaveBeenCalledTimes(1);
+  expect(logSpy).toHaveBeenCalledWith(
+    'warn',
+    'Workspace tool request completed',
+    expect.objectContaining({
+      outcome: 'disconnected',
+      status: undefined,
+      operation: 'list_files',
+      workerId: 'user-worker',
+    }),
+  );
 });

--- a/service/src/workspace-tools/router.ts
+++ b/service/src/workspace-tools/router.ts
@@ -3,9 +3,8 @@ import { Router } from 'express';
 import type { RequestHandler, Response } from 'express';
 import type { AuthenticatedRequest } from '../types';
 import type { RedisBridgeStore } from '../bridge/store';
-import type { WorkspaceToolRequest } from '../../../packages/code/src/protocol';
 
-import logger from '../logger';
+import { getWorkspaceToolOutcome } from './outcome';
 import { getPrincipalOrReject } from '../auth/principal';
 import { BridgeStoreError } from '../bridge/store';
 import { checkServiceShutDown } from '../lifecycle';
@@ -48,47 +47,27 @@ export function createWorkspaceToolsRouter(options: WorkspaceToolsRouterOptions)
   router.post(
     '/workspace-tools/execute',
     asyncRoute(async (req, res) => {
-      const startedAt = performance.now();
-      const target: { operation?: WorkspaceToolRequest['operation']; workerId?: string } = {};
-      let errorCode: string | undefined;
-      let dispatchStartedAt: number | undefined;
+      const outcome = getWorkspaceToolOutcome(res);
       const deadlineBudgetMs = Math.max(1, options.timeoutMs ?? 30_000);
-      const logOutcome = (): void => {
-        res.removeListener('finish', logOutcome);
-        res.removeListener('close', logOutcome);
-        const finished = res.writableFinished;
-        const now = performance.now();
-        logger.log(finished && res.statusCode < 400 ? 'info' : 'warn', 'Workspace tool request completed', {
-          route: '/workspace-tools/execute',
-          ...target,
-          status: finished ? res.statusCode : undefined,
-          outcome: finished ? 'completed' : 'disconnected',
-          errorCode,
-          durationMs: Math.round(now - startedAt),
-          dispatchDurationMs: dispatchStartedAt == null ? undefined : Math.round(now - dispatchStartedAt),
-          deadlineBudgetMs,
-        });
-      };
-      res.once('finish', logOutcome);
-      res.once('close', logOutcome);
+      outcome.deadlineBudgetMs = deadlineBudgetMs;
       const principal = getPrincipalOrReject(req, res);
       if (!principal) {
-        errorCode = 'UNAUTHENTICATED';
+        outcome.errorCode = 'UNAUTHENTICATED';
         return;
       }
       if ((options.isShuttingDown ?? checkServiceShutDown)()) {
-        errorCode = 'SERVICE_SHUTTING_DOWN';
+        outcome.errorCode = 'SERVICE_SHUTTING_DOWN';
         res.status(503).json({ error: 'Service is shutting down' });
         return;
       }
       if (!isWorkspaceToolRequest(req.body)) {
-        errorCode = 'INVALID_WORKSPACE_TOOL_REQUEST';
+        outcome.errorCode = 'INVALID_WORKSPACE_TOOL_REQUEST';
         res.status(400).json({
           error: 'Invalid workspace tool request',
         });
         return;
       }
-      target.operation = req.body.operation;
+      outcome.operation = req.body.operation;
 
       let selection: { workerId: string; explicit: boolean } | undefined;
       try {
@@ -101,20 +80,20 @@ export function createWorkspaceToolsRouter(options: WorkspaceToolsRouterOptions)
         });
       } catch (error) {
         if (error instanceof BridgeWorkerSelectionError) {
-          errorCode = 'WORKER_SELECTION_REJECTED';
+          outcome.errorCode = 'WORKER_SELECTION_REJECTED';
           res.status(error.status).json({ error: error.message });
           return;
         }
         throw error;
       }
       if (selection == null) {
-        errorCode = 'WORKSPACE_BACKEND_UNAVAILABLE';
+        outcome.errorCode = 'WORKSPACE_BACKEND_UNAVAILABLE';
         res.status(503).json({
           error: 'Workspace tools require the remote-bridge backend',
         });
         return;
       }
-      target.workerId = selection.workerId;
+      outcome.workerId = selection.workerId;
 
       const controller = new AbortController();
       const abort = (): void => controller.abort();
@@ -124,7 +103,8 @@ export function createWorkspaceToolsRouter(options: WorkspaceToolsRouterOptions)
       };
       res.once('close', abortClosedResponse);
       try {
-        dispatchStartedAt = performance.now();
+        outcome.dispatchPending = true;
+        const dispatchStartedAt = performance.now();
         const settlement = await options.store.dispatchWorkspaceTool({
           workerId: selection.workerId,
           tenantId: principal.tenantId,
@@ -133,9 +113,11 @@ export function createWorkspaceToolsRouter(options: WorkspaceToolsRouterOptions)
           request: req.body,
           deadlineAtMs: Date.now() + deadlineBudgetMs,
           signal: controller.signal,
+        }).finally(() => {
+          outcome.dispatchDurationMs = Math.round(performance.now() - dispatchStartedAt);
         });
         if (settlement.status === 'rejected') {
-          errorCode = settlement.errorCode ?? 'WORKSPACE_TOOL_REJECTED';
+          outcome.errorCode = settlement.errorCode ?? 'WORKSPACE_TOOL_REJECTED';
           let status = 422;
           if (
             settlement.errorCode === 'SEARCH_TIMEOUT' ||
@@ -165,16 +147,18 @@ export function createWorkspaceToolsRouter(options: WorkspaceToolsRouterOptions)
         res.status(200).json(settlement.result);
       } catch (error) {
         if (error instanceof BridgeStoreError) {
-          errorCode = error.code;
+          outcome.errorCode = error.code;
           res.status(bridgeStoreStatus(error)).json({
             error: error.message,
             code: error.code,
           });
           return;
         }
-        errorCode = 'INTERNAL_ERROR';
+        outcome.errorCode = 'INTERNAL_ERROR';
         throw error;
       } finally {
+        outcome.dispatchPending = false;
+        outcome.flush();
         req.removeListener('aborted', abort);
         res.removeListener('close', abortClosedResponse);
       }

--- a/service/src/workspace-tools/router.ts
+++ b/service/src/workspace-tools/router.ts
@@ -3,7 +3,9 @@ import { Router } from 'express';
 import type { RequestHandler, Response } from 'express';
 import type { AuthenticatedRequest } from '../types';
 import type { RedisBridgeStore } from '../bridge/store';
+import type { WorkspaceToolRequest } from '../../../packages/code/src/protocol';
 
+import logger from '../logger';
 import { getPrincipalOrReject } from '../auth/principal';
 import { BridgeStoreError } from '../bridge/store';
 import { checkServiceShutDown } from '../lifecycle';
@@ -46,18 +48,47 @@ export function createWorkspaceToolsRouter(options: WorkspaceToolsRouterOptions)
   router.post(
     '/workspace-tools/execute',
     asyncRoute(async (req, res) => {
+      const startedAt = performance.now();
+      const target: { operation?: WorkspaceToolRequest['operation']; workerId?: string } = {};
+      let errorCode: string | undefined;
+      let dispatchStartedAt: number | undefined;
+      const deadlineBudgetMs = Math.max(1, options.timeoutMs ?? 30_000);
+      const logOutcome = (): void => {
+        res.removeListener('finish', logOutcome);
+        res.removeListener('close', logOutcome);
+        const finished = res.writableFinished;
+        const now = performance.now();
+        logger.log(finished && res.statusCode < 400 ? 'info' : 'warn', 'Workspace tool request completed', {
+          route: '/workspace-tools/execute',
+          ...target,
+          status: finished ? res.statusCode : undefined,
+          outcome: finished ? 'completed' : 'disconnected',
+          errorCode,
+          durationMs: Math.round(now - startedAt),
+          dispatchDurationMs: dispatchStartedAt == null ? undefined : Math.round(now - dispatchStartedAt),
+          deadlineBudgetMs,
+        });
+      };
+      res.once('finish', logOutcome);
+      res.once('close', logOutcome);
       const principal = getPrincipalOrReject(req, res);
-      if (!principal) return;
+      if (!principal) {
+        errorCode = 'UNAUTHENTICATED';
+        return;
+      }
       if ((options.isShuttingDown ?? checkServiceShutDown)()) {
+        errorCode = 'SERVICE_SHUTTING_DOWN';
         res.status(503).json({ error: 'Service is shutting down' });
         return;
       }
       if (!isWorkspaceToolRequest(req.body)) {
+        errorCode = 'INVALID_WORKSPACE_TOOL_REQUEST';
         res.status(400).json({
           error: 'Invalid workspace tool request',
         });
         return;
       }
+      target.operation = req.body.operation;
 
       let selection: { workerId: string; explicit: boolean } | undefined;
       try {
@@ -70,36 +101,41 @@ export function createWorkspaceToolsRouter(options: WorkspaceToolsRouterOptions)
         });
       } catch (error) {
         if (error instanceof BridgeWorkerSelectionError) {
+          errorCode = 'WORKER_SELECTION_REJECTED';
           res.status(error.status).json({ error: error.message });
           return;
         }
         throw error;
       }
       if (selection == null) {
+        errorCode = 'WORKSPACE_BACKEND_UNAVAILABLE';
         res.status(503).json({
           error: 'Workspace tools require the remote-bridge backend',
         });
         return;
       }
+      target.workerId = selection.workerId;
 
       const controller = new AbortController();
-      const abort = () => controller.abort();
+      const abort = (): void => controller.abort();
       req.once('aborted', abort);
-      const abortClosedResponse = () => {
+      const abortClosedResponse = (): void => {
         if (!res.writableEnded) abort();
       };
       res.once('close', abortClosedResponse);
       try {
+        dispatchStartedAt = performance.now();
         const settlement = await options.store.dispatchWorkspaceTool({
           workerId: selection.workerId,
           tenantId: principal.tenantId,
           requireTenantBinding:
             selection.explicit && (options.dynamicWorkers || selection.workerId !== options.configuredWorkerId),
           request: req.body,
-          deadlineAtMs: Date.now() + Math.max(1, options.timeoutMs ?? 30_000),
+          deadlineAtMs: Date.now() + deadlineBudgetMs,
           signal: controller.signal,
         });
         if (settlement.status === 'rejected') {
+          errorCode = settlement.errorCode ?? 'WORKSPACE_TOOL_REJECTED';
           let status = 422;
           if (
             settlement.errorCode === 'SEARCH_TIMEOUT' ||
@@ -129,12 +165,14 @@ export function createWorkspaceToolsRouter(options: WorkspaceToolsRouterOptions)
         res.status(200).json(settlement.result);
       } catch (error) {
         if (error instanceof BridgeStoreError) {
+          errorCode = error.code;
           res.status(bridgeStoreStatus(error)).json({
             error: error.message,
             code: error.code,
           });
           return;
         }
+        errorCode = 'INTERNAL_ERROR';
         throw error;
       } finally {
         req.removeListener('aborted', abort);


### PR DESCRIPTION
## Summary

I add outcome logging to `/workspace-tools/execute` so an attached BYOM tool rejection can be distinguished from a sibling `/exec` failure. The existing `Request received` log belongs only to `/exec`; the workspace route previously returned precise HTTP statuses and error codes without recording them.

- Record one structured outcome per completed or disconnected workspace request, including HTTP status when a response finishes, error code, validated operation and selected worker, elapsed time, dispatch duration, and configured deadline budget.
- Install logging before parsing, authentication, and rate-limit middleware in both production entry points; exclude preview-host traffic using the gateway's raw-Host parser and retain exact execution-profile rejection codes.
- Wait for dispatch settlement before emitting a disconnected outcome, preserving its terminal error code.
- Cover authentication, request validation, worker selection, backend availability, shutdown, worker settlement, and bridge-store rejection paths.
- Preserve actual store/worker error codes, including `WORKER_MISMATCH`, `WORKER_BUSY`, and `ASSIGNMENT_EXPIRED`; use stable diagnostic categories for early responses that have no protocol error code.
- Omit raw request bodies, commands, file contents, headers, upstream error text, tenant/user identifiers, and unvalidated worker selection inputs.
- Keep existing response bodies/statuses, dispatch deadlines, cancellation, and worker concurrency behavior.

Related LibreChat fix: https://github.com/danny-avila/LibreChat/pull/15723. The historical repro's status is unrecoverable from retained logs; deployment plus a fresh repro is required. Neither timeout nor worker mismatch is established for that request.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Run `bun test src/workspace-tools/router.test.ts src/middleware/execution-profile.test.ts src/hosted-app/preview-access.test.ts` from `service`: 50 tests pass, covering success, all explicit store status mappings and default 409, worker rejection mappings, early responses, one-log-per-request behavior, upstream authentication/rate-limit rejection, delayed cancellation settlement, response-transmission time excluded from dispatch timing, preview-host exclusion, exact profile-rejection codes, exact route/method matching, and parser failures (400/413/415).
- Run scoped ESLint: no errors, with six existing warnings in preview access/gateway code. Run `git diff --check`: pass.
- Run `npx tsc --noEmit` from `service`: six unrelated baseline errors. An untouched worktree at base `725f799`, using identical dependencies, produces byte-for-byte identical diagnostics; no workspace-tools diagnostics remain.
- Observe existing Redis DNS warnings during local tests; the router tests still pass. No production deployment or live repro was performed.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes



