### PR TITLE
feat: Isolate Native SRT Executor Processes

### DIFF
--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -98,6 +98,22 @@ native workspaces need separate worker processes, not multiple instances of
 the default manager in one process. This lifecycle guard does not enable
 parallel assignments on a single bridge worker.
 
+The CLI hosts the native manager in a persistent, dedicated Node executor
+process. It does not inherit the bridge credential, arbitrary host environment,
+or Node loader/debugger options. Workspace policy and per-command masked
+credentials travel over private parent/child IPC, never command-line arguments.
+The bridge retains pairing and GitHub App identity management. Cancellation is
+addressed to the active command; executor loss after dispatch is treated as an
+uncertain mutation and is never automatically replayed. Restarting a worker
+still requires its existing quarantine checks. Native platform limitations on
+hard descendant teardown continue to apply.
+
+Embedding applications can use `NativeProcessWorkspaceCommandSandbox` from
+`@librechat/code` for separate native managers in one host application, with
+`prepare()`, `execute()`, and `close()`. Each instance is serial and must be
+closed by its owner. The bridge scheduler remains serial until negotiated
+execution slots and workspace-scoped quarantine are supported end to end.
+
 The bridge worker remains outside the sandbox so it can maintain its outbound
 Code API connection. On macOS and Linux, each worker process creates an
 owner-only scratch directory and grants SRT access to that exact directory

--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -27,7 +27,7 @@ import {
   EndpointRuntimeSupervisor,
 } from './runtime.js';
 import { RuntimeWorkspaceCommandSandbox } from './workspace-runtime.js';
-import { NativeSrtWorkspaceCommandSandbox } from './native-sandbox.js';
+import { NativeProcessWorkspaceCommandSandbox } from './native-process.js';
 import {
   GITHUB_ALLOWED_DOMAINS,
   GITHUB_CREDENTIAL_ENV_NAME,
@@ -659,7 +659,7 @@ async function run(
         });
   const nativeCommandSandbox =
     allowWorkspaceCommands && commandSandboxMode === 'native-srt'
-      ? new NativeSrtWorkspaceCommandSandbox({
+      ? new NativeProcessWorkspaceCommandSandbox({
           workspaceRoot: canonicalWorkerDirectory!,
           protectedPaths: [
             identityPath,
@@ -738,6 +738,7 @@ async function run(
     await github.provider?.getCredential(controller.signal);
     await nativeCommandSandbox?.prepare();
   } catch (error) {
+    await nativeCommandSandbox?.close().catch(() => undefined);
     await fileRelaySupervisor?.stop().catch(() => undefined);
     throw error;
   }

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -6,5 +6,6 @@ export * from './runtime.js';
 export * from './workspace.js';
 export * from './workspace-runtime.js';
 export * from './native-sandbox.js';
+export * from './native-process.js';
 export * from './github.js';
 export * from './worker.js';

--- a/packages/code/src/native-process-child.test.ts
+++ b/packages/code/src/native-process-child.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { fork } from 'node:child_process';
+import test from 'node:test';
+import { nativeExecutorEnvironment } from './native-process.js';
+
+for (const signal of ['SIGINT', 'SIGHUP', 'SIGTERM'] as const) {
+  test(
+    `executor routes ${signal} through shutdown rather than default signal exit`,
+    { skip: process.platform === 'win32', timeout: 10_000 },
+    async (t) => {
+      const child = fork(
+        new URL('./native-process-child.js', import.meta.url),
+        [],
+        {
+          execArgv: [],
+          env: nativeExecutorEnvironment(process.env),
+          stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+        },
+      );
+      t.after(() => {
+        child.kill('SIGKILL');
+      });
+      const exited = new Promise<{
+        code: number | null;
+        signal: NodeJS.Signals | null;
+      }>((resolve, reject) => {
+        child.once('error', reject);
+        child.once('exit', (code, exitSignal) =>
+          resolve({ code, signal: exitSignal }),
+        );
+      });
+      // An invalid-state reply proves module initialization and signal-handler
+      // installation finished without requiring platform SRT dependencies.
+      child.once('message', () => child.kill(signal));
+      child.send({ id: 'startup-probe', type: 'probe' });
+      assert.deepEqual(await exited, { code: 1, signal: null });
+    },
+  );
+}

--- a/packages/code/src/native-process-child.ts
+++ b/packages/code/src/native-process-child.ts
@@ -92,7 +92,7 @@ process.on('message', async (raw: unknown) => {
         error instanceof WorkspaceToolError
           ? error.code
           : 'COMMAND_UNAVAILABLE',
-      ...(message.type === 'prepare' && error instanceof WorkspaceToolError
+      ...(error instanceof WorkspaceToolError
         ? { errorMessage: error.message.slice(0, 1024) }
         : {}),
       mutation:

--- a/packages/code/src/native-process-child.ts
+++ b/packages/code/src/native-process-child.ts
@@ -15,7 +15,7 @@ if (!process.send) throw new Error('Native executor requires IPC');
 function reply(message: object): void {
   if (!process.connected) return;
   try {
-    process.send?.(message, () => undefined);
+    process.send?.({ ...message, fatal: shuttingDown }, () => undefined);
   } catch {
     /* Parent was lost. */
   }
@@ -92,6 +92,9 @@ process.on('message', async (raw: unknown) => {
         error instanceof WorkspaceToolError
           ? error.code
           : 'COMMAND_UNAVAILABLE',
+      ...(message.type === 'prepare' && error instanceof WorkspaceToolError
+        ? { errorMessage: error.message.slice(0, 1024) }
+        : {}),
       mutation:
         error instanceof WorkspaceToolError
           ? error.mutationMayHaveCommitted

--- a/packages/code/src/native-process-child.ts
+++ b/packages/code/src/native-process-child.ts
@@ -30,6 +30,8 @@ const shutdown = () => {
 };
 process.on('disconnect', shutdown);
 process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+process.on('SIGHUP', shutdown);
 process.on('message', async (raw: unknown) => {
   if (shuttingDown) return;
   const message = raw as {

--- a/packages/code/src/native-process-child.ts
+++ b/packages/code/src/native-process-child.ts
@@ -1,0 +1,106 @@
+import { NativeSrtWorkspaceCommandSandbox } from './native-sandbox.js';
+import { WorkspaceToolError } from './workspace.js';
+import type { NativeSrtWorkspaceCommandSandboxOptions } from './native-sandbox.js';
+import type { WorkspaceExecuteCommandRequest } from './protocol.js';
+
+// This entrypoint is private to a forked trusted executor. No HTTP listener,
+// argv credentials, bridge token, or persisted pairing material is required.
+let sandbox: NativeSrtWorkspaceCommandSandbox | undefined;
+let active: { id: string; controller: AbortController } | undefined;
+let busy = false;
+let credentials: Record<string, string> = {};
+let wrappedCommand: string | undefined;
+
+if (!process.send) throw new Error('Native executor requires IPC');
+function reply(message: object): void {
+  if (!process.connected) return;
+  try {
+    process.send?.(message, () => undefined);
+  } catch {
+    /* Parent was lost. */
+  }
+}
+let shuttingDown = false;
+const shutdown = () => {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  active?.controller.abort();
+  void (sandbox?.close() ?? Promise.resolve()).finally(() => process.exit(1));
+  setTimeout(() => process.exit(1), 5000);
+};
+process.on('disconnect', shutdown);
+process.on('SIGTERM', shutdown);
+process.on('message', async (raw: unknown) => {
+  if (shuttingDown) return;
+  const message = raw as {
+    id: string;
+    type: string;
+    options: Omit<
+      NativeSrtWorkspaceCommandSandboxOptions,
+      'maskedEnvironment'
+    > & {
+      variables?: NonNullable<
+        NativeSrtWorkspaceCommandSandboxOptions['maskedEnvironment']
+      >['variables'];
+    };
+    request: WorkspaceExecuteCommandRequest;
+    credentials?: Record<string, string>;
+    wrappedCommand?: string;
+  };
+  if (!message || typeof message.id !== 'string') return;
+  if (message.type === 'cancel') {
+    if (active?.id === message.id) active.controller.abort();
+    return;
+  }
+  if (busy) return;
+  busy = true;
+  try {
+    let result: unknown;
+    if (message.type === 'prepare' && !sandbox) {
+      const { variables, ...options } = message.options;
+      sandbox = new NativeSrtWorkspaceCommandSandbox({
+        ...options,
+        ...(variables
+          ? {
+              maskedEnvironment: {
+                variables,
+                async resolve() {
+                  return credentials;
+                },
+                wrapCommand(command) {
+                  return wrappedCommand ?? command;
+                },
+              },
+            }
+          : {}),
+      });
+      await sandbox.prepare();
+    } else if (message.type === 'execute' && sandbox) {
+      active = { id: message.id, controller: new AbortController() };
+      credentials = message.credentials ?? {};
+      wrappedCommand = message.wrappedCommand;
+      result = await sandbox.execute(message.request, active.controller.signal);
+    } else if (message.type === 'close' && sandbox) {
+      await sandbox.close();
+    } else throw new Error('Invalid executor state');
+    reply({ id: message.id, ok: true, result });
+  } catch (error) {
+    reply({
+      id: message.id,
+      ok: false,
+      code:
+        error instanceof WorkspaceToolError
+          ? error.code
+          : 'COMMAND_UNAVAILABLE',
+      mutation:
+        error instanceof WorkspaceToolError
+          ? error.mutationMayHaveCommitted
+          : true,
+    });
+  } finally {
+    active = undefined;
+    credentials = {};
+    wrappedCommand = undefined;
+    busy = false;
+  }
+});

--- a/packages/code/src/native-process.test.ts
+++ b/packages/code/src/native-process.test.ts
@@ -29,6 +29,7 @@ const result = {
 
 function fixture(
   execute?: (child: EventEmitter, message: Record<string, any>) => void,
+  prepare?: (child: EventEmitter, message: Record<string, any>) => void,
 ) {
   const child = new EventEmitter() as ChildProcess;
   let options: ForkOptions | undefined;
@@ -39,6 +40,8 @@ function fixture(
       messages.push(message);
       callback(null);
       queueMicrotask(() => {
+        if (message.type === 'prepare' && prepare)
+          return prepare(child, message);
         if (message.type === 'execute' && execute)
           return execute(child, message);
         if (message.type === 'cancel') return;
@@ -247,6 +250,55 @@ test('executor startup loss is not reported as an applied mutation', async () =>
   assert.equal(
     fake.messages.some((m) => m.type === 'execute'),
     false,
+  );
+  await sandbox.close();
+});
+
+test('executor shutdown receipt fences reuse before the OS exit event', async () => {
+  const fake = fixture((child, message) =>
+    child.emit('message', {
+      id: message.id,
+      ok: false,
+      fatal: true,
+      mutation: true,
+      code: 'EXECUTION_ABORTED',
+    }),
+  );
+  const sandbox = new NativeProcessWorkspaceCommandSandbox(
+    { workspaceRoot: '/workspace' },
+    fake.fork,
+  );
+  await assert.rejects(sandbox.execute(request));
+  await assert.rejects(sandbox.execute(request), /unavailable/);
+  assert.equal(fake.messages.filter((m) => m.type === 'execute').length, 1);
+  await sandbox.close();
+});
+
+test('executor preserves bounded startup diagnostics and conventional host settings', async () => {
+  assert.deepEqual(
+    nativeExecutorEnvironment({
+      HTTPS_PROXY: 'http://proxy:8080',
+      PATHEXT: '.EXE',
+      NODE_OPTIONS: 'unsafe',
+    }),
+    { HTTPS_PROXY: 'http://proxy:8080', PATHEXT: '.EXE' },
+  );
+  const fake = fixture(undefined, (child, message) =>
+    child.emit('message', {
+      id: message.id,
+      ok: false,
+      mutation: false,
+      code: 'COMMAND_UNAVAILABLE',
+      errorMessage: 'Native sandbox dependencies are unavailable: bubblewrap',
+    }),
+  );
+  const sandbox = new NativeProcessWorkspaceCommandSandbox(
+    { workspaceRoot: '/workspace' },
+    fake.fork,
+  );
+  await assert.rejects(
+    sandbox.prepare(),
+    /dependencies are unavailable: bubblewrap/,
   );
   await sandbox.close();
 });

--- a/packages/code/src/native-process.test.ts
+++ b/packages/code/src/native-process.test.ts
@@ -1,0 +1,252 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+import type { ChildProcess, ForkOptions } from 'node:child_process';
+import {
+  NativeProcessWorkspaceCommandSandbox,
+  nativeExecutorEnvironment,
+} from './native-process.js';
+import { WorkspaceToolError } from './workspace.js';
+
+const request = {
+  protocolVersion: 1 as const,
+  operation: 'execute_command' as const,
+  workspaceId: 'primary',
+  command: 'printf ok',
+  timeoutMs: 1000,
+  maxOutputBytes: 64,
+};
+const result = {
+  protocolVersion: 1,
+  operation: 'execute_command',
+  workspaceId: 'primary',
+  stdout: 'ok',
+  stderr: '',
+  exitCode: 0,
+  truncated: false,
+  timedOut: false,
+};
+
+function fixture(
+  execute?: (child: EventEmitter, message: Record<string, any>) => void,
+) {
+  const child = new EventEmitter() as ChildProcess;
+  let options: ForkOptions | undefined;
+  const messages: Record<string, any>[] = [];
+  Object.assign(child, {
+    connected: true,
+    send(message: Record<string, any>, callback: (error: null) => void) {
+      messages.push(message);
+      callback(null);
+      queueMicrotask(() => {
+        if (message.type === 'execute' && execute)
+          return execute(child, message);
+        if (message.type === 'cancel') return;
+        child.emit('message', {
+          id: message.id,
+          ok: true,
+          ...(message.type === 'execute' ? { result } : {}),
+        });
+      });
+      return true;
+    },
+    kill() {
+      child.emit('exit', 1);
+      return true;
+    },
+  });
+  return {
+    child,
+    messages,
+    get options() {
+      return options;
+    },
+    fork(_path: URL, args: string[], value: ForkOptions) {
+      assert.deepEqual(args, []);
+      options = value;
+      return child;
+    },
+  };
+}
+
+test('executor bootstrap excludes bridge credentials and Node injection variables', async () => {
+  assert.deepEqual(
+    nativeExecutorEnvironment({
+      PATH: '/bin',
+      HOME: '/home/user',
+      NODE_OPTIONS: '--require bad.js',
+      LIBRECHAT_CODE_WORKER_TOKEN: 'secret',
+      GITHUB_TOKEN: 'secret',
+      AWS_SECRET_ACCESS_KEY: 'secret',
+    }),
+    { PATH: '/bin', HOME: '/home/user' },
+  );
+  const fake = fixture();
+  const sandbox = new NativeProcessWorkspaceCommandSandbox(
+    {
+      workspaceRoot: '/workspace',
+      environment: {
+        PATH: '/bin',
+        NODE_OPTIONS: 'secret',
+        LIBRECHAT_CODE_WORKER_TOKEN: 'secret',
+      },
+    },
+    fake.fork,
+  );
+  await sandbox.prepare();
+  assert.deepEqual(fake.options?.execArgv, []);
+  assert.deepEqual(fake.options?.env, { PATH: '/bin' });
+  assert.equal(JSON.stringify(fake.messages).includes('secret'), false);
+  await sandbox.close();
+});
+
+test('executor hands credentials over IPC only for the current command', async () => {
+  const fake = fixture();
+  const sandbox = new NativeProcessWorkspaceCommandSandbox(
+    {
+      workspaceRoot: '/workspace',
+      maskedEnvironment: {
+        variables: [{ name: 'TOKEN', injectHosts: ['github.com'] }],
+        async resolve() {
+          return { TOKEN: 'per-command-secret' };
+        },
+        wrapCommand(command) {
+          return `wrapped ${command}`;
+        },
+      },
+    },
+    fake.fork,
+  );
+  assert.deepEqual(await sandbox.execute(request), result);
+  assert.equal(
+    JSON.stringify(fake.options).includes('per-command-secret'),
+    false,
+  );
+  assert.equal(
+    JSON.stringify(fake.messages[0]).includes('per-command-secret'),
+    false,
+  );
+  assert.deepEqual(fake.messages[1].credentials, {
+    TOKEN: 'per-command-secret',
+  });
+  assert.equal(fake.messages[1].wrappedCommand, 'wrapped printf ok');
+  await sandbox.close();
+});
+
+test('executor loss after dispatch is an uncertain mutation and is never replayed', async () => {
+  const fake = fixture((child) => child.emit('exit', 1));
+  const sandbox = new NativeProcessWorkspaceCommandSandbox(
+    { workspaceRoot: '/workspace' },
+    fake.fork,
+  );
+  await assert.rejects(
+    sandbox.execute(request),
+    (error: unknown) =>
+      error instanceof WorkspaceToolError && error.mutationMayHaveCommitted,
+  );
+  await assert.rejects(sandbox.execute(request), /unavailable/);
+  assert.equal(fake.messages.filter((m) => m.type === 'execute').length, 1);
+  await sandbox.close();
+});
+
+test('executor cancellation targets the active request and preserves mutation certainty', async () => {
+  let dispatched!: () => void;
+  const dispatch = new Promise<void>((resolve) => {
+    dispatched = resolve;
+  });
+  const fake = fixture(() => dispatched());
+  const sandbox = new NativeProcessWorkspaceCommandSandbox(
+    { workspaceRoot: '/workspace' },
+    fake.fork,
+  );
+  const controller = new AbortController();
+  const execution = sandbox.execute(request, controller.signal);
+  await dispatch;
+  await assert.rejects(sandbox.execute(request), /unavailable/);
+  controller.abort();
+  const command = fake.messages.find((m) => m.type === 'execute')!;
+  assert.deepEqual(fake.messages.at(-1), { type: 'cancel', id: command.id });
+  fake.child.emit('message', {
+    id: command.id,
+    ok: false,
+    code: 'EXECUTION_ABORTED',
+    mutation: true,
+  });
+  await assert.rejects(
+    execution,
+    (error: unknown) =>
+      error instanceof WorkspaceToolError &&
+      error.code === 'EXECUTION_ABORTED' &&
+      error.mutationMayHaveCommitted,
+  );
+  await sandbox.close();
+});
+
+test('executor rejects mismatched results as uncertain and fences subsequent commands', async () => {
+  const fake = fixture((child, message) =>
+    child.emit('message', {
+      id: message.id,
+      ok: true,
+      result: { ...result, workspaceId: 'another-workspace' },
+    }),
+  );
+  const sandbox = new NativeProcessWorkspaceCommandSandbox(
+    { workspaceRoot: '/workspace' },
+    fake.fork,
+  );
+  await assert.rejects(
+    sandbox.execute(request),
+    (error: unknown) =>
+      error instanceof WorkspaceToolError && error.mutationMayHaveCommitted,
+  );
+  await assert.rejects(sandbox.execute(request), /unavailable/);
+  await sandbox.close();
+});
+
+test('executor close drains an active command before closing IPC', async () => {
+  let dispatched!: () => void;
+  const dispatch = new Promise<void>((resolve) => {
+    dispatched = resolve;
+  });
+  const fake = fixture(() => dispatched());
+  const sandbox = new NativeProcessWorkspaceCommandSandbox(
+    { workspaceRoot: '/workspace' },
+    fake.fork,
+  );
+  const execution = sandbox.execute(request);
+  await dispatch;
+  const closing = sandbox.close();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(
+    fake.messages.some((m) => m.type === 'close'),
+    false,
+  );
+  const command = fake.messages.find((m) => m.type === 'execute')!;
+  fake.child.emit('message', { id: command.id, ok: true, result });
+  assert.deepEqual(await execution, result);
+  await closing;
+  assert.equal(fake.messages.filter((m) => m.type === 'close').length, 1);
+  await assert.rejects(sandbox.execute(request), /unavailable/);
+});
+
+test('executor startup loss is not reported as an applied mutation', async () => {
+  const fake = fixture();
+  const sandbox = new NativeProcessWorkspaceCommandSandbox(
+    { workspaceRoot: '/workspace' },
+    (path, args, options) => {
+      const child = fake.fork(path, args, options);
+      queueMicrotask(() => child.emit('error', new Error('startup failed')));
+      return child;
+    },
+  );
+  await assert.rejects(
+    sandbox.execute(request),
+    (error: unknown) =>
+      error instanceof WorkspaceToolError && !error.mutationMayHaveCommitted,
+  );
+  assert.equal(
+    fake.messages.some((m) => m.type === 'execute'),
+    false,
+  );
+  await sandbox.close();
+});

--- a/packages/code/src/native-process.test.ts
+++ b/packages/code/src/native-process.test.ts
@@ -33,6 +33,7 @@ function fixture(
 ) {
   const child = new EventEmitter() as ChildProcess;
   let options: ForkOptions | undefined;
+  let killCalls = 0;
   const messages: Record<string, any>[] = [];
   Object.assign(child, {
     connected: true,
@@ -54,11 +55,15 @@ function fixture(
       return true;
     },
     kill() {
+      killCalls += 1;
       child.emit('exit', 1);
       return true;
     },
   });
   return {
+    get killCalls() {
+      return killCalls;
+    },
     child,
     messages,
     get options() {
@@ -302,6 +307,11 @@ test('executor preserves bounded startup diagnostics and conventional host setti
   await assert.rejects(
     sandbox.prepare(),
     /dependencies are unavailable: bubblewrap/,
+  );
+  assert.equal(
+    fake.killCalls,
+    1,
+    'failed prepare must terminate without caller cleanup',
   );
   await sandbox.close();
 });

--- a/packages/code/src/native-process.test.ts
+++ b/packages/code/src/native-process.test.ts
@@ -276,11 +276,14 @@ test('executor shutdown receipt fences reuse before the OS exit event', async ()
 
 test('executor preserves bounded startup diagnostics and conventional host settings', async () => {
   assert.deepEqual(
-    nativeExecutorEnvironment({
-      HTTPS_PROXY: 'http://proxy:8080',
-      PATHEXT: '.EXE',
-      NODE_OPTIONS: 'unsafe',
-    }),
+    nativeExecutorEnvironment(
+      {
+        HTTPS_PROXY: 'http://proxy:8080',
+        PATHEXT: '.EXE',
+        NODE_OPTIONS: 'unsafe',
+      },
+      'win32',
+    ),
     { HTTPS_PROXY: 'http://proxy:8080', PATHEXT: '.EXE' },
   );
   const fake = fixture(undefined, (child, message) =>
@@ -301,4 +304,67 @@ test('executor preserves bounded startup diagnostics and conventional host setti
     /dependencies are unavailable: bubblewrap/,
   );
   await sandbox.close();
+});
+
+test('executor matches POSIX names exactly and folds names only on Windows', () => {
+  const env = {
+    PATH: '/bin',
+    Path: 'private',
+    home: 'private',
+    Temp: 'private',
+    PATHEXT: 'private',
+    https_proxy: 'http://proxy:8080',
+    custom_PROXY: 'private',
+  };
+  assert.deepEqual(nativeExecutorEnvironment(env, 'linux'), {
+    PATH: '/bin',
+    https_proxy: 'http://proxy:8080',
+  });
+  assert.deepEqual(
+    nativeExecutorEnvironment({ Path: 'C:\\bin', Temp: 'C:\\temp' }, 'win32'),
+    { Path: 'C:\\bin', Temp: 'C:\\temp' },
+  );
+});
+
+test('executor classifies every pre-dispatch setup failure as mutation-atomic', async () => {
+  for (const failure of ['fork', 'credential', 'wrapper', 'abort'] as const) {
+    const fake = fixture();
+    const controller = new AbortController();
+    const sandbox = new NativeProcessWorkspaceCommandSandbox(
+      {
+        workspaceRoot: '/workspace',
+        maskedEnvironment: {
+          variables: [],
+          async resolve() {
+            if (failure === 'abort') controller.abort();
+            if (failure === 'credential' || failure === 'abort')
+              throw new Error('private provider error');
+            return {};
+          },
+          wrapCommand(command) {
+            if (failure === 'wrapper') throw new Error('wrapper failed');
+            return command;
+          },
+        },
+      },
+      failure === 'fork'
+        ? () => {
+            throw new Error('fork failed');
+          }
+        : fake.fork,
+    );
+    await assert.rejects(
+      sandbox.execute(request, controller.signal),
+      (error: unknown) =>
+        error instanceof WorkspaceToolError &&
+        !error.mutationMayHaveCommitted &&
+        error.code ===
+          (failure === 'abort' ? 'EXECUTION_ABORTED' : 'COMMAND_UNAVAILABLE'),
+    );
+    assert.equal(
+      fake.messages.some((m) => m.type === 'execute'),
+      false,
+    );
+    await sandbox.close();
+  }
 });

--- a/packages/code/src/native-process.ts
+++ b/packages/code/src/native-process.ts
@@ -19,22 +19,12 @@ export type NativeProcessSandboxOptions = Omit<
  * In particular, never inherit NODE_OPTIONS, bridge identity, or app secrets. */
 export function nativeExecutorEnvironment(
   source: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
 ): NodeJS.ProcessEnv {
   const allowed = new Set([
     'PATH',
     'HOME',
-    'USERPROFILE',
-    'SYSTEMROOT',
-    'WINDIR',
-    'COMSPEC',
-    'TEMP',
-    'TMP',
     'TMPDIR',
-    'LOCALAPPDATA',
-    'APPDATA',
-    'PROGRAMDATA',
-    'PROGRAMFILES',
-    'PROGRAMFILES(X86)',
     'LANG',
     'LC_ALL',
     'LC_CTYPE',
@@ -44,18 +34,41 @@ export function nativeExecutorEnvironment(
     'TERM',
     'COLORTERM',
     'NO_COLOR',
-    'SYSTEMDRIVE',
-    'PATHEXT',
-    'HOMEDRIVE',
-    'HOMEPATH',
     'HTTP_PROXY',
     'HTTPS_PROXY',
     'ALL_PROXY',
     'NO_PROXY',
+    'http_proxy',
+    'https_proxy',
+    'all_proxy',
+    'no_proxy',
   ]);
+  if (platform === 'win32') {
+    for (const name of [
+      'USERPROFILE',
+      'SYSTEMROOT',
+      'WINDIR',
+      'COMSPEC',
+      'TEMP',
+      'TMP',
+      'LOCALAPPDATA',
+      'APPDATA',
+      'PROGRAMDATA',
+      'PROGRAMFILES',
+      'PROGRAMFILES(X86)',
+      'SYSTEMDRIVE',
+      'PATHEXT',
+      'HOMEDRIVE',
+      'HOMEPATH',
+    ]) {
+      allowed.add(name);
+    }
+  }
   return Object.fromEntries(
     Object.entries(source).filter(
-      ([name, value]) => value != null && allowed.has(name.toUpperCase()),
+      ([name, value]) =>
+        value != null &&
+        allowed.has(platform === 'win32' ? name.toUpperCase() : name),
     ),
   );
 }
@@ -145,7 +158,6 @@ export class NativeProcessWorkspaceCommandSandbox
             : 'COMMAND_UNAVAILABLE';
         pending.reject(
           new WorkspaceToolError(
-            !pending.mutation &&
             typeof message.errorMessage === 'string' &&
             message.errorMessage.length <= 1024
               ? message.errorMessage
@@ -214,14 +226,30 @@ export class NativeProcessWorkspaceCommandSandbox
   ): Promise<WorkspaceExecuteCommandResult> {
     if (signal?.aborted)
       throw new WorkspaceToolError('Command aborted', 'EXECUTION_ABORTED');
-    await this.prepare();
-    const credentials = await this.options.maskedEnvironment?.resolve(signal);
-    if (signal?.aborted)
-      throw new WorkspaceToolError('Command aborted', 'EXECUTION_ABORTED');
-    const wrappedCommand = this.options.maskedEnvironment?.wrapCommand?.(
-      request.command,
-      process.platform,
-    );
+    let credentials: Record<string, string> | undefined;
+    let wrappedCommand: string | undefined;
+    try {
+      await this.prepare();
+      if (signal?.aborted) throw new Error('aborted');
+      credentials = await this.options.maskedEnvironment?.resolve(signal);
+      if (signal?.aborted) throw new Error('aborted');
+      wrappedCommand = this.options.maskedEnvironment?.wrapCommand?.(
+        request.command,
+        process.platform,
+      );
+      if (signal?.aborted) throw new Error('aborted');
+    } catch (error) {
+      // No execute RPC has been sent: setup, token refresh and wrapping cannot
+      // have mutated the workspace. Do not quarantine it for setup failures.
+      if (signal?.aborted)
+        throw new WorkspaceToolError('Command aborted', 'EXECUTION_ABORTED');
+      throw error instanceof WorkspaceToolError
+        ? new WorkspaceToolError(error.message, error.code, false)
+        : new WorkspaceToolError(
+            'Native executor setup failed before dispatch',
+            'COMMAND_UNAVAILABLE',
+          );
+    }
     const result = await this.rpc(
       'execute',
       { request, credentials, wrappedCommand },

--- a/packages/code/src/native-process.ts
+++ b/packages/code/src/native-process.ts
@@ -15,7 +15,7 @@ export type NativeProcessSandboxOptions = Omit<
   'manager' | 'spawnCommand' | 'platform'
 >;
 
-/** Only operating-system discovery variables cross into the trusted executor.
+/** Only OS discovery and conventional proxy settings cross into the executor.
  * In particular, never inherit NODE_OPTIONS, bridge identity, or app secrets. */
 export function nativeExecutorEnvironment(
   source: NodeJS.ProcessEnv,
@@ -38,6 +38,20 @@ export function nativeExecutorEnvironment(
     'LANG',
     'LC_ALL',
     'LC_CTYPE',
+    'LOGNAME',
+    'USER',
+    'SHELL',
+    'TERM',
+    'COLORTERM',
+    'NO_COLOR',
+    'SYSTEMDRIVE',
+    'PATHEXT',
+    'HOMEDRIVE',
+    'HOMEPATH',
+    'HTTP_PROXY',
+    'HTTPS_PROXY',
+    'ALL_PROXY',
+    'NO_PROXY',
   ]);
   return Object.fromEntries(
     Object.entries(source).filter(
@@ -57,6 +71,7 @@ export class NativeProcessWorkspaceCommandSandbox
   private active?: Promise<WorkspaceExecuteCommandResult>;
   private closing?: Promise<void>;
   private failed = false;
+  private terminationTimer?: ReturnType<typeof setTimeout>;
   private pending?: {
     id: string;
     resolve(value: unknown): void;
@@ -107,6 +122,8 @@ export class NativeProcessWorkspaceCommandSandbox
         result?: unknown;
         mutation?: unknown;
         code?: unknown;
+        errorMessage?: unknown;
+        fatal?: unknown;
       };
       if (
         !message ||
@@ -116,6 +133,7 @@ export class NativeProcessWorkspaceCommandSandbox
         return;
       const pending = this.pending;
       if (!pending) return;
+      if (message.fatal === true) this.failed = true;
       if (message.ok === true) pending.resolve(message.result);
       else {
         const code =
@@ -127,7 +145,11 @@ export class NativeProcessWorkspaceCommandSandbox
             : 'COMMAND_UNAVAILABLE';
         pending.reject(
           new WorkspaceToolError(
-            'Native executor request failed',
+            !pending.mutation &&
+            typeof message.errorMessage === 'string' &&
+            message.errorMessage.length <= 1024
+              ? message.errorMessage
+              : 'Native executor request failed',
             code,
             pending.mutation && message.mutation !== false,
           ),
@@ -207,9 +229,16 @@ export class NativeProcessWorkspaceCommandSandbox
       true,
       signal,
     );
+    if (signal?.aborted) {
+      throw new WorkspaceToolError(
+        'Command aborted',
+        'EXECUTION_ABORTED',
+        true,
+      );
+    }
     if (!isWorkspaceToolResult(request, result)) {
       this.failed = true;
-      this.child?.kill();
+      this.terminate();
       throw this.unavailable(true);
     }
     return result as WorkspaceExecuteCommandResult;
@@ -228,23 +257,35 @@ export class NativeProcessWorkspaceCommandSandbox
     const child = this.child;
     let timer: ReturnType<typeof setTimeout>;
     const abort = () => {
-      if (child.connected) child.send({ type: 'cancel', id }, () => undefined);
+      try {
+        if (child.connected)
+          child.send({ type: 'cancel', id }, () => undefined);
+      } catch {
+        this.failed = true;
+        this.terminate();
+      }
     };
     try {
       return await new Promise((resolve, reject) => {
         this.pending = { id, resolve, reject, mutation };
         timer = setTimeout(() => {
           this.failed = true;
-          child.kill();
+          this.terminate();
           reject(this.unavailable(mutation));
         }, timeoutMs);
         signal?.addEventListener('abort', abort, { once: true });
-        child.send({ type, id, ...payload }, (error) => {
-          if (error) {
-            this.failed = true;
-            reject(this.unavailable(mutation));
-          }
-        });
+        const sendFailed = () => {
+          this.failed = true;
+          this.terminate();
+          reject(this.unavailable(mutation));
+        };
+        try {
+          child.send({ type, id, ...payload }, (error) => {
+            if (error) sendFailed();
+          });
+        } catch {
+          sendFailed();
+        }
         if (signal?.aborted) abort();
       });
     } finally {
@@ -268,7 +309,17 @@ export class NativeProcessWorkspaceCommandSandbox
         await this.rpc('close', {}, 10_000, false);
     } finally {
       this.failed = true;
-      this.child?.kill();
+      this.terminate();
     }
+  }
+
+  private terminate(): void {
+    const child = this.child;
+    if (!child || this.terminationTimer) return;
+    // Give SRT time to abort/reap its command, then bound executor shutdown.
+    this.terminationTimer = setTimeout(() => child.kill('SIGKILL'), 6000);
+    this.terminationTimer.unref();
+    child.once('exit', () => clearTimeout(this.terminationTimer));
+    child.kill('SIGTERM');
   }
 }

--- a/packages/code/src/native-process.ts
+++ b/packages/code/src/native-process.ts
@@ -196,7 +196,11 @@ export class NativeProcessWorkspaceCommandSandbox
       },
       30_000,
       false,
-    );
+    ).catch((error) => {
+      this.failed = true;
+      this.terminate();
+      throw error;
+    });
   }
 
   async execute(

--- a/packages/code/src/native-process.ts
+++ b/packages/code/src/native-process.ts
@@ -1,0 +1,274 @@
+import { fork } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { WorkspaceToolError } from './workspace.js';
+import { isWorkspaceToolRequest, isWorkspaceToolResult } from './protocol.js';
+import type { ChildProcess, ForkOptions } from 'node:child_process';
+import type { NativeSrtWorkspaceCommandSandboxOptions } from './native-sandbox.js';
+import type { WorkspaceCommandSandbox } from './workspace.js';
+import type {
+  WorkspaceExecuteCommandRequest,
+  WorkspaceExecuteCommandResult,
+} from './protocol.js';
+
+export type NativeProcessSandboxOptions = Omit<
+  NativeSrtWorkspaceCommandSandboxOptions,
+  'manager' | 'spawnCommand' | 'platform'
+>;
+
+/** Only operating-system discovery variables cross into the trusted executor.
+ * In particular, never inherit NODE_OPTIONS, bridge identity, or app secrets. */
+export function nativeExecutorEnvironment(
+  source: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const allowed = new Set([
+    'PATH',
+    'HOME',
+    'USERPROFILE',
+    'SYSTEMROOT',
+    'WINDIR',
+    'COMSPEC',
+    'TEMP',
+    'TMP',
+    'TMPDIR',
+    'LOCALAPPDATA',
+    'APPDATA',
+    'PROGRAMDATA',
+    'PROGRAMFILES',
+    'PROGRAMFILES(X86)',
+    'LANG',
+    'LC_ALL',
+    'LC_CTYPE',
+  ]);
+  return Object.fromEntries(
+    Object.entries(source).filter(
+      ([name, value]) => value != null && allowed.has(name.toUpperCase()),
+    ),
+  );
+}
+
+/** One persistent, process-isolated SRT manager per workspace. No automatic
+ * restart/replay: losing IPC after execution starts is an ambiguous mutation. */
+export class NativeProcessWorkspaceCommandSandbox
+  implements WorkspaceCommandSandbox
+{
+  readonly mutationFailuresAreAtomic = true as const;
+  private child?: ChildProcess;
+  private ready?: Promise<void>;
+  private active?: Promise<WorkspaceExecuteCommandResult>;
+  private closing?: Promise<void>;
+  private failed = false;
+  private pending?: {
+    id: string;
+    resolve(value: unknown): void;
+    reject(error: Error): void;
+    mutation: boolean;
+  };
+
+  constructor(
+    private readonly options: NativeProcessSandboxOptions,
+    private readonly forkExecutor: (
+      path: URL,
+      args: string[],
+      options: ForkOptions,
+    ) => ChildProcess = fork,
+  ) {}
+
+  async prepare(): Promise<void> {
+    if (this.failed || this.closing) throw this.unavailable(false);
+    if (this.ready) return this.ready;
+    this.ready = this.start();
+    return this.ready;
+  }
+
+  private unavailable(mutation: boolean): WorkspaceToolError {
+    return new WorkspaceToolError(
+      'Native executor is unavailable',
+      'COMMAND_UNAVAILABLE',
+      mutation,
+    );
+  }
+
+  private async start(): Promise<void> {
+    const child = this.forkExecutor(
+      new URL('./native-process-child.js', import.meta.url),
+      [],
+      {
+        execArgv: [],
+        env: nativeExecutorEnvironment(this.options.environment ?? process.env),
+        stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+        serialization: 'json',
+      },
+    );
+    this.child = child;
+    child.on('message', (raw: unknown) => {
+      const message = raw as {
+        id?: unknown;
+        ok?: unknown;
+        result?: unknown;
+        mutation?: unknown;
+        code?: unknown;
+      };
+      if (
+        !message ||
+        typeof message !== 'object' ||
+        message.id !== this.pending?.id
+      )
+        return;
+      const pending = this.pending;
+      if (!pending) return;
+      if (message.ok === true) pending.resolve(message.result);
+      else {
+        const code =
+          message.code === 'INVALID_PATH' ||
+          message.code === 'INVALID_REQUEST' ||
+          message.code === 'EXECUTION_ABORTED' ||
+          message.code === 'REGISTRATION_INVALID'
+            ? message.code
+            : 'COMMAND_UNAVAILABLE';
+        pending.reject(
+          new WorkspaceToolError(
+            'Native executor request failed',
+            code,
+            pending.mutation && message.mutation !== false,
+          ),
+        );
+      }
+    });
+    const lost = () => {
+      this.failed = true;
+      this.pending?.reject(this.unavailable(this.pending.mutation));
+    };
+    child.on('error', lost);
+    child.on('exit', lost);
+    child.on('disconnect', lost);
+    const {
+      workspaceRoot,
+      protectedPaths,
+      allowedDomains,
+      homeDirectory,
+      shellPath,
+    } = this.options;
+    await this.rpc(
+      'prepare',
+      {
+        options: {
+          workspaceRoot,
+          protectedPaths,
+          allowedDomains,
+          homeDirectory,
+          shellPath,
+          variables: this.options.maskedEnvironment?.variables,
+        },
+      },
+      30_000,
+      false,
+    );
+  }
+
+  async execute(
+    request: WorkspaceExecuteCommandRequest,
+    signal?: AbortSignal,
+  ): Promise<WorkspaceExecuteCommandResult> {
+    if (
+      !isWorkspaceToolRequest(request) ||
+      request.operation !== 'execute_command'
+    ) {
+      throw new WorkspaceToolError('Invalid native command', 'INVALID_REQUEST');
+    }
+    if (this.active || this.closing || this.failed)
+      throw this.unavailable(false);
+    const active = this.executeOnce(request, signal);
+    this.active = active;
+    try {
+      return await active;
+    } finally {
+      this.active = undefined;
+    }
+  }
+
+  private async executeOnce(
+    request: WorkspaceExecuteCommandRequest,
+    signal?: AbortSignal,
+  ): Promise<WorkspaceExecuteCommandResult> {
+    if (signal?.aborted)
+      throw new WorkspaceToolError('Command aborted', 'EXECUTION_ABORTED');
+    await this.prepare();
+    const credentials = await this.options.maskedEnvironment?.resolve(signal);
+    if (signal?.aborted)
+      throw new WorkspaceToolError('Command aborted', 'EXECUTION_ABORTED');
+    const wrappedCommand = this.options.maskedEnvironment?.wrapCommand?.(
+      request.command,
+      process.platform,
+    );
+    const result = await this.rpc(
+      'execute',
+      { request, credentials, wrappedCommand },
+      (request.timeoutMs ?? 30_000) + 5_000,
+      true,
+      signal,
+    );
+    if (!isWorkspaceToolResult(request, result)) {
+      this.failed = true;
+      this.child?.kill();
+      throw this.unavailable(true);
+    }
+    return result as WorkspaceExecuteCommandResult;
+  }
+
+  private async rpc(
+    type: string,
+    payload: object,
+    timeoutMs: number,
+    mutation: boolean,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    if (this.pending || !this.child?.connected || this.failed)
+      throw this.unavailable(false);
+    const id = randomUUID();
+    const child = this.child;
+    let timer: ReturnType<typeof setTimeout>;
+    const abort = () => {
+      if (child.connected) child.send({ type: 'cancel', id }, () => undefined);
+    };
+    try {
+      return await new Promise((resolve, reject) => {
+        this.pending = { id, resolve, reject, mutation };
+        timer = setTimeout(() => {
+          this.failed = true;
+          child.kill();
+          reject(this.unavailable(mutation));
+        }, timeoutMs);
+        signal?.addEventListener('abort', abort, { once: true });
+        child.send({ type, id, ...payload }, (error) => {
+          if (error) {
+            this.failed = true;
+            reject(this.unavailable(mutation));
+          }
+        });
+        if (signal?.aborted) abort();
+      });
+    } finally {
+      clearTimeout(timer!);
+      signal?.removeEventListener('abort', abort);
+      this.pending = undefined;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.closing) return this.closing;
+    this.closing = this.stop();
+    return this.closing;
+  }
+
+  private async stop(): Promise<void> {
+    await this.active?.catch(() => undefined);
+    await this.ready?.catch(() => undefined);
+    try {
+      if (this.child?.connected && !this.failed)
+        await this.rpc('close', {}, 10_000, false);
+    } finally {
+      this.failed = true;
+      this.child?.kill();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

I moved native CLI command execution into a persistent, isolated Node process so SRT policy and cleanup state no longer share the bridge process.

- Keep pairing credentials and GitHub App identity management in the bridge.
- Pass workspace policy and per-command credential material over IPC, excluding arbitrary inherited environment and Node loader options.
- Route cancellation to the active command and preserve mutation uncertainty after executor loss.
- Reject malformed results and prevent automatic replay or reuse of a failed executor.
- Close executor processes after startup failure and orderly worker shutdown.
- Export the process executor for embedding applications and document the remaining serial scheduler boundary.

This is the native execution-isolation layer for BYOM concurrency. It does not enable parallel Code API assignments: negotiated slots and workspace-scoped quarantine remain follow-up work. Existing worker wire protocol and serial dispatch remain compatible.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- Passed eleven focused IPC lifecycle, credential isolation, cancellation, malformed-result, startup-diagnostic, platform-environment and executor-loss tests, plus three focused CLI preflight regressions. Pre-dispatch coverage includes fork, credential, wrapper, and cancellation failures.
- Passed the code package TypeScript build/typecheck and `git diff --check`.
- Verified two real native SRT executor processes on macOS: concurrent one-second commands completed in approximately 1.18 seconds with independent workspace outputs; cancellation in one did not interrupt the other.
- Verified real SRT masking across IPC and executor-loss handling: uncertain outcome, fenced reuse, and graceful termination reaping the running command.
- Passed three focused subprocess signal tests and live native SRT SIGINT/SIGHUP/SIGTERM checks, verifying command reaping and executor fencing.
- Left broad suites/platform matrices to CI. Codegraph selector access is unavailable locally without its bearer token; local checks are source-selected.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
