### PR TITLE
fix: helm egress deployment getting stuck on install

### DIFF
--- a/helm/codeapi/templates/egress-gateway-deployment.yaml
+++ b/helm/codeapi/templates/egress-gateway-deployment.yaml
@@ -24,10 +24,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.egressGrant.ledgerRequired }}
       initContainers:
         - name: wait-for-redis
           image: busybox:1.36.1
           command: ['sh', '-c', 'until nc -z {{ include "codeapi.redis.host" . }} {{ include "codeapi.redis.port" . }}; do echo waiting for redis; sleep 2; done']
+      {{- end }}
       containers:
         - name: egress-gateway
           image: "{{ .Values.egressGateway.image.repository }}:{{ .Values.egressGateway.image.tag }}"

--- a/helm/codeapi/templates/egress-gateway-deployment.yaml
+++ b/helm/codeapi/templates/egress-gateway-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.egressGrant.ledgerRequired }}
+      {{- if or .Values.egressGrant.ledgerRequired .Values.hardenedSandboxMode }}
       initContainers:
         - name: wait-for-redis
           image: busybox:1.36.1

--- a/helm/codeapi/templates/egress-gateway-deployment.yaml
+++ b/helm/codeapi/templates/egress-gateway-deployment.yaml
@@ -24,6 +24,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        - name: wait-for-redis
+          image: busybox:1.36.1
+          command: ['sh', '-c', 'until nc -z {{ include "codeapi.redis.host" . }} {{ include "codeapi.redis.port" . }}; do echo waiting for redis; sleep 2; done']
       containers:
         - name: egress-gateway
           image: "{{ .Values.egressGateway.image.repository }}:{{ .Values.egressGateway.image.tag }}"


### PR DESCRIPTION
The egress-deployment only tries to connect to redis 5 times before giving up. This change ensures that redis is running before trying the first time.
