### PR TITLE
fix: Fence Native SRT Lifecycle Ownership

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -88,6 +88,16 @@ bubblewrap plus seccomp on Linux, and the SRT restricted-account helper on
 Windows. Startup fails before worker registration when the platform or its
 dependencies are unavailable. There is no unsandboxed command fallback.
 
+The native SRT manager owns process-global policy, proxy, and cleanup state.
+Only one sandbox instance may own a manager, and that instance accepts one
+command at a time. Overlapping calls fail before a second command starts;
+they are not queued inside the sandbox. `close()` waits for the active command
+and initialization before resetting the manager and removing scratch. A failed
+reset keeps ownership fenced until a later `close()` succeeds. Independent
+native workspaces need separate worker processes, not multiple instances of
+the default manager in one process. This lifecycle guard does not enable
+parallel assignments on a single bridge worker.
+
 The bridge worker remains outside the sandbox so it can maintain its outbound
 Code API connection. On macOS and Linux, each worker process creates an
 owner-only scratch directory and grants SRT access to that exact directory

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -117,6 +117,130 @@ function fakeManager(
   };
 }
 
+test('exclusive lifecycle rejects a second workspace sharing an SRT manager', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const fake = fakeManager();
+  const first = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fake.manager,
+  });
+  const second = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fake.manager,
+  });
+  t.after(() => first.close());
+  t.after(() => second.close());
+  await first.prepare();
+  await assert.rejects(
+    second.prepare(),
+    /already belongs to another workspace/,
+  );
+  await second.close();
+  assert.equal(
+    fake.reset,
+    false,
+    'a rejected owner must not reset the live manager',
+  );
+  assert.equal((await first.execute(request)).stdout, 'hello');
+  await first.close();
+  await second.prepare();
+  assert.equal((await second.execute(request)).stdout, 'hello');
+});
+
+test('exclusive lifecycle rejects overlapping commands and waits before resetting', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  let entered!: () => void;
+  const wrapping = new Promise<void>((resolve) => {
+    entered = resolve;
+  });
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const fake = fakeManager({
+    beforeWrap: async () => {
+      entered();
+      await gate;
+    },
+  });
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fake.manager,
+  });
+  t.after(() => sandbox.close());
+  const execution = sandbox.execute(request);
+  await wrapping;
+  await assert.rejects(sandbox.execute(request), /active command/);
+  const closing = sandbox.close();
+  const secondClose = sandbox.close();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(fake.reset, false);
+  await assert.rejects(sandbox.prepare(), /closing/);
+  release();
+  assert.equal((await execution).stdout, 'hello');
+  await Promise.all([closing, secondClose]);
+  assert.equal(fake.reset, true);
+});
+
+test('exclusive lifecycle retains ownership after a failed reset until cleanup succeeds', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const fake = fakeManager();
+  let failReset = true;
+  fake.manager.reset = async () => {
+    if (failReset) throw new Error('reset failed');
+  };
+  const first = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fake.manager,
+  });
+  const second = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fake.manager,
+  });
+  await first.prepare();
+  await assert.rejects(first.close(), /reset failed/);
+  await assert.rejects(first.execute(request), /requires cleanup/);
+  await assert.rejects(second.prepare(), /already belongs/);
+  failReset = false;
+  await first.close();
+  await second.prepare();
+  await second.close();
+});
+
+test('exclusive lifecycle waits for initialization before resetting the manager', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const fake = fakeManager();
+  let entered!: () => void;
+  const initializing = new Promise<void>((resolve) => {
+    entered = resolve;
+  });
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  fake.manager.initialize = async () => {
+    entered();
+    await gate;
+  };
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    manager: fake.manager,
+  });
+  const preparing = sandbox.prepare();
+  await initializing;
+  const closing = sandbox.close();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(fake.reset, false);
+  release();
+  await preparing;
+  await closing;
+  assert.equal(fake.reset, true);
+});
+
 test('initializes SRT with a default-deny network and scrubbed worker credentials', async (t) => {
   const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
   const identity = join(tmpdir(), 'librechat-code-identity.json');

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -139,6 +139,13 @@ interface NativeSandboxManager {
   reset(): Promise<void>;
 }
 
+// SRT's default manager is process-global, including its policy and cleanup
+// state. Distinct workspace objects must not reconfigure the same manager.
+const managerOwners = new WeakMap<
+  NativeSandboxManager,
+  NativeSrtWorkspaceCommandSandbox
+>();
+
 type SpawnCommand = (
   command: string,
   args: readonly string[],
@@ -238,6 +245,9 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
   private initialized?: Promise<void>;
   private canonicalRoot?: string;
   private scratchDirectory?: string;
+  private execution?: Promise<WorkspaceExecuteCommandResult>;
+  private closing?: Promise<void>;
+  private resetFailed = false;
 
   constructor(
     private readonly options: NativeSrtWorkspaceCommandSandboxOptions,
@@ -254,10 +264,27 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
   }
 
   private async initialize(): Promise<void> {
+    if (this.closing || this.resetFailed) {
+      throw new WorkspaceToolError(
+        'Native sandbox is closing or requires cleanup',
+        'COMMAND_UNAVAILABLE',
+      );
+    }
     if (this.initialized) return this.initialized;
+    const owner = managerOwners.get(this.manager);
+    if (owner && owner !== this) {
+      throw new WorkspaceToolError(
+        'Native sandbox manager already belongs to another workspace; use a separate worker process',
+        'COMMAND_UNAVAILABLE',
+      );
+    }
+    managerOwners.set(this.manager, this);
     this.initialized = this.initializeOnce().catch(async (error) => {
-      await this.manager.reset().catch(() => undefined);
+      await this.manager.reset().catch(() => {
+        this.resetFailed = true;
+      });
       await this.removeScratchDirectory().catch(() => undefined);
+      if (!this.resetFailed) managerOwners.delete(this.manager);
       this.initialized = undefined;
       throw error;
     });
@@ -417,6 +444,25 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
   }
 
   async execute(
+    request: WorkspaceExecuteCommandRequest,
+    signal?: AbortSignal,
+  ): Promise<WorkspaceExecuteCommandResult> {
+    if (this.execution || this.closing) {
+      throw new WorkspaceToolError(
+        'Native sandbox already has an active command or is closing',
+        'COMMAND_UNAVAILABLE',
+      );
+    }
+    const execution = this.executeExclusive(request, signal);
+    this.execution = execution;
+    try {
+      return await execution;
+    } finally {
+      this.execution = undefined;
+    }
+  }
+
+  private async executeExclusive(
     request: WorkspaceExecuteCommandRequest,
     signal?: AbortSignal,
   ): Promise<WorkspaceExecuteCommandResult> {
@@ -810,13 +856,28 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
   }
 
   async close(): Promise<void> {
-    if (!this.initialized && !this.scratchDirectory) return;
+    if (this.closing) return this.closing;
+    const closing = this.closeExclusive();
+    this.closing = closing;
     try {
-      if (this.initialized) await this.manager.reset();
+      await closing;
     } finally {
-      this.initialized = undefined;
-      this.canonicalRoot = undefined;
-      await this.removeScratchDirectory();
+      this.closing = undefined;
     }
+  }
+
+  private async closeExclusive(): Promise<void> {
+    // Never reset proxy/credential state or remove scratch beneath a live child.
+    await this.execution?.catch(() => undefined);
+    await this.initialized?.catch(() => undefined);
+    if (managerOwners.get(this.manager) === this) {
+      this.resetFailed = true;
+      await this.manager.reset();
+      this.resetFailed = false;
+      managerOwners.delete(this.manager);
+    }
+    this.initialized = undefined;
+    this.canonicalRoot = undefined;
+    await this.removeScratchDirectory();
   }
 }


### PR DESCRIPTION
## Summary

I fenced native SRT lifecycle operations so workspace instances cannot overwrite another instance's process-global policy or reset its active command.

- Reserve each manager for one sandbox instance before asynchronous initialization begins.
- Reject overlapping commands before starting a second execution.
- Wait for initialization and command settlement before reset and scratch cleanup.
- Retain ownership after failed reset until cleanup succeeds.
- Document the one-manager/one-command boundary and requirement for separate processes for independent native workspaces.

This is an independent safety prerequisite for BYOM concurrency, not an implementation of parallel bridge assignments. Existing CLI execution remains serial; no Code API or LibreChat deployment changes are required.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- Passed seven focused native lifecycle, initialization-failure, scratch isolation, and credential-handoff tests.
- Passed three focused regressions for bounded output, descendant termination, and cancellation mutation certainty.
- Passed the code package TypeScript build/typecheck and `git diff --check`.
- Verified real native SRT on macOS under Node: rejected competing ownership and overlapping execution, preserved an active command during close, and transferred ownership after successful cleanup.
- Used source-selected focused tests because the Codegraph HTTP selector token is unavailable locally; left full suites and platform matrices to CI.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
