### PR TITLE
🛟 fix: Recover Hosted App Stop Failures

### DIFF
--- a/api/src/hosted-app.test.ts
+++ b/api/src/hosted-app.test.ts
@@ -424,9 +424,61 @@ describe('HostedAppSupervisor', () => {
     expect(error).toBeInstanceOf(HostedAppError);
     expect(error.code).toBe('hosted_app_cleanup_failed');
     expect(error.status).toBe(503);
+    expect(supervisor.status()).toMatchObject({
+      state: 'failed',
+      message: 'hosted app cleanup failed',
+    });
 
     permitCleanup = true;
     await supervisor.shutdown();
+  });
+
+  test('allows checkpoint and restore to retry cleanup after stop fails', async () => {
+    const root = await workspace();
+    let permitCleanup = false;
+    const fixture = dependencies(root, {
+      killCgroup: async () => {
+        if (!permitCleanup) throw new Error('cgroup remains populated');
+      },
+    });
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+    await expect(supervisor.stop()).rejects.toMatchObject({
+      code: 'hosted_app_cleanup_failed',
+      status: 503,
+    });
+    const operations: string[] = [];
+
+    await expect(supervisor.withQuiescedWorkspace(async () => {
+      operations.push('unsafe checkpoint');
+    })).rejects.toMatchObject({
+      code: 'hosted_app_cleanup_failed',
+      status: 503,
+    });
+    expect(operations).toEqual([]);
+
+    permitCleanup = true;
+    await supervisor.withQuiescedWorkspace(async () => { operations.push('checkpoint'); });
+    await supervisor.withQuiescedWorkspace(async () => { operations.push('restore'); });
+
+    expect(operations).toEqual(['checkpoint', 'restore']);
+    expect(fixture.cgroupKills).toHaveLength(3);
+  });
+
+  test('surfaces replacement cleanup failure as retryable without spawning', async () => {
+    const root = await workspace();
+    const fixture = dependencies(root, {
+      killCgroup: async () => { throw new Error('cgroup remains populated'); },
+    });
+    const supervisor = new HostedAppSupervisor(fixture.deps);
+    await supervisor.start(request());
+
+    const error = await supervisor.start(request({ revision: 'rev-2' })).catch(value => value);
+
+    expect(error).toBeInstanceOf(HostedAppError);
+    expect(error).toMatchObject({ code: 'hosted_app_cleanup_failed', status: 503 });
+    expect(supervisor.status()?.state).toBe('failed');
+    expect(fixture.spawns).toHaveLength(1);
   });
 
   test('fails workspace mutation closed until a failed app cgroup is drained', async () => {

--- a/api/src/hosted-app.test.ts
+++ b/api/src/hosted-app.test.ts
@@ -337,7 +337,9 @@ describe('HostedAppSupervisor', () => {
 
     expect(error).toBeInstanceOf(HostedAppError);
     expect(error.code).toBe('hosted_app_start_failed');
+    expect(error.message).toBe('hosted app exited');
     expect(supervisor.status()?.state).toBe('failed');
+    expect(supervisor.status()?.message).toBe('hosted app exited');
   });
 
   test('serializes quiesced workspace access and rejects it while an app is running', async () => {

--- a/api/src/hosted-app.test.ts
+++ b/api/src/hosted-app.test.ts
@@ -430,7 +430,9 @@ describe('HostedAppSupervisor', () => {
     });
 
     permitCleanup = true;
-    await supervisor.shutdown();
+    const recovered = await supervisor.stop();
+    expect(recovered).toMatchObject({ state: 'stopped' });
+    expect(recovered).not.toHaveProperty('message');
   });
 
   test('allows checkpoint and restore to retry cleanup after stop fails', async () => {

--- a/api/src/hosted-app.ts
+++ b/api/src/hosted-app.ts
@@ -724,7 +724,7 @@ export class HostedAppSupervisor {
         await this.deps.killCgroup();
         active.cgroupDrained = true;
         active.status.state = 'stopped';
-        delete active.status.message;
+        if (!preserveActive) delete active.status.message;
         active.status.exited_at ??= this.deps.now().toISOString();
         if (!preserveActive) this.active = undefined;
         return publicStatus(active);
@@ -752,7 +752,7 @@ export class HostedAppSupervisor {
       await this.deps.killCgroup();
       active.cgroupDrained = true;
       active.status.state = 'stopped';
-      delete active.status.message;
+      if (!preserveActive) delete active.status.message;
       active.status.exited_at ??= this.deps.now().toISOString();
       const status = publicStatus(active);
       if (!preserveActive) this.active = undefined;

--- a/api/src/hosted-app.ts
+++ b/api/src/hosted-app.ts
@@ -458,18 +458,7 @@ export class HostedAppSupervisor {
   }
 
   async stop(): Promise<HostedAppStatus | undefined> {
-    return this.serialize(async () => {
-      try {
-        return await this.stopImpl();
-      } catch (error) {
-        logger.error({ err: error }, 'Hosted-app stop cleanup failed');
-        throw new HostedAppError(
-          'hosted_app_cleanup_failed',
-          'the hosted app could not be stopped safely',
-          503,
-        );
-      }
-    });
+    return this.serialize(() => this.stopImpl());
   }
 
   async shutdown(): Promise<void> {
@@ -729,42 +718,60 @@ export class HostedAppSupervisor {
   private async stopImpl(preserveActive = false): Promise<HostedAppStatus | undefined> {
     const active = this.active;
     if (!active) return undefined;
-    const child = active.process;
-    if (!child?.pid) {
+    try {
+      const child = active.process;
+      if (!child?.pid) {
+        await this.deps.killCgroup();
+        active.cgroupDrained = true;
+        active.status.state = 'stopped';
+        active.status.exited_at ??= this.deps.now().toISOString();
+        if (!preserveActive) this.active = undefined;
+        return publicStatus(active);
+      }
+
+      active.status.state = 'stopping';
+      this.deps.killProcessGroup(child.pid, 'SIGTERM');
+      const exited = new Promise<boolean>(resolve => child.once('exit', () => resolve(true)));
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timedOut = new Promise<boolean>(resolve => {
+        timer = setTimeout(() => resolve(false), config.hosted_app_stop_timeout_ms);
+        timer.unref?.();
+      });
+      const stopped = await Promise.race([exited, timedOut]);
+      if (timer) clearTimeout(timer);
+      if (!stopped && active.process?.pid) {
+        await this.deps.killCgroup();
+        await Promise.race([
+          new Promise<void>(resolve => child.once('exit', () => resolve())),
+          new Promise<void>(resolve => setTimeout(resolve, config.hosted_app_stop_timeout_ms)),
+        ]);
+      }
+      /* Always sweep the cgroup: the tracked parent may have exited cleanly
+       * while a daemonized descendant stayed alive in a different process group. */
       await this.deps.killCgroup();
       active.cgroupDrained = true;
       active.status.state = 'stopped';
       active.status.exited_at ??= this.deps.now().toISOString();
+      const status = publicStatus(active);
       if (!preserveActive) this.active = undefined;
-      return publicStatus(active);
+      return status;
+    } catch (error) {
+      /* Keep the failed record so checkpoint/restore can retry the cgroup
+       * sweep. A `stopping` record would permanently reject those operations
+       * before they reach the recoverable cleanup path. */
+      active.cgroupDrained = false;
+      active.status.state = 'failed';
+      active.status.message = 'hosted app cleanup failed';
+      logger.error(
+        { err: error, appId: active.request.app_id },
+        'Hosted-app stop cleanup failed',
+      );
+      throw new HostedAppError(
+        'hosted_app_cleanup_failed',
+        'the hosted app could not be stopped safely',
+        503,
+      );
     }
-
-    active.status.state = 'stopping';
-    this.deps.killProcessGroup(child.pid, 'SIGTERM');
-    const exited = new Promise<boolean>(resolve => child.once('exit', () => resolve(true)));
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const timedOut = new Promise<boolean>(resolve => {
-      timer = setTimeout(() => resolve(false), config.hosted_app_stop_timeout_ms);
-      timer.unref?.();
-    });
-    const stopped = await Promise.race([exited, timedOut]);
-    if (timer) clearTimeout(timer);
-    if (!stopped && active.process?.pid) {
-      await this.deps.killCgroup();
-      await Promise.race([
-        new Promise<void>(resolve => child.once('exit', () => resolve())),
-        new Promise<void>(resolve => setTimeout(resolve, config.hosted_app_stop_timeout_ms)),
-      ]);
-    }
-    /* Always sweep the cgroup: the tracked parent may have exited cleanly
-     * while a daemonized descendant stayed alive in a different process group. */
-    await this.deps.killCgroup();
-    active.cgroupDrained = true;
-    active.status.state = 'stopped';
-    active.status.exited_at ??= this.deps.now().toISOString();
-    const status = publicStatus(active);
-    if (!preserveActive) this.active = undefined;
-    return status;
   }
 }
 

--- a/api/src/hosted-app.ts
+++ b/api/src/hosted-app.ts
@@ -724,6 +724,7 @@ export class HostedAppSupervisor {
         await this.deps.killCgroup();
         active.cgroupDrained = true;
         active.status.state = 'stopped';
+        delete active.status.message;
         active.status.exited_at ??= this.deps.now().toISOString();
         if (!preserveActive) this.active = undefined;
         return publicStatus(active);
@@ -751,6 +752,7 @@ export class HostedAppSupervisor {
       await this.deps.killCgroup();
       active.cgroupDrained = true;
       active.status.state = 'stopped';
+      delete active.status.message;
       active.status.exited_at ??= this.deps.now().toISOString();
       const status = publicStatus(active);
       if (!preserveActive) this.active = undefined;


### PR DESCRIPTION
## Summary

I fixed the hosted-app supervisor state leak that could permanently block checkpoint and restore after a failed stop. Fixes #122.

- Move every stop cleanup failure into the recoverable `failed` state while retaining the active record and marking its cgroup as undrained.
- Return the retryable `hosted_app_cleanup_failed` 503 response from explicit stops, revision replacement, and startup cleanup paths.
- Retry the cgroup safety sweep before checkpoint or restore, and run workspace operations only after the retry succeeds.
- Add regression coverage for failed stops, repeated cleanup failure, checkpoint/restore recovery, and revision replacement.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran:

```sh
bun test src/hosted-app.test.ts
bun run build
git diff --check
```

The focused suite passes 22 tests, including failure injection around stop, cgroup cleanup retry, checkpoint/restore access, and replacement starts. The production API bundle builds successfully.

The repository-wide TypeScript check still reports existing errors in unrelated test files and an existing state-narrowing diagnostic in `hosted-app.ts`; this change adds no build failure.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in the complex recovery path
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
