### PR TITLE
fix: Preserve Replacement Bridge Lease Ownership

### DIFF
--- a/service/src/bridge/cleanup-ownership.test.ts
+++ b/service/src/bridge/cleanup-ownership.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import Redis from 'ioredis';
 import RedisMock from 'ioredis-mock';
 import { RedisBridgeStore } from './store';
@@ -24,38 +24,59 @@ for (const backend of ['mock', 'redis'] as const) {
       redis.disconnect();
     });
 
-    for (const acknowledged of [false, true]) {
-      test(`delayed cleanup preserves replacement lease (acknowledged=${acknowledged})`, async () => {
-        prefix = `cleanup-test:${randomUUID()}:`;
-        if (backend === 'redis') {
-          admin = new Redis(redisUrl!);
-          redis = new Redis(redisUrl!, { keyPrefix: prefix });
-        } else {
-          redis = new RedisMock() as unknown as Redis;
-        }
-        const store = new RedisBridgeStore(redis);
-        const workerId = 'cleanup-owner';
-        const incarnationId = 'cleanup-incarnation';
-        const claim = `codeapi:bridge:v1:worker:${workerId}:incarnation:${incarnationId}:lease-claim`;
-        const ack = `codeapi:bridge:v1:worker:${workerId}:incarnation:${incarnationId}:lease-ack`;
-        const assignmentId = 'old-assignment';
-        const replacementId = 'replacement-assignment';
-        const lock = `codeapi:bridge:v1:worker:${workerId}:lock`;
-        await redis.set(claim, replacementId);
-        if (acknowledged) await redis.set(ack, replacementId);
-        await redis.set(lock, replacementId);
-        await redis.set(`codeapi:bridge:v1:assignment:${assignmentId}`, '{}');
-        // Model an already-issued cleanup that resumes after the worker's
-        // previous lock expired and a replacement assignment claimed it.
-        const cleanupStore = store as unknown as {
-          cleanup(assignment: CodeBridgeAssignment): Promise<void>;
-        };
-        await cleanupStore.cleanup({ workerId, incarnationId, assignmentId } as CodeBridgeAssignment);
-        expect(await redis.get(claim)).toBe(replacementId);
-        expect(await redis.get(ack)).toBe(acknowledged ? replacementId : null);
-        expect(await redis.get(lock)).toBe(replacementId);
-        expect(await redis.get(`codeapi:bridge:v1:assignment:${assignmentId}`)).toBeNull();
-      });
+    for (const stateful of [false, true]) {
+      for (const acknowledged of [false, true]) {
+        test(`delayed cleanup preserves replacement lease (acknowledged=${acknowledged}, stateful=${stateful})`, async () => {
+          prefix = `cleanup-test:${randomUUID()}:`;
+          if (backend === 'redis') {
+            admin = new Redis(redisUrl!);
+            redis = new Redis(redisUrl!, { keyPrefix: prefix });
+          } else {
+            redis = new RedisMock() as unknown as Redis;
+          }
+          const store = new RedisBridgeStore(redis);
+          const workerId = 'cleanup-owner';
+          const incarnationId = 'cleanup-incarnation';
+          const claim = `codeapi:bridge:v1:worker:${workerId}:incarnation:${incarnationId}:lease-claim`;
+          const ack = `codeapi:bridge:v1:worker:${workerId}:incarnation:${incarnationId}:lease-ack`;
+          const assignmentId = 'old-assignment';
+          const replacementId = 'replacement-assignment';
+          const lock = `codeapi:bridge:v1:worker:${workerId}:lock`;
+          const runtimeSessionId = stateful ? 'old-workspace' : undefined;
+          const marker = `codeapi:bridge:v1:worker:${workerId}:workspace:${createHash(
+            'sha256',
+          )
+            .update(runtimeSessionId ?? '')
+            .digest('hex')}:quarantined`;
+          await redis.set(claim, replacementId);
+          if (acknowledged) await redis.set(ack, replacementId);
+          await redis.set(lock, replacementId);
+          await redis.set(`codeapi:bridge:v1:assignment:${assignmentId}`, '{}');
+          if (stateful) await redis.set(marker, assignmentId);
+          // Model an already-issued cleanup that resumes after the worker's
+          // previous lock expired and a replacement assignment claimed it.
+          const cleanupStore = store as unknown as {
+            cleanup(assignment: CodeBridgeAssignment): Promise<void>;
+          };
+          await cleanupStore.cleanup({
+            workerId,
+            incarnationId,
+            assignmentId,
+            runtimeSessionId,
+          } as CodeBridgeAssignment);
+          expect(await redis.get(claim)).toBe(replacementId);
+          expect(await redis.get(ack)).toBe(
+            acknowledged ? replacementId : null,
+          );
+          expect(await redis.get(lock)).toBe(replacementId);
+          expect(
+            await redis.get(`codeapi:bridge:v1:assignment:${assignmentId}`),
+          ).toBeNull();
+          // Unknown previous execution must remain fenced, independently of
+          // the newer assignment's claim and lock.
+          if (stateful) expect(await redis.get(marker)).toBe(assignmentId);
+        });
+      }
     }
   });
 }

--- a/service/src/bridge/cleanup-ownership.test.ts
+++ b/service/src/bridge/cleanup-ownership.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import Redis from 'ioredis';
+import RedisMock from 'ioredis-mock';
+import { RedisBridgeStore } from './store';
+import type { CodeBridgeAssignment } from './store';
+
+const redisUrl = process.env.BRIDGE_TEST_REDIS_URL;
+for (const backend of ['mock', 'redis'] as const) {
+  const suite = backend === 'redis' && !redisUrl ? describe.skip : describe;
+  suite(`lease cleanup ownership (${backend})`, () => {
+    let redis: Redis;
+    let admin: Redis | undefined;
+    let prefix: string;
+    afterEach(async () => {
+      if (admin) {
+        const keys = await admin.keys(`${prefix}*`);
+        if (keys.length) await admin.del(...keys);
+        admin.disconnect();
+        admin = undefined;
+      } else {
+        await redis.flushall();
+      }
+      redis.disconnect();
+    });
+
+    for (const acknowledged of [false, true]) {
+      test(`delayed cleanup preserves replacement lease (acknowledged=${acknowledged})`, async () => {
+        prefix = `cleanup-test:${randomUUID()}:`;
+        if (backend === 'redis') {
+          admin = new Redis(redisUrl!);
+          redis = new Redis(redisUrl!, { keyPrefix: prefix });
+        } else {
+          redis = new RedisMock() as unknown as Redis;
+        }
+        const store = new RedisBridgeStore(redis);
+        const workerId = 'cleanup-owner';
+        const incarnationId = 'cleanup-incarnation';
+        const claim = `codeapi:bridge:v1:worker:${workerId}:incarnation:${incarnationId}:lease-claim`;
+        const ack = `codeapi:bridge:v1:worker:${workerId}:incarnation:${incarnationId}:lease-ack`;
+        const assignmentId = 'old-assignment';
+        const replacementId = 'replacement-assignment';
+        const lock = `codeapi:bridge:v1:worker:${workerId}:lock`;
+        await redis.set(claim, replacementId);
+        if (acknowledged) await redis.set(ack, replacementId);
+        await redis.set(lock, replacementId);
+        await redis.set(`codeapi:bridge:v1:assignment:${assignmentId}`, '{}');
+        // Model an already-issued cleanup that resumes after the worker's
+        // previous lock expired and a replacement assignment claimed it.
+        const cleanupStore = store as unknown as {
+          cleanup(assignment: CodeBridgeAssignment): Promise<void>;
+        };
+        await cleanupStore.cleanup({ workerId, incarnationId, assignmentId } as CodeBridgeAssignment);
+        expect(await redis.get(claim)).toBe(replacementId);
+        expect(await redis.get(ack)).toBe(acknowledged ? replacementId : null);
+        expect(await redis.get(lock)).toBe(replacementId);
+        expect(await redis.get(`codeapi:bridge:v1:assignment:${assignmentId}`)).toBeNull();
+      });
+    }
+  });
+}

--- a/service/src/bridge/store.ts
+++ b/service/src/bridge/store.ts
@@ -1785,7 +1785,11 @@ export class RedisBridgeStore {
       'if queued == 0 and acknowledged and ARGV[2] == "1" and redis.call(\'GET\', KEYS[5]) == ARGV[1] then',
       '  return -1',
       'end',
-      "return redis.call('DEL', KEYS[1], KEYS[3], KEYS[4])",
+      // A delayed cleanup can outlive its lock. Never erase the next
+      // assignment's claim or acknowledgement when that happens.
+      "if claimed then redis.call('DEL', KEYS[3]) end",
+      "if acknowledged then redis.call('DEL', KEYS[4]) end",
+      "return redis.call('DEL', KEYS[1])",
     ].join('\n');
     const cleanupResult = Number(
       await boundedCommand(


### PR DESCRIPTION
## Summary

I fixed a delayed bridge cleanup deleting a newer assignment's lease claim and acknowledgement after the original lock expires.

- Preserve claim and acknowledgement keys unless they belong to the assignment being cleaned up.
- Keep assignment deletion and lock-release ownership checks intact.
- Add focused regression coverage for acknowledged and unacknowledged replacement leases, with optional real Redis verification.

This is a prerequisite ownership fix for bounded concurrent worker leases; it does not enable concurrent dispatch.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Reproduced both replacement-lease regressions before the fix.
- Passed eight cleanup ownership cases across Redis mock and an isolated real Redis server, including stateful quarantine preservation.
- Passed two existing focused cleanup/finalization tests.
- Passed scoped TypeScript checking and `git diff --check`.
- Used source-based test selection because the Codegraph selector credential was unavailable; rely on CI for full suites.

Reproduce with `bun test service/src/bridge/cleanup-ownership.test.ts`. Set `BRIDGE_TEST_REDIS_URL` to an isolated test Redis endpoint to also exercise real Redis.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
