### PR TITLE
fix: fail denied input downloads once per batch

### DIFF
--- a/api/src/download.test.ts
+++ b/api/src/download.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, spyOn } from 'bun:test';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -437,6 +437,74 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
     expect(writtenName).toBe('你好.txt');
     const contents = await fsp.readFile(path.join(tmpDir, '你好.txt'), 'utf8');
     expect(contents).toBe('hi');
+  });
+
+  it.each([401, 403])('does not retry an HTTP %i authorization denial', async status => {
+    const file: TFile = { id: 'denied', storage_session_id: 'previous', name: 'denied.txt' };
+    let requests = 0;
+    routes.set('/sessions/previous/objects/denied', {
+      status,
+      onRequest: () => { requests++; },
+    });
+    const job = makeJob([file]);
+    asInternals(job).submissionDir = tmpDir;
+
+    await expect(job.downloadAndWriteFile(file, 5, 1)).rejects.toThrow(`HTTP error: ${status}`);
+    expect(requests).toBe(1);
+    expect(await fsp.readdir(tmpDir)).toEqual([]);
+  });
+
+  it.each([404, 408, 429, 503])('still retries transient HTTP %i responses', async status => {
+    const file: TFile = { id: 'transient', storage_session_id: 'previous', name: 'ready.txt' };
+    let requests = 0;
+    const route: Route = {
+      status,
+      body: 'ready',
+      onRequest: () => { if (++requests === 2) route.status = 200; },
+    };
+    routes.set('/sessions/previous/objects/transient', route);
+    const job = makeJob([file]);
+    asInternals(job).submissionDir = tmpDir;
+
+    await expect(job.downloadAndWriteFile(file, 5, 1)).resolves.toBe('ready.txt');
+    expect(requests).toBe(2);
+    expect(await fsp.readFile(path.join(tmpDir, 'ready.txt'), 'utf8')).toBe('ready');
+  });
+
+  it('accounts for a denied 240-file batch once and stops queued downloads', async () => {
+    const files: TFile[] = Array.from({ length: 240 }, (_, index) => ({
+      id: `file-${index}`, storage_session_id: 'previous', name: `file-${index}.txt`,
+    }));
+    let requests = 0;
+    routes.set('/sessions/previous/objects', { status: 200, body: '[]' });
+    for (const file of files) {
+      routes.set(`/sessions/previous/objects/${file.id}`, {
+        status: 403,
+        delayMs: file.id === 'file-0' ? 0 : 30,
+        onRequest: () => { requests++; },
+      });
+    }
+    let dirty = false;
+    const job = makeJob(files, sessionWorkspaceAt(tmpDir, 'batch-test', () => { dirty = true; }));
+    const log = (job as unknown as { log: import('pino').Logger }).log;
+    const errorLog = spyOn(log, 'error');
+    const originalConcurrency = config.prime_concurrency;
+    config.prime_concurrency = 8;
+    try {
+      await expect(job.prime()).rejects.toBeInstanceOf(SessionWorkspaceDirtyError);
+      expect(dirty).toBe(true);
+      expect(requests).toBeGreaterThan(0);
+      expect(requests).toBeLessThanOrEqual(8);
+      expect(errorLog).toHaveBeenCalledTimes(1);
+      expect(errorLog).toHaveBeenCalledWith(expect.objectContaining({
+        inputCount: 240, completed: 0, failed: 1, cancelled: 7, notStarted: 232,
+      }), 'Input preparation batch failed');
+      expect(await fsp.readdir(tmpDir)).toEqual([]);
+    } finally {
+      errorLog.mockRestore();
+      config.prime_concurrency = originalConcurrency;
+      await job.cleanup();
+    }
   });
 
   it('fails when the server keeps 404-ing past the retry cap (no phantom write)', async () => {

--- a/api/src/job.ts
+++ b/api/src/job.ts
@@ -60,6 +60,14 @@ export {
 const AUTO_LOAD_DIRKEEP_TIMEOUT_MS = 10000;
 const AUTO_LOAD_DIRKEEP_RETRIES = 2;
 
+/** Replaying the same sealed grant cannot repair an authorization denial. */
+class InputAuthorizationError extends Error {
+  constructor(status: number) {
+    super(`HTTP error: ${status}`);
+    this.name = 'InputAuthorizationError';
+  }
+}
+
 /**
  * Bridges a `fetch` response body to a Node-stream Readable. The types at the
  * module boundary (Node's `stream/web` vs. lib.dom) don't overlap cleanly,
@@ -993,11 +1001,18 @@ export class Job {
       submissionDir: this.submissionDir,
       identity: this.jobIdentity,
     };
+    const startedAt = performance.now();
+    let started = 0;
+    let completed = 0;
+    let cancelled = 0;
     let firstFailure: { error: unknown } | undefined;
     const runFileOperation = async (operation: () => Promise<void>): Promise<void> => {
+      started++;
       try {
         await operation();
+        completed++;
       } catch (error) {
+        if (firstFailure) cancelled++;
         if (!firstFailure) {
           firstFailure = { error };
           controller.abort(error);
@@ -1031,6 +1046,15 @@ export class Job {
       Array.from({ length: workerCount }, () => runPrimeWorker()),
     );
     if (firstFailure) {
+      this.log.error({
+        inputCount: fileOps.length,
+        completed,
+        failed: 1,
+        cancelled,
+        notStarted: fileOps.length - started,
+        durationMs: Math.round(performance.now() - startedAt),
+        err: firstFailure.error,
+      }, 'Input preparation batch failed');
       if (this.session) {
         /* A sibling may already have atomically replaced its destination. The
          * workspace now matches neither the previous checkpoint nor the full
@@ -1302,6 +1326,9 @@ export class Job {
 
         if (!response.ok) {
           await response.body?.cancel().catch(() => {});
+          if (response.status === 401 || response.status === 403) {
+            throw new InputAuthorizationError(response.status);
+          }
           throw new Error(`HTTP error: ${response.status}`);
         }
 
@@ -1366,11 +1393,10 @@ export class Job {
           try { await fsp.unlink(tempPath); } catch { /* may not exist */ }
           throw abortReason(operation.signal);
         }
-        /* ValidationError is deterministic — a bad Content-Disposition
-         * filename will fail identically on every retry. Abort fast
-         * (cleanup + rethrow) instead of burning ~7.5s on exponential
-         * backoff and surfacing the error as a generic download failure. */
-        if (error instanceof ValidationError) {
+        /* Invalid filenames and authorization denials cannot recover by
+         * replaying the same request. Abort the batch before exponential
+         * backoff amplifies the failure across its remaining files. */
+        if (error instanceof ValidationError || error instanceof InputAuthorizationError) {
           try { await fsp.unlink(tempPath); } catch { /* may not exist */ }
           throw error;
         }
@@ -1383,7 +1409,9 @@ export class Job {
       }
     }
 
-    this.log.error({ fileId: file.id, maxRetries, err: lastError }, 'Failed to download file');
+    if (!context?.signal) {
+      this.log.error({ fileId: file.id, maxRetries, err: lastError }, 'Failed to download file');
+    }
     try { await fsp.unlink(tempPath); } catch { /* may not exist */ }
     throw lastError ?? new Error(`Failed to download input ${file.id}`);
   }


### PR DESCRIPTION
## Summary

I stop repeated authorization-denied downloads and report input-preparation failures once per batch. Previously each denied file could retry with the same authorization and emit its own terminal error while sibling downloads continued.

- Stop retries on HTTP 401/403 input responses.
- Abort and settle sibling workers after a terminal failure.
- Report completed, failed, cancelled, not-started, and elapsed batch values.
- Preserve transient download retries and cleanup behavior.

**Follow-up:** #179 distinguishes permanent denials from transient Redis ledger conflicts and preserves unclassified legacy 403 retries. That correction is separate from this merged change.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Run focused download, job cleanup, inline priming atomicity, and session-input priming tests: 32 passed. A 240-file denial case verifies bounded admission, sibling cancellation, one batch error, and cleanup. `git diff --check` passed. API typechecking reproduced the same eight diagnostics on the untouched baseline with identical dependencies.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
