### PR TITLE
🧳 fix: Isolate Native Sandbox Scratch Storage

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -89,9 +89,15 @@ Windows. Startup fails before worker registration when the platform or its
 dependencies are unavailable. There is no unsandboxed command fallback.
 
 The bridge worker remains outside the sandbox so it can maintain its outbound
-Code API connection. Each command and its descendants run inside SRT with:
+Code API connection. Each worker process creates an owner-only scratch
+directory and grants SRT access to that exact directory without opening the
+host temporary-directory root. Commands receive it through `TMPDIR` (`TEMP`
+and `TMP` are also set on Windows), and worker shutdown removes it. SRT's
+shared compatibility scratch path is explicitly denied. Each command and its
+descendants run inside SRT with:
 
-- write access restricted to the one canonical registered workspace;
+- write access restricted to the one canonical registered workspace and the
+  worker's private scratch directory;
 - read access denied to the worker's home directory except for that workspace;
 - paired identity and mutation-quarantine files explicitly denied;
 - `LIBRECHAT_CODE_*` and nonessential inherited environment variables removed;

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -89,11 +89,12 @@ Windows. Startup fails before worker registration when the platform or its
 dependencies are unavailable. There is no unsandboxed command fallback.
 
 The bridge worker remains outside the sandbox so it can maintain its outbound
-Code API connection. Each worker process creates an owner-only scratch
-directory and grants SRT access to that exact directory without opening the
-host temporary-directory root. Commands receive it through `TMPDIR` (`TEMP`
-and `TMP` are also set on Windows), and worker shutdown removes it. SRT's
-shared compatibility scratch path is explicitly denied. Each command and its
+Code API connection. On macOS and Linux, each worker process creates an
+owner-only scratch directory and grants SRT access to that exact directory
+without opening the host temporary-directory root. Commands receive it through
+`TMPDIR`, and orderly worker shutdown removes it. SRT's shared compatibility
+scratch path is explicitly denied. Windows uses the restricted SRT account's
+isolated profile and temporary directory instead. Each command and its
 descendants run inside SRT with:
 
 - write access restricted to the one canonical registered workspace and the

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -94,8 +94,10 @@ owner-only scratch directory and grants SRT access to that exact directory
 without opening the host temporary-directory root. Commands receive it through
 `TMPDIR`, and orderly worker shutdown removes it. SRT's shared compatibility
 scratch path is explicitly denied. Windows uses the restricted SRT account's
-isolated profile and temporary directory instead. Each command and its
-descendants run inside SRT with:
+isolated profile and temporary directory instead. A workspace registration is
+rejected if it sits inside SRT's shared scratch path or is broad enough to
+contain worker scratch storage. Each command and its descendants run inside
+SRT with:
 
 - write access restricted to the one canonical registered workspace and the
   worker's private scratch directory;

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -221,6 +221,108 @@ test('removes scratch storage when SRT initialization fails', async (t) => {
   assert.equal(fake.reset, true);
 });
 
+test('rejects workspaces nested inside SRT shared scratch storage', async (t) => {
+  if (process.platform === 'win32') return;
+  const sharedRoot = '/tmp/claude';
+  await mkdir(sharedRoot, { recursive: true });
+  const root = await mkdtemp(join(sharedRoot, 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fakeManager().manager,
+  });
+
+  await assert.rejects(
+    sandbox.prepare(),
+    (error: WorkspaceToolError) =>
+      error.code === 'REGISTRATION_INVALID' &&
+      /inherited writable path/.test(error.message),
+  );
+});
+
+test('rejects a workspace that contains worker scratch storage', async () => {
+  if (process.platform === 'win32') return;
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: tmpdir(),
+    manager: fakeManager().manager,
+  });
+
+  await assert.rejects(
+    sandbox.prepare(),
+    (error: WorkspaceToolError) =>
+      error.code === 'REGISTRATION_INVALID' &&
+      /contain worker scratch storage/.test(error.message),
+  );
+  await sandbox.close();
+});
+
+test('keeps concurrent sandbox scratch directories independent', async (t) => {
+  const firstRoot = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  const secondRoot = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(firstRoot, { recursive: true, force: true }));
+  t.after(() => rm(secondRoot, { recursive: true, force: true }));
+  let releaseWrap!: () => void;
+  let wrapStarted!: () => void;
+  const wrapStartedPromise = new Promise<void>((resolve) => {
+    wrapStarted = resolve;
+  });
+  const holdWrap = new Promise<void>((resolve) => {
+    releaseWrap = resolve;
+  });
+  const firstFake = fakeManager({
+    async beforeWrap() {
+      wrapStarted();
+      await holdWrap;
+    },
+  });
+  const secondFake = fakeManager();
+  const firstSandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: firstRoot,
+    manager: firstFake.manager,
+  });
+  const secondSandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: secondRoot,
+    manager: secondFake.manager,
+  });
+  const firstExecution = firstSandbox.execute({
+    ...request,
+    command: 'printf first',
+  });
+  await wrapStartedPromise;
+  await secondSandbox.prepare();
+  const firstScratch = firstFake.config?.filesystem.allowWrite[1];
+  const secondScratch = secondFake.config?.filesystem.allowWrite[1];
+  assert.equal(typeof firstScratch, 'string');
+  assert.equal(typeof secondScratch, 'string');
+  assert.notEqual(firstScratch, secondScratch);
+  assert.ok(!secondScratch!.startsWith(`${firstScratch}/`));
+  releaseWrap();
+  await firstExecution;
+  await firstSandbox.close();
+  await access(secondScratch!);
+  await secondSandbox.close();
+});
+
+test('removes scratch storage after a command revokes traversal permissions', async (t) => {
+  if (process.platform === 'win32') return;
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fakeManager().manager,
+  });
+
+  const result = await sandbox.execute({
+    ...request,
+    command:
+      'printf %s "$TMPDIR"; mkdir "$TMPDIR/locked"; touch "$TMPDIR/locked/file"; chmod 000 "$TMPDIR/locked" "$TMPDIR"',
+  });
+
+  assert.equal(result.exitCode, 0);
+  await sandbox.close();
+  await assert.rejects(access(result.stdout));
+});
+
 const proxyEnvironment = {
   HTTP_PROXY: 'http://upstream.invalid:8080',
   HTTPS_PROXY: 'http://upstream.invalid:8080',

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import {
   access,
@@ -656,16 +657,26 @@ test('terminates detached command descendants before returning', async (t) => {
 test('reports cancellation after command start as a potentially committed mutation', async (t) => {
   const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
   t.after(() => rm(root, { recursive: true, force: true }));
+  let commandStarted!: () => void;
+  const commandStartedPromise = new Promise<void>((resolve) => {
+    commandStarted = resolve;
+  });
   const sandbox = new NativeSrtWorkspaceCommandSandbox({
     workspaceRoot: root,
     manager: fakeManager().manager,
+    spawnCommand(command, args, options) {
+      const child = spawn(command, [...args], options);
+      commandStarted();
+      return child;
+    },
   });
   const controller = new AbortController();
   const execution = sandbox.execute(
     { ...request, command: 'sleep 30' },
     controller.signal,
   );
-  setTimeout(() => controller.abort(), 25);
+  await commandStartedPromise;
+  controller.abort();
 
   await assert.rejects(
     execution,

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -6,6 +6,7 @@ import {
   mkdir,
   realpath,
   rm,
+  stat,
   writeFile,
 } from 'node:fs/promises';
 import { tmpdir, homedir } from 'node:os';
@@ -34,6 +35,7 @@ function fakeManager(
     beforeWrap?: () => Promise<void>;
     appendGitSafeDirectory?: boolean;
     inheritedGitEnvironment?: Record<string, string>;
+    initializeError?: Error;
     wrappedEnvironment?: NodeJS.ProcessEnv;
   } = {},
 ) {
@@ -41,6 +43,7 @@ function fakeManager(
   let reset = false;
   let credentialSeenDuringWrap: string | undefined;
   let gitLfsRequiredSeenDuringWrap: string | undefined;
+  let scratchSelectorSeenDuringWrap: string | undefined;
   const manager = {
     isSupportedPlatform: () => true,
     async checkDependenciesAsync() {
@@ -48,11 +51,13 @@ function fakeManager(
     },
     async initialize(value: SandboxRuntimeConfig) {
       config = value;
+      if (options.initializeError) throw options.initializeError;
     },
     async wrapWithSandboxArgv(command: string) {
       await options.beforeWrap?.();
       credentialSeenDuringWrap = process.env.LIBRECHAT_CODE_TEST_CREDENTIAL;
       gitLfsRequiredSeenDuringWrap = process.env.GIT_CONFIG_VALUE_3;
+      scratchSelectorSeenDuringWrap = process.env.CLAUDE_CODE_TMPDIR;
       const ambientGitEnvironment = Object.fromEntries(
         Object.entries(process.env).filter(
           ([name, value]) => name.startsWith('GIT_CONFIG_') && value != null,
@@ -105,6 +110,9 @@ function fakeManager(
     get gitLfsRequiredSeenDuringWrap() {
       return gitLfsRequiredSeenDuringWrap;
     },
+    get scratchSelectorSeenDuringWrap() {
+      return scratchSelectorSeenDuringWrap;
+    },
   };
 }
 
@@ -133,20 +141,82 @@ test('initializes SRT with a default-deny network and scrubbed worker credential
     join(await realpath(tmpdir()), 'librechat-code-identity.json'),
   );
   const canonicalHome = await realpath(homedir());
+  const scratchDirectory = fake.config?.filesystem.allowWrite[1];
+  assert.equal(typeof scratchDirectory, 'string');
   assert.deepEqual(fake.config?.network.allowedDomains, []);
   assert.equal(fake.config?.network.strictAllowlist, true);
   assert.equal(fake.config?.network.allowAllUnixSockets, false);
-  assert.deepEqual(fake.config?.filesystem.allowRead, [canonicalRoot]);
-  assert.deepEqual(fake.config?.filesystem.allowWrite, [canonicalRoot]);
+  assert.deepEqual(fake.config?.filesystem.allowRead, [
+    canonicalRoot,
+    scratchDirectory,
+  ]);
+  assert.deepEqual(fake.config?.filesystem.allowWrite, [
+    canonicalRoot,
+    scratchDirectory,
+  ]);
+  assert.equal((await stat(scratchDirectory!)).mode & 0o777, 0o700);
   assert.ok(fake.config?.filesystem.denyRead.includes(canonicalHome));
   assert.ok(fake.config?.filesystem.denyWrite.includes(canonicalIdentity));
+  assert.ok(
+    fake.config?.filesystem.denyWrite.some((path) =>
+      path.endsWith('/tmp/claude'),
+    ),
+  );
   const denied = fake.config?.credentials?.envVars?.map(({ name }) => name);
   assert.ok(denied?.includes('LIBRECHAT_CODE_WORKER_TOKEN'));
   assert.ok(denied?.includes('AWS_SECRET_ACCESS_KEY'));
   assert.ok(!denied?.includes('PATH'));
   assert.ok(denied?.includes('Path'));
   assert.ok(denied?.includes('lc_api_token'));
+  assert.ok(denied?.includes('CLAUDE_CODE_TMPDIR'));
+  assert.ok(denied?.includes('CLAUDE_TMPDIR'));
   await sandbox.close();
+  assert.equal(fake.reset, true);
+  await assert.rejects(access(scratchDirectory!));
+});
+
+test('provides an isolated scratch directory to commands and restores the host environment', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const originalTmpdir = process.env.TMPDIR;
+  const originalSrtTmpdir = process.env.CLAUDE_CODE_TMPDIR;
+  const originalLegacySrtTmpdir = process.env.CLAUDE_TMPDIR;
+  const fake = fakeManager();
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fake.manager,
+  });
+
+  const result = await sandbox.execute({
+    ...request,
+    maxOutputBytes: 1_024,
+    command: 'touch "$TMPDIR/probe" && printf %s "$TMPDIR"',
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /librechat-code-srt-/);
+  await access(join(result.stdout, 'probe'));
+  assert.equal(fake.scratchSelectorSeenDuringWrap, result.stdout);
+  assert.equal(process.env.TMPDIR, originalTmpdir);
+  assert.equal(process.env.CLAUDE_CODE_TMPDIR, originalSrtTmpdir);
+  assert.equal(process.env.CLAUDE_TMPDIR, originalLegacySrtTmpdir);
+  await sandbox.close();
+  await assert.rejects(access(result.stdout));
+});
+
+test('removes scratch storage when SRT initialization fails', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const fake = fakeManager({ initializeError: new Error('init failed') });
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fake.manager,
+  });
+
+  await assert.rejects(sandbox.prepare(), /init failed/);
+  const scratchDirectory = fake.config?.filesystem.allowWrite[1];
+  assert.equal(typeof scratchDirectory, 'string');
+  await assert.rejects(access(scratchDirectory!));
   assert.equal(fake.reset, true);
 });
 

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -102,6 +102,8 @@ const {
 } = TRUSTED_GIT_ENVIRONMENT;
 
 const NATIVE_SANDBOX_SCRATCH_PREFIX = 'librechat-code-srt-';
+// SRT grants these shared compatibility paths by default. A worker-specific
+// TMPDIR must also deny them or separate worker processes can exchange files.
 const SRT_SHARED_SCRATCH_PATHS = ['/tmp/claude', '/private/tmp/claude'];
 const SRT_SCRATCH_SELECTOR_NAMES = [
   'CLAUDE_CODE_TMPDIR',

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -11,7 +11,17 @@ import {
   sep,
 } from 'node:path';
 import { constants as fsConstants } from 'node:fs';
-import { access, mkdtemp, open, realpath, rm, stat } from 'node:fs/promises';
+import {
+  access,
+  chmod,
+  lstat,
+  mkdtemp,
+  open,
+  readdir,
+  realpath,
+  rm,
+  stat,
+} from 'node:fs/promises';
 
 import { SandboxManager } from '@anthropic-ai/sandbox-runtime';
 
@@ -109,6 +119,8 @@ const SRT_SCRATCH_SELECTOR_NAMES = [
   'CLAUDE_CODE_TMPDIR',
   'CLAUDE_TMPDIR',
 ] as const;
+// Capture this before any command wrapper can temporarily mutate process.env.
+const HOST_TEMPORARY_ROOT = tmpdir();
 
 interface NativeSandboxManager {
   isSupportedPlatform(): boolean;
@@ -295,11 +307,13 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
         ),
       )),
     ];
-    const deniedInheritedWritablePaths = [
-      ...new Set(inheritedWritablePaths),
-    ].filter(
-      (path) => !isWithin(root, path) && !isWithin(path, root),
-    );
+    const deniedInheritedWritablePaths = [...new Set(inheritedWritablePaths)];
+    if (deniedInheritedWritablePaths.some((path) => isWithin(path, root))) {
+      throw new WorkspaceToolError(
+        'Native sandbox workspace cannot be inside an inherited writable path',
+        'REGISTRATION_INVALID',
+      );
+    }
     const dependencies = await this.manager.checkDependenciesAsync();
     if (dependencies.errors.length > 0) {
       throw new WorkspaceToolError(
@@ -319,6 +333,15 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
     }
     const canonicalScratchDirectory =
       await this.createScratchDirectory(sharedScratchPaths);
+    if (
+      canonicalScratchDirectory &&
+      isWithin(root, canonicalScratchDirectory)
+    ) {
+      throw new WorkspaceToolError(
+        'Native sandbox workspace cannot contain worker scratch storage',
+        'REGISTRATION_INVALID',
+      );
+    }
     const config: SandboxRuntimeConfig = {
       network: {
         allowedDomains: [...(this.options.allowedDomains ?? [])],
@@ -443,7 +466,6 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
           ...TRUSTED_GIT_ENVIRONMENT,
           ...(credentialEnvironment ?? {}),
           ...this.scratchSelectorEnvironment(),
-          ...this.scratchEnvironment(),
         },
         () =>
           this.manager.wrapWithSandboxArgv(
@@ -680,7 +702,7 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
   ): Promise<string | undefined> {
     // Windows SRT supplies the restricted account's private TEMP directory.
     if (this.platform === 'win32') return undefined;
-    const canonicalTemporaryRoot = await canonicalPath(tmpdir());
+    const canonicalTemporaryRoot = await canonicalPath(HOST_TEMPORARY_ROOT);
     const sharedScratchRoot = sharedScratchPaths.find((path) =>
       isWithin(path, canonicalTemporaryRoot),
     );
@@ -741,9 +763,50 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
 
   private async removeScratchDirectory(): Promise<void> {
     const scratchDirectory = this.scratchDirectory;
-    this.scratchDirectory = undefined;
     if (!scratchDirectory) return;
-    await rm(scratchDirectory, { recursive: true, force: true });
+    try {
+      await rm(scratchDirectory, { recursive: true, force: true });
+    } catch {
+      await this.restoreScratchTraversal(scratchDirectory);
+      await rm(scratchDirectory, { recursive: true, force: true });
+    }
+    this.scratchDirectory = undefined;
+  }
+
+  private async restoreScratchTraversal(root: string): Promise<void> {
+    const pending = [root];
+    for (let index = 0; index < pending.length; index += 1) {
+      const directory = pending[index];
+      const metadata = await lstat(directory).catch(
+        (error: NodeJS.ErrnoException) => {
+          if (error.code === 'ENOENT') return undefined;
+          throw error;
+        },
+      );
+      if (!metadata?.isDirectory()) continue;
+      // Commands own their scratch contents and may remove all directory mode
+      // bits. Restore traversal before opening the directory with O_NOFOLLOW.
+      await chmod(directory, 0o700);
+      let handle;
+      try {
+        handle = await open(
+          directory,
+          fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+        );
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (['ENOENT', 'ELOOP', 'ENOTDIR'].includes(code ?? '')) continue;
+        throw error;
+      }
+      try {
+        if (!(await handle.stat()).isDirectory()) continue;
+      } finally {
+        await handle.close();
+      }
+      for (const entry of await readdir(directory, { withFileTypes: true })) {
+        if (entry.isDirectory()) pending.push(join(directory, entry.name));
+      }
+    }
   }
 
   async close(): Promise<void> {

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -317,46 +317,8 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
         );
       }
     }
-    const canonicalTemporaryRoot = await canonicalPath(tmpdir());
-    const sharedScratchRoot = sharedScratchPaths.find((path) =>
-      isWithin(path, canonicalTemporaryRoot),
-    );
-    const scratchDirectory = await mkdtemp(
-      join(
-        sharedScratchRoot
-          ? dirname(sharedScratchRoot)
-          : canonicalTemporaryRoot,
-        NATIVE_SANDBOX_SCRATCH_PREFIX,
-      ),
-    );
-    let canonicalScratchDirectory: string;
-    try {
-      if (this.platform !== 'win32') {
-        await assertPrivateStorageAncestors(scratchDirectory);
-        const scratchHandle = await open(scratchDirectory, 'r');
-        try {
-          await removePrivateStorageAcl(scratchHandle, scratchDirectory);
-          await scratchHandle.chmod(0o700);
-          await assertPrivateStorageAcl(
-            scratchHandle,
-            scratchDirectory,
-            true,
-          );
-          if (((await scratchHandle.stat()).mode & 0o777) !== 0o700) {
-            throw new Error('Native sandbox scratch directory is not private');
-          }
-        } finally {
-          await scratchHandle.close();
-        }
-      }
-      canonicalScratchDirectory = await realpath(scratchDirectory);
-      this.scratchDirectory = canonicalScratchDirectory;
-    } catch (error) {
-      await rm(scratchDirectory, { recursive: true, force: true }).catch(
-        () => undefined,
-      );
-      throw error;
-    }
+    const canonicalScratchDirectory =
+      await this.createScratchDirectory(sharedScratchPaths);
     const config: SandboxRuntimeConfig = {
       network: {
         allowedDomains: [...(this.options.allowedDomains ?? [])],
@@ -373,8 +335,14 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
             deniedInheritedWritablePaths.includes(path),
           ),
         ],
-        allowRead: [root, canonicalScratchDirectory],
-        allowWrite: [root, canonicalScratchDirectory],
+        allowRead: [
+          root,
+          ...(canonicalScratchDirectory ? [canonicalScratchDirectory] : []),
+        ],
+        allowWrite: [
+          root,
+          ...(canonicalScratchDirectory ? [canonicalScratchDirectory] : []),
+        ],
         denyWrite: [...protectedPaths, ...deniedInheritedWritablePaths],
         allowGitConfig: false,
       },
@@ -705,6 +673,50 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
       code <= 255
       ? code
       : 1;
+  }
+
+  private async createScratchDirectory(
+    sharedScratchPaths: string[],
+  ): Promise<string | undefined> {
+    // Windows SRT supplies the restricted account's private TEMP directory.
+    if (this.platform === 'win32') return undefined;
+    const canonicalTemporaryRoot = await canonicalPath(tmpdir());
+    const sharedScratchRoot = sharedScratchPaths.find((path) =>
+      isWithin(path, canonicalTemporaryRoot),
+    );
+    const scratchDirectory = await mkdtemp(
+      join(
+        sharedScratchRoot
+          ? dirname(sharedScratchRoot)
+          : canonicalTemporaryRoot,
+        NATIVE_SANDBOX_SCRATCH_PREFIX,
+      ),
+    );
+    try {
+      await assertPrivateStorageAncestors(scratchDirectory);
+      const scratchHandle = await open(scratchDirectory, 'r');
+      try {
+        await removePrivateStorageAcl(scratchHandle, scratchDirectory);
+        await scratchHandle.chmod(0o700);
+        await assertPrivateStorageAcl(
+          scratchHandle,
+          scratchDirectory,
+          true,
+        );
+        if (((await scratchHandle.stat()).mode & 0o777) !== 0o700) {
+          throw new Error('Native sandbox scratch directory is not private');
+        }
+      } finally {
+        await scratchHandle.close();
+      }
+      this.scratchDirectory = await realpath(scratchDirectory);
+      return this.scratchDirectory;
+    } catch (error) {
+      await rm(scratchDirectory, { recursive: true, force: true }).catch(
+        () => undefined,
+      );
+      throw error;
+    }
   }
 
   private scratchEnvironment(): NodeJS.ProcessEnv {

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import {
   basename,
   dirname,
@@ -11,7 +11,7 @@ import {
   sep,
 } from 'node:path';
 import { constants as fsConstants } from 'node:fs';
-import { access, realpath, stat } from 'node:fs/promises';
+import { access, mkdtemp, open, realpath, rm, stat } from 'node:fs/promises';
 
 import { SandboxManager } from '@anthropic-ai/sandbox-runtime';
 
@@ -21,6 +21,11 @@ import {
   BRIDGE_WORKSPACE_COMMAND_DEFAULT_TIMEOUT_MS,
   isWorkspaceToolRequest,
 } from './protocol.js';
+import {
+  assertPrivateStorageAcl,
+  assertPrivateStorageAncestors,
+  removePrivateStorageAcl,
+} from './private-storage.js';
 import { WorkspaceToolError } from './workspace.js';
 
 import type {
@@ -95,6 +100,13 @@ const {
   GIT_CONFIG_COUNT: TRUSTED_GIT_CONFIG_COUNT,
   ...TRUSTED_GIT_CONFIG_ENTRIES
 } = TRUSTED_GIT_ENVIRONMENT;
+
+const NATIVE_SANDBOX_SCRATCH_PREFIX = 'librechat-code-srt-';
+const SRT_SHARED_SCRATCH_PATHS = ['/tmp/claude', '/private/tmp/claude'];
+const SRT_SCRATCH_SELECTOR_NAMES = [
+  'CLAUDE_CODE_TMPDIR',
+  'CLAUDE_TMPDIR',
+] as const;
 
 interface NativeSandboxManager {
   isSupportedPlatform(): boolean;
@@ -211,6 +223,7 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
   private readonly platform: NodeJS.Platform;
   private initialized?: Promise<void>;
   private canonicalRoot?: string;
+  private scratchDirectory?: string;
 
   constructor(
     private readonly options: NativeSrtWorkspaceCommandSandboxOptions,
@@ -230,6 +243,7 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
     if (this.initialized) return this.initialized;
     this.initialized = this.initializeOnce().catch(async (error) => {
       await this.manager.reset().catch(() => undefined);
+      await this.removeScratchDirectory().catch(() => undefined);
       this.initialized = undefined;
       throw error;
     });
@@ -266,6 +280,24 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
         'REGISTRATION_INVALID',
       );
     }
+    const sharedScratchPaths = await Promise.all(
+      (this.platform === 'win32' ? [] : SRT_SHARED_SCRATCH_PATHS).map(
+        canonicalPath,
+      ),
+    );
+    const inheritedWritablePaths = [
+      ...sharedScratchPaths,
+      ...(await Promise.all(
+        [join(home, '.npm', '_logs'), join(home, '.claude', 'debug')].map(
+          canonicalPath,
+        ),
+      )),
+    ];
+    const deniedInheritedWritablePaths = [
+      ...new Set(inheritedWritablePaths),
+    ].filter(
+      (path) => !isWithin(root, path) && !isWithin(path, root),
+    );
     const dependencies = await this.manager.checkDependenciesAsync();
     if (dependencies.errors.length > 0) {
       throw new WorkspaceToolError(
@@ -283,6 +315,46 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
         );
       }
     }
+    const canonicalTemporaryRoot = await canonicalPath(tmpdir());
+    const sharedScratchRoot = sharedScratchPaths.find((path) =>
+      isWithin(path, canonicalTemporaryRoot),
+    );
+    const scratchDirectory = await mkdtemp(
+      join(
+        sharedScratchRoot
+          ? dirname(sharedScratchRoot)
+          : canonicalTemporaryRoot,
+        NATIVE_SANDBOX_SCRATCH_PREFIX,
+      ),
+    );
+    let canonicalScratchDirectory: string;
+    try {
+      if (this.platform !== 'win32') {
+        await assertPrivateStorageAncestors(scratchDirectory);
+        const scratchHandle = await open(scratchDirectory, 'r');
+        try {
+          await removePrivateStorageAcl(scratchHandle, scratchDirectory);
+          await scratchHandle.chmod(0o700);
+          await assertPrivateStorageAcl(
+            scratchHandle,
+            scratchDirectory,
+            true,
+          );
+          if (((await scratchHandle.stat()).mode & 0o777) !== 0o700) {
+            throw new Error('Native sandbox scratch directory is not private');
+          }
+        } finally {
+          await scratchHandle.close();
+        }
+      }
+      canonicalScratchDirectory = await realpath(scratchDirectory);
+      this.scratchDirectory = canonicalScratchDirectory;
+    } catch (error) {
+      await rm(scratchDirectory, { recursive: true, force: true }).catch(
+        () => undefined,
+      );
+      throw error;
+    }
     const config: SandboxRuntimeConfig = {
       network: {
         allowedDomains: [...(this.options.allowedDomains ?? [])],
@@ -293,10 +365,15 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
         ...(this.options.maskedEnvironment ? { tlsTerminate: {} } : {}),
       },
       filesystem: {
-        denyRead: [home],
-        allowRead: [root],
-        allowWrite: [root],
-        denyWrite: protectedPaths,
+        denyRead: [
+          home,
+          ...sharedScratchPaths.filter((path) =>
+            deniedInheritedWritablePaths.includes(path),
+          ),
+        ],
+        allowRead: [root, canonicalScratchDirectory],
+        allowWrite: [root, canonicalScratchDirectory],
+        denyWrite: [...protectedPaths, ...deniedInheritedWritablePaths],
         allowGitConfig: false,
       },
       credentials: {
@@ -305,7 +382,14 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
           mode: 'deny' as const,
         })),
         envVars: [
-          ...deniedEnvironmentNames(this.environment, this.platform)
+          ...deniedEnvironmentNames(
+            {
+              ...this.environment,
+              CLAUDE_CODE_TMPDIR: '',
+              CLAUDE_TMPDIR: '',
+            },
+            this.platform,
+          )
             .filter((name) => {
               const normalized = normalizedEnvironmentName(
                 name,
@@ -388,6 +472,8 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
         {
           ...TRUSTED_GIT_ENVIRONMENT,
           ...(credentialEnvironment ?? {}),
+          ...this.scratchSelectorEnvironment(),
+          ...this.scratchEnvironment(),
         },
         () =>
           this.manager.wrapWithSandboxArgv(
@@ -476,6 +562,7 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
             cwd,
             env: {
               ...wrapped.env,
+              ...this.scratchEnvironment(),
               ...TRUSTED_GIT_CONFIG_ENTRIES,
               GIT_CONFIG_COUNT:
                 wrapped.env.GIT_CONFIG_COUNT ?? TRUSTED_GIT_CONFIG_COUNT,
@@ -618,10 +705,41 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
       : 1;
   }
 
+  private scratchEnvironment(): NodeJS.ProcessEnv {
+    const scratchDirectory = this.scratchDirectory;
+    if (!scratchDirectory) return {};
+    return this.platform === 'win32'
+      ? {
+          TMPDIR: scratchDirectory,
+          TEMP: scratchDirectory,
+          TMP: scratchDirectory,
+        }
+      : { TMPDIR: scratchDirectory };
+  }
+
+  private scratchSelectorEnvironment(): NodeJS.ProcessEnv {
+    const scratchDirectory = this.scratchDirectory;
+    if (!scratchDirectory) return {};
+    return Object.fromEntries(
+      SRT_SCRATCH_SELECTOR_NAMES.map((name) => [name, scratchDirectory]),
+    );
+  }
+
+  private async removeScratchDirectory(): Promise<void> {
+    const scratchDirectory = this.scratchDirectory;
+    this.scratchDirectory = undefined;
+    if (!scratchDirectory) return;
+    await rm(scratchDirectory, { recursive: true, force: true });
+  }
+
   async close(): Promise<void> {
-    if (!this.initialized) return;
-    await this.manager.reset();
-    this.initialized = undefined;
-    this.canonicalRoot = undefined;
+    if (!this.initialized && !this.scratchDirectory) return;
+    try {
+      if (this.initialized) await this.manager.reset();
+    } finally {
+      this.initialized = undefined;
+      this.canonicalRoot = undefined;
+      await this.removeScratchDirectory();
+    }
   }
 }


### PR DESCRIPTION
## Summary

I isolated temporary storage for native BYOM commands so build tools can use writable scratch space without exposing host-global temporary files across worker processes.

- Create an owner-only, worker-lifetime scratch directory for macOS and Linux native workers.
- Direct `TMPDIR` and the SRT temporary-directory selectors to the private directory.
- Keep Windows on SRT's restricted-account profile and isolated temporary directory.
- Deny SRT's shared POSIX compatibility scratch paths and inherited home-directory write paths.
- Reject workspace roots that are inside those implicit paths or broad enough to contain private worker scratch.
- Remove scratch contents after orderly worker shutdown and failed initialization, including trees whose command removed owner traversal permissions.
- Preserve the workspace root, credential masking, network policy, and command-approval boundaries.
- Document the native scratch lifecycle and filesystem limits.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm run build` in `packages/code`.
- Ran `node --test dist/native-sandbox.test.js` (40 focused tests passed on Node.js 24.16.0).
- Repeated the synchronized cancellation regression 30 times on Node.js 24.16.0.
- Ran a real macOS Seatbelt/SRT probe that created a file through the private `TMPDIR`, verified read/write denial for `/tmp/claude`, and verified cleanup after sandbox shutdown.
- Confirmed `git diff --check` passes.

### **Test Configuration**:

- macOS
- Node.js 24.16.0
- `@anthropic-ai/sandbox-runtime` 0.0.75

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
