### PR TITLE
🚶 fix: Reset BYOM Execution Budgets After Admission

### DIFF
--- a/docs/byom-worker-admission.md
+++ b/docs/byom-worker-admission.md
@@ -5,8 +5,12 @@ The limit is 32 admitted requests per worker, including the active request. When
 the limit is reached, the workspace endpoint returns HTTP 429 with
 `WORKER_QUEUE_FULL`. A different worker has an independent admission queue.
 
-Waiting uses the caller's existing absolute dispatch deadline. It does not reset
-or extend execution timeouts. Disconnecting or cancelling removes the waiting
+The workspace HTTP endpoint allows at most 30 seconds for admission. After
+admission and worker validation, a separate execution deadline starts. Commands
+receive their requested timeout (30 seconds by default, up to five minutes),
+capped by the operator's `JOB_TIMEOUT`, plus five seconds to settle the result.
+Read/search/list operations receive up to 30 seconds, also capped by `JOB_TIMEOUT`.
+Disconnecting or cancelling removes the waiting
 request without cancelling the active assignment. Expired entries are pruned;
 Redis key expiry also bounds state left by a crashed API process.
 
@@ -15,12 +19,20 @@ binding and workspace operation. A waiting request cannot migrate to a replaceme
 worker. Existing execution acknowledgement, fencing, settlement and quarantine
 rules remain responsible for the active assignment.
 
-This is compatible with existing workers and requires only a Code API update.
+This is compatible with existing workers: assignments retain the same absolute
+deadline and server-relative timing fields. Store callers that omit the new
+internal `executionTimeoutMs` argument retain their existing absolute-deadline behavior.
 Existing workers still execute one assignment at a time. Parallel execution across
 workspaces requires separate lease claims and isolated native sandbox contexts;
-this admission change does not advertise that capability. Queue time and execution
-time currently share the HTTP request deadline. Separate budgets require a matching
-LibreChat client change so that the client does not disconnect while waiting.
+this admission change does not advertise that capability.
+
+LibreChat must allow queue time plus execution/settlement time and five seconds
+for HTTP delivery: 65 seconds for reads, 70 seconds for default commands, and
+340 seconds for five-minute commands. Either side can be upgraded first. Older
+clients still cancel at their earlier deadline; newer clients preserve errors from
+older servers without retrying mutations. Both updates are needed for the full
+waiting budget. Any reverse proxy request timeout must accommodate these totals.
+The worker package does not need an update for the deadline change.
 
 Focused regression coverage lives in `service/src/bridge/admission.test.ts` and
 `service/src/bridge/worker-admission.test.ts`.

--- a/service/src/bridge/store.ts
+++ b/service/src/bridge/store.ts
@@ -573,6 +573,7 @@ export class RedisBridgeStore {
     requireTenantBinding?: boolean;
     request: WorkspaceToolRequest;
     deadlineAtMs: number;
+    executionTimeoutMs?: number;
     signal: AbortSignal;
   }): Promise<CodeBridgeWorkspaceSettlement> {
     if (!isWorkspaceToolRequest(args.request)) {
@@ -614,12 +615,20 @@ export class RedisBridgeStore {
     workspaceRequest?: WorkspaceToolRequest;
     runtimeSessionId?: string;
     deadlineAtMs: number;
+    executionTimeoutMs?: number;
     signal: AbortSignal;
     finalize?: (
       settlement: CodeBridgeSettlement,
       registration: RegisteredBridgeWorker,
     ) => Promise<CodeBridgeSettlement>;
   }): Promise<CodeBridgeSettlement> {
+    if (args.executionTimeoutMs !== undefined && (
+      args.workspaceRequest == null ||
+      !Number.isSafeInteger(args.executionTimeoutMs) ||
+      args.executionTimeoutMs < 1 || args.executionTimeoutMs > 305_000
+    )) {
+      throw new BridgeStoreError('ASSIGNMENT_INVALID', 'Invalid workspace execution budget');
+    }
     this.assertDispatchActive(args.signal, args.deadlineAtMs);
     const dispatchable = await this.dispatchCommand(
       () => this.dispatchableRegistration(args.workerId),
@@ -682,7 +691,8 @@ export class RedisBridgeStore {
 
     const assignmentId = randomBytes(18).toString('base64url');
     const leaseToken = randomBytes(32).toString('base64url');
-    const ttlSeconds = assignmentTtlSeconds(args.deadlineAtMs);
+    // The lock is acquired before admission finishes; it must outlive the later execution deadline.
+    const ttlSeconds = assignmentTtlSeconds(args.deadlineAtMs + (args.executionTimeoutMs ?? 0));
     const lockIncarnationId = registration.incarnationId;
     let assignment: StoredAssignment | undefined;
     let resultCommitted = false;
@@ -747,6 +757,10 @@ export class RedisBridgeStore {
         if (!supportsWorkspaceTool(current.registration, args.workspaceRequest!)) {
           throw new BridgeStoreError('WORKER_MISMATCH', 'Bridge worker capabilities changed while the request was waiting');
         }
+      }
+      this.assertDispatchActive(args.signal, args.deadlineAtMs);
+      if (args.executionTimeoutMs !== undefined) {
+        args = { ...args, deadlineAtMs: Date.now() + args.executionTimeoutMs };
       }
       const generation = await this.dispatchCommand(
         () => this.redis.incr(generationKey(args.workerId)),

--- a/service/src/bridge/worker-admission.test.ts
+++ b/service/src/bridge/worker-admission.test.ts
@@ -37,11 +37,13 @@ function dispatch(
   path: string,
   controller = new AbortController(),
   budgetMs = 5000,
+  executionTimeoutMs?: number,
 ): ReturnType<RedisBridgeStore['dispatchWorkspaceTool']> {
   return store.dispatchWorkspaceTool({
     workerId,
     signal: controller.signal,
     deadlineAtMs: Date.now() + budgetMs,
+    executionTimeoutMs,
     request: {
       protocolVersion: BRIDGE_PROTOCOL_VERSION,
       operation: 'read_file',
@@ -111,7 +113,7 @@ test('an expired queued call never reaches the worker and does not strand later 
   const first = dispatch('first');
   const assignment = await store.lease(workerId, incarnationId, 1000);
   await expect(
-    dispatch('expired', new AbortController(), 25),
+    dispatch('expired', new AbortController(), 25, 1000),
   ).rejects.toMatchObject({ code: 'ASSIGNMENT_EXPIRED' });
   const third = dispatch('third');
   await settle(assignment);
@@ -141,4 +143,30 @@ test('a queued request is rejected if the worker withdraws its capability', asyn
   await first;
   await expect(second).rejects.toMatchObject({ code: 'WORKER_MISMATCH' });
   expect(await store.lease(workerId, incarnationId, 50)).toBeUndefined();
+});
+
+test('execution receives a fresh budget after waiting and the lock covers long commands', async () => {
+  await register();
+  const first = dispatch('first');
+  const active = await store.lease(workerId, incarnationId, 1000);
+  const second = dispatch('second', new AbortController(), 1000, 305_000);
+  await new Promise(resolve => setTimeout(resolve, 150));
+  await settle(active);
+  await first;
+  const next = await store.lease(workerId, incarnationId, 1000);
+  expect(next).toBeDefined();
+  expect(Date.parse(next!.expiresAt) - Date.now()).toBeGreaterThan(304_000);
+  expect(await redis.pttl(`codeapi:bridge:v1:worker:${workerId}:lock`)).toBeGreaterThan(305_000);
+  await settle(next);
+  await second;
+});
+
+test('execution expires independently of an unused queue allowance', async () => {
+  await register();
+  const completion = dispatch('short', new AbortController(), 5000, 150);
+  void completion.catch(() => undefined);
+  const assignment = await store.lease(workerId, incarnationId, 1000);
+  expect(assignment).toBeDefined();
+  expect(Date.parse(assignment!.expiresAt) - Date.now()).toBeLessThanOrEqual(150);
+  await expect(completion).rejects.toMatchObject({ code: 'ASSIGNMENT_EXPIRED' });
 });

--- a/service/src/workspace-tools/router.test.ts
+++ b/service/src/workspace-tools/router.test.ts
@@ -14,6 +14,7 @@ import { hostedAppPreviewGateway } from '../hosted-app/preview-gateway';
 import { applyPrincipal } from '../auth/principal';
 import { BridgeStoreError } from '../bridge/store';
 import { bridgeStoreStatus, createWorkspaceToolsRouter } from './router';
+import type { WorkspaceToolRequest } from '../../../packages/code/src/protocol';
 
 let server: Server | undefined;
 let logCompleted: ReturnType<typeof Promise.withResolvers<void>>;
@@ -33,6 +34,46 @@ afterEach(() => {
 test('maps invalid worker results to an upstream failure', () => {
   expect(bridgeStoreStatus(new BridgeStoreError('RESULT_INVALID', 'invalid worker result'))).toBe(502);
   expect(bridgeStoreStatus(new BridgeStoreError('WORKER_QUEUE_FULL', 'queue full'))).toBe(429);
+});
+
+test.each<[WorkspaceToolRequest, number, number?]>([
+  [{ protocolVersion: 1, operation: 'read_file', workspaceId: 'primary', path: 'README.md' }, 30_000, undefined],
+  [{ protocolVersion: 1, operation: 'execute_command', workspaceId: 'primary', command: 'echo ready' }, 35_000, undefined],
+  [{ protocolVersion: 1, operation: 'execute_command', workspaceId: 'primary', command: 'echo ready', timeoutMs: 300_000 }, 305_000, undefined],
+  [{ protocolVersion: 1, operation: 'execute_command', workspaceId: 'primary', command: 'echo ready' }, 6000, 1000],
+  [{ protocolVersion: 1, operation: 'execute_command', workspaceId: 'primary', command: 'echo ready' }, 35_000, 600_000],
+])('separates the admission deadline from execution budget for %j', async (request, expectedExecution, ceiling) => {
+  const app = express();
+  app.use(json());
+  app.use((req, _res, next) => {
+    applyPrincipal(req, { userId: 'user-1', tenantId: 'tenant-1', principalSource: 'librechat_jwt', codeWorkerId: 'user-worker' });
+    next();
+  });
+  let executionBudget: number | undefined;
+  let queueRemaining: number | undefined;
+  let commandTimeout: number | undefined;
+  app.use(createWorkspaceToolsRouter({
+    backend: 'remote-bridge', configuredWorkerId: 'user-worker', dynamicWorkers: false,
+    timeoutMs: ceiling,
+    store: { async dispatchWorkspaceTool(args) {
+      executionBudget = args.executionTimeoutMs;
+      if (args.request.operation === 'execute_command') commandTimeout = args.request.timeoutMs;
+      queueRemaining = args.deadlineAtMs - Date.now();
+      return { protocolVersion: 1, generation: 1, leaseToken: 'lease', incarnationId: 'incarnation', status: 'rejected', error: 'fixture' };
+    } },
+  }));
+  server = createServer(app);
+  await new Promise<void>(resolve => server!.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (address == null || typeof address === 'string') throw new Error('Missing listener');
+  const response = await fetch(`http://127.0.0.1:${address.port}/workspace-tools/execute`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(request),
+  });
+  await response.json();
+  expect(executionBudget).toBe(expectedExecution);
+  if (request.operation === 'execute_command') expect(commandTimeout).toBe(expectedExecution - 5000);
+  expect(queueRemaining).toBeGreaterThan(29_000);
+  expect(queueRemaining).toBeLessThanOrEqual(30_000);
 });
 
 test('rejects new workspace dispatches while the service is shutting down', async () => {
@@ -167,7 +208,7 @@ test.each([
       operation: 'search_text',
       workerId: 'user-worker',
       dispatchDurationMs: expect.any(Number),
-      deadlineBudgetMs: 30_000,
+      deadlineBudgetMs: 60_000,
     }),
   );
   await expect(response.json()).resolves.toMatchObject({
@@ -330,7 +371,7 @@ test.each([
       status: expectedStatus,
       errorCode,
       outcome: 'completed',
-      deadlineBudgetMs: 300_000,
+      deadlineBudgetMs: 60_000,
       dispatchDurationMs: expect.any(Number),
     }),
   );

--- a/service/src/workspace-tools/router.ts
+++ b/service/src/workspace-tools/router.ts
@@ -3,12 +3,16 @@ import { Router } from 'express';
 import type { RequestHandler, Response } from 'express';
 import type { AuthenticatedRequest } from '../types';
 import type { RedisBridgeStore } from '../bridge/store';
+import type { WorkspaceToolRequest } from '../../../packages/code/src/protocol';
 
 import { getWorkspaceToolOutcome } from './outcome';
 import { getPrincipalOrReject } from '../auth/principal';
 import { BridgeStoreError } from '../bridge/store';
 import { checkServiceShutDown } from '../lifecycle';
-import { isWorkspaceToolRequest } from '../../../packages/code/src/protocol';
+import {
+  isWorkspaceToolRequest,
+  BRIDGE_WORKSPACE_COMMAND_DEFAULT_TIMEOUT_MS,
+} from '../../../packages/code/src/protocol';
 import {
   CODEAPI_BRIDGE_WORKER_HEADER,
   BridgeWorkerSelectionError,
@@ -21,6 +25,7 @@ interface WorkspaceToolsRouterOptions {
   configuredWorkerId: string;
   dynamicWorkers: boolean;
   timeoutMs?: number;
+  queueTimeoutMs?: number;
   isShuttingDown?: () => boolean;
 }
 
@@ -43,14 +48,21 @@ export function bridgeStoreStatus(error: BridgeStoreError): number {
 }
 
 export function createWorkspaceToolsRouter(options: WorkspaceToolsRouterOptions): Router {
+  const queueBudgetMs = options.queueTimeoutMs ?? 30_000;
+  if (!Number.isSafeInteger(queueBudgetMs) || queueBudgetMs < 1 || queueBudgetMs > 30_000) {
+    throw new RangeError('Workspace queue timeout must be between 1 and 30000 milliseconds');
+  }
+  if (options.timeoutMs !== undefined && (
+    !Number.isSafeInteger(options.timeoutMs) || options.timeoutMs < 1
+  )) {
+    throw new RangeError('Workspace execution timeout must be a positive safe integer');
+  }
   const router = Router();
 
   router.post(
     '/workspace-tools/execute',
     asyncRoute(async (req, res) => {
       const outcome = getWorkspaceToolOutcome(res);
-      const deadlineBudgetMs = Math.max(1, options.timeoutMs ?? 30_000);
-      outcome.deadlineBudgetMs = deadlineBudgetMs;
       const principal = getPrincipalOrReject(req, res);
       if (!principal) {
         outcome.errorCode = 'UNAUTHENTICATED';
@@ -69,6 +81,16 @@ export function createWorkspaceToolsRouter(options: WorkspaceToolsRouterOptions)
         return;
       }
       outcome.operation = req.body.operation;
+      const request: WorkspaceToolRequest = req.body.operation === 'execute_command'
+        ? { ...req.body, timeoutMs: Math.min(
+          req.body.timeoutMs ?? BRIDGE_WORKSPACE_COMMAND_DEFAULT_TIMEOUT_MS,
+          options.timeoutMs ?? Number.MAX_SAFE_INTEGER,
+        ) }
+        : req.body;
+      const executionBudgetMs = request.operation === 'execute_command'
+        ? request.timeoutMs! + 5_000
+        : Math.min(options.timeoutMs ?? 30_000, 30_000);
+      outcome.deadlineBudgetMs = queueBudgetMs + executionBudgetMs;
 
       let selection: { workerId: string; explicit: boolean } | undefined;
       try {
@@ -111,8 +133,9 @@ export function createWorkspaceToolsRouter(options: WorkspaceToolsRouterOptions)
           tenantId: principal.tenantId,
           requireTenantBinding:
             selection.explicit && (options.dynamicWorkers || selection.workerId !== options.configuredWorkerId),
-          request: req.body,
-          deadlineAtMs: Date.now() + deadlineBudgetMs,
+          request,
+          deadlineAtMs: Date.now() + queueBudgetMs,
+          executionTimeoutMs: executionBudgetMs,
           signal: controller.signal,
         }).finally(() => {
           outcome.dispatchDurationMs = Math.round(performance.now() - dispatchStartedAt);


### PR DESCRIPTION
## Summary

I separated BYOM workspace admission time from execution time so waiting for a busy worker does not consume the command's runtime budget.

- Bound admission to 30 seconds and start a fresh execution deadline after worker validation.
- Honor the command timeout under the operator's `JOB_TIMEOUT` ceiling, with a separate five-second settlement allowance.
- Keep Redis locks and assignment state alive through the execution window.
- Preserve cancellation, expired-waiter rejection, and legacy store callers' absolute deadlines.
- Document the matching LibreChat HTTP budgets and rolling-upgrade behavior; workers use the existing protocol.

The companion LibreChat change https://github.com/danny-avila/LibreChat/pull/15750 allows both budgets plus HTTP delivery time. Either side can upgrade first; older clients retain their earlier cancellation deadline until upgraded.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- Passed six focused admission/lifecycle tests, including fresh execution deadlines, long-command lock lifetime, cancellation, and expiry without execution.
- Passed five HTTP budget cases for reads, default/max commands, and short/long operator ceilings.
- Passed focused HTTP rejection logging tests.
- Built `@librechat/code` successfully.
- Service ESM typecheck retains the four existing local diagnostics recorded on the untouched base; no new diagnostics in changed files.
- Passed an isolated live probe using the actual LibreChat client, HTTP router, Redis and native SRT under Node: two simultaneous commands completed in 5.06 seconds, with fresh execution windows of 7.91 and 7.99 seconds after admission (3-second queue limit, 3-second execution plus 5-second settlement). Used ephemeral ports 55864/55869, fixture authentication and a lease/settlement harness, not the deployed UI or full worker transport.
- Left full suites to CI; no deployment changes are required now.
- Passed a second three-caller live probe: two commands completed and one expired in the queue with HTTP 504; no third assignment was leased. Used ephemeral ports 55998/56003.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
