### PR TITLE
fix: preserve retries for transient egress ledger conflicts

### DIFF
--- a/api/src/download.test.ts
+++ b/api/src/download.test.ts
@@ -55,6 +55,7 @@ function makeRuntime(): Runtime {
 function makeJob(files: TFile[] = [], session?: SessionWorkspace): Job {
   return new Job({
     session_id: 'test-session',
+    egress_grant: 'test-grant',
     runtime: makeRuntime(),
     files,
     args: [],
@@ -456,6 +457,7 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
   });
 
   it.each([403, 404, 408, 429, 503])('still retries transient HTTP %i responses', async status => {
+    config.egress_gateway_url = `http://127.0.0.1:${serverPort}`;
     const file: TFile = { id: 'transient', storage_session_id: 'previous', name: 'ready.txt' };
     let requests = 0;
     const route: Route = {
@@ -470,6 +472,41 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
     await expect(job.downloadAndWriteFile(file, 5, 1)).resolves.toBe('ready.txt');
     expect(requests).toBe(2);
     expect(await fsp.readFile(path.join(tmpDir, 'ready.txt'), 'utf8')).toBe('ready');
+  });
+
+  it('does not retry an unclassified direct file-server denial', async () => {
+    config.egress_gateway_url = '';
+    let requests = 0;
+    const file: TFile = { id: 'denied', storage_session_id: 'previous', name: 'denied.txt' };
+    routes.set('/sessions/previous/objects/denied', {
+      status: 403, onRequest: () => { requests++; },
+    });
+    const job = makeJob([file]);
+    asInternals(job).submissionDir = tmpDir;
+    await expect(job.downloadAndWriteFile(file, 5, 1)).rejects.toThrow('HTTP error: 403');
+    expect(requests).toBe(1);
+  });
+
+  it.each(['legacy', 'classified', 'direct'])('handles %s marker denials before priming', async mode => {
+    config.egress_gateway_url = mode === 'direct' ? '' : `http://127.0.0.1:${serverPort}`;
+    let requests = 0;
+    const route: Route = {
+      status: 403, body: '[]',
+      headers: mode === 'classified' ? { 'X-CodeAPI-Error-Code': 'scope_mismatch' } : {},
+      onRequest: () => { if (++requests === 2) route.status = 200; },
+    };
+    routes.set('/sessions/previous/objects', route);
+    const file: TFile = { id: 'ready', storage_session_id: 'previous', name: 'ready.txt' };
+    routes.set('/sessions/previous/objects/ready', { status: 200, body: 'ready' });
+    const job = makeJob([file], sessionWorkspaceAt(tmpDir, 'marker-retry'));
+    if (mode === 'legacy') {
+      await job.prime();
+      expect(requests).toBe(2);
+      expect(await fsp.readFile(path.join(tmpDir, 'ready.txt'), 'utf8')).toBe('ready');
+    } else {
+      await expect(job.prime()).rejects.toThrow('HTTP error loading .dirkeep markers: 403');
+      expect(requests).toBe(1);
+    }
   });
 
   it('accounts for a denied 240-file batch once and stops queued downloads', async () => {

--- a/api/src/download.test.ts
+++ b/api/src/download.test.ts
@@ -475,6 +475,42 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
     expect(await fsp.readFile(path.join(tmpDir, 'ready.txt'), 'utf8')).toBe('ready');
   });
 
+  it.each([false, true])('honors conflict retry hints with cancellation=%s', async cancel => {
+    config.egress_gateway_url = `http://127.0.0.1:${serverPort}`;
+    const controller = new AbortController();
+    const timestamps: number[] = [];
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const route: Route = {
+      status: 503, body: 'ready',
+      headers: { 'X-CodeAPI-Error-Code': 'ledger_conflict', 'Retry-After': '1' },
+      onRequest: () => {
+        timestamps.push(performance.now());
+        if (timestamps.length === 2) route.status = 200;
+        else if (cancel) timer = setTimeout(() => controller.abort(new Error('cancelled retry')), 25);
+      },
+    };
+    routes.set('/sessions/previous/objects/retry-hint', route);
+    const file: TFile = { id: 'retry-hint', storage_session_id: 'previous', name: 'ready.txt' };
+    const job = makeJob([file]);
+    asInternals(job).submissionDir = tmpDir;
+    try {
+      const result = job.downloadAndWriteFile(file, 5, 1, {
+        submissionDir: tmpDir, identity: fallbackSandboxIdentity(), signal: controller.signal,
+      });
+      if (cancel) {
+        await expect(result).rejects.toThrow('cancelled retry');
+        expect(timestamps).toHaveLength(1);
+        expect(await fsp.readdir(tmpDir)).toEqual([]);
+      } else {
+        await expect(result).resolves.toBe('ready.txt');
+        expect(timestamps).toHaveLength(2);
+        expect(timestamps[1] - timestamps[0]).toBeGreaterThanOrEqual(900);
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
   it('does not retry an unclassified direct file-server denial', async () => {
     config.egress_gateway_url = '';
     let requests = 0;

--- a/api/src/download.test.ts
+++ b/api/src/download.test.ts
@@ -444,6 +444,7 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
     let requests = 0;
     routes.set('/sessions/previous/objects/denied', {
       status,
+      headers: { 'X-CodeAPI-Error-Code': 'scope_mismatch' },
       onRequest: () => { requests++; },
     });
     const job = makeJob([file]);
@@ -454,7 +455,7 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
     expect(await fsp.readdir(tmpDir)).toEqual([]);
   });
 
-  it.each([404, 408, 429, 503])('still retries transient HTTP %i responses', async status => {
+  it.each([403, 404, 408, 429, 503])('still retries transient HTTP %i responses', async status => {
     const file: TFile = { id: 'transient', storage_session_id: 'previous', name: 'ready.txt' };
     let requests = 0;
     const route: Route = {
@@ -480,6 +481,7 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
     for (const file of files) {
       routes.set(`/sessions/previous/objects/${file.id}`, {
         status: 403,
+        headers: { 'X-CodeAPI-Error-Code': 'scope_mismatch' },
         delayMs: file.id === 'file-0' ? 0 : 30,
         onRequest: () => { requests++; },
       });

--- a/api/src/download.test.ts
+++ b/api/src/download.test.ts
@@ -441,6 +441,7 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
   });
 
   it.each([401, 403])('does not retry an HTTP %i authorization denial', async status => {
+    config.egress_gateway_url = `http://127.0.0.1:${serverPort}`;
     const file: TFile = { id: 'denied', storage_session_id: 'previous', name: 'denied.txt' };
     let requests = 0;
     routes.set('/sessions/previous/objects/denied', {
@@ -510,6 +511,7 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
   });
 
   it('accounts for a denied 240-file batch once and stops queued downloads', async () => {
+    config.egress_gateway_url = `http://127.0.0.1:${serverPort}`;
     const files: TFile[] = Array.from({ length: 240 }, (_, index) => ({
       id: `file-${index}`, storage_session_id: 'previous', name: `file-${index}.txt`,
     }));

--- a/api/src/egress.ts
+++ b/api/src/egress.ts
@@ -1,1 +1,2 @@
 export const EGRESS_GRANT_HEADER = 'X-CodeAPI-Egress-Grant';
+export const EGRESS_ERROR_CODE_HEADER = 'X-CodeAPI-Error-Code';

--- a/api/src/job.ts
+++ b/api/src/job.ts
@@ -1410,7 +1410,14 @@ export class Job {
         }
         lastError = error instanceof Error ? error : new Error(String(error));
         if (attempt < maxRetries) {
-          const delay = retryDelay * Math.pow(2, attempt - 1);
+          const backoff = retryDelay * Math.pow(2, attempt - 1);
+          const retryAfterSeconds = response?.status === 503
+            ? Number(response.headers.get('retry-after')) : NaN;
+          /* Use the same bounded retry hint as marker discovery, without
+           * shortening exponential backoff or bypassing batch cancellation. */
+          const delay = Number.isFinite(retryAfterSeconds)
+            ? Math.max(backoff, Math.min(1000, Math.max(0, retryAfterSeconds * 1000)))
+            : backoff;
           this.log.warn({ fileId: file.id, attempt, maxRetries, delay, err: lastError }, 'Download failed, retrying');
           await sleep(delay, operation.signal);
         }

--- a/api/src/job.ts
+++ b/api/src/job.ts
@@ -15,7 +15,7 @@ import { getRuntimes } from './runtime';
 import { execute } from './nsjail';
 import { config } from './config';
 import { internalServiceHeaders } from './internal-service-auth';
-import { EGRESS_GRANT_HEADER } from './egress';
+import { EGRESS_GRANT_HEADER, EGRESS_ERROR_CODE_HEADER } from './egress';
 import { injectTraceHeaders } from './telemetry';
 import {
   applyReadOnlyInputPermissions,
@@ -1326,7 +1326,11 @@ export class Job {
 
         if (!response.ok) {
           await response.body?.cancel().catch(() => {});
-          if (response.status === 401 || response.status === 403) {
+          const reason = response.headers.get(EGRESS_ERROR_CODE_HEADER);
+          /* Older gateways also used 403 for transient ledger contention.
+           * Only classify 403 as permanent when the gateway distinguishes it. */
+          if (response.status === 401 || (response.status === 403 &&
+            (reason === 'scope_mismatch' || reason === 'wrong_type'))) {
             throw new InputAuthorizationError(response.status);
           }
           throw new Error(`HTTP error: ${response.status}`);

--- a/api/src/job.ts
+++ b/api/src/job.ts
@@ -1196,6 +1196,11 @@ export class Job {
     }
   }
 
+  private isLegacyGatewayDenial(response: Response): boolean {
+    return !!config.egress_gateway_url && response.status === 403 &&
+      !response.headers.has(EGRESS_ERROR_CODE_HEADER);
+  }
+
   /**
    * Fetches normalized objects for one inherited session and returns the
    * `.dirkeep` markers belonging to exactly that session. Guards against:
@@ -1219,7 +1224,7 @@ export class Job {
             signal: controller.signal,
           },
         );
-        if (res.status === 503 && attempt < AUTO_LOAD_DIRKEEP_RETRIES) {
+        if ((res.status === 503 || this.isLegacyGatewayDenial(res)) && attempt < AUTO_LOAD_DIRKEEP_RETRIES) {
           await res.body?.cancel().catch(() => {});
           const retryAfterSeconds = Number(res.headers.get('retry-after'));
           await sleep(
@@ -1326,11 +1331,10 @@ export class Job {
 
         if (!response.ok) {
           await response.body?.cancel().catch(() => {});
-          const reason = response.headers.get(EGRESS_ERROR_CODE_HEADER);
           /* Older gateways also used 403 for transient ledger contention.
            * Only classify 403 as permanent when the gateway distinguishes it. */
-          if (response.status === 401 || (response.status === 403 &&
-            (reason === 'scope_mismatch' || reason === 'wrong_type'))) {
+          if (response.status === 401 ||
+            (response.status === 403 && !this.isLegacyGatewayDenial(response))) {
             throw new InputAuthorizationError(response.status);
           }
           throw new Error(`HTTP error: ${response.status}`);

--- a/packages/code/src/relay.test.ts
+++ b/packages/code/src/relay.test.ts
@@ -381,3 +381,38 @@ test('file relay rejects plaintext remote upstreams', async () => {
     /HTTPS unless it is a local development host/,
   );
 });
+
+for (const [status, reason] of [[403, 'scope_mismatch'], [503, 'ledger_conflict']] as const) {
+  test(`file relay preserves ${reason} classification`, async () => {
+    const upstream = createServer((_req, res) => {
+      res.writeHead(status, {
+        'X-CodeAPI-Error-Code': reason,
+        'Retry-After': '1',
+        'X-Internal-Secret': 'must-not-forward',
+      }).end('rejected');
+    });
+    const upstreamUrl = await listen(upstream);
+    const relay = await startFileRelay({
+      host: '127.0.0.1', port: 0, upstreamUrl, token: 'relay-secret',
+      maxBytes: 1024, timeoutMs: 1000,
+    });
+    try {
+      const response = await fetch(`${relay.url}/sessions/storage-1/objects/file-1`, {
+        headers: {
+          'X-LibreChat-Code-Relay-Token': 'relay-secret',
+          'X-CodeAPI-Egress-Grant': 'grant-1',
+        },
+      });
+      assert.equal(response.status, status);
+      assert.equal(response.headers.get('x-codeapi-error-code'), reason);
+      assert.equal(response.headers.get('retry-after'), '1');
+      assert.equal(response.headers.get('x-internal-secret'), null);
+      assert.equal(await response.text(), 'rejected');
+    } finally {
+      await relay.close();
+      await new Promise<void>((resolve, reject) =>
+        upstream.close(error => error ? reject(error) : resolve()),
+      );
+    }
+  });
+}

--- a/packages/code/src/relay.ts
+++ b/packages/code/src/relay.ts
@@ -240,6 +240,12 @@ export async function startFileRelay(
                 )!,
               }
             : {}),
+          ...(upstreamResponse.headers.has('x-codeapi-error-code')
+            ? { 'X-CodeAPI-Error-Code': upstreamResponse.headers.get('x-codeapi-error-code')! }
+            : {}),
+          ...(upstreamResponse.headers.has('retry-after')
+            ? { 'Retry-After': upstreamResponse.headers.get('retry-after')! }
+            : {}),
           'Content-Length': String(body.length),
         });
         response.end(body);

--- a/service/src/egress-gateway.test.ts
+++ b/service/src/egress-gateway.test.ts
@@ -1,6 +1,6 @@
 process.env.CODEAPI_EGRESS_GATEWAY_AUTOSTART = 'false';
 
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, test, spyOn } from 'bun:test';
 import crypto from 'crypto';
 import RedisMock from 'ioredis-mock';
 import type { Server } from 'http';
@@ -435,6 +435,39 @@ describe('egress gateway routes', () => {
     }
   });
 
+  test('reports exhausted ledger conflicts as retryable without forwarding the read', async () => {
+    const redis = new RedisMock();
+    env.EGRESS_LEDGER_REQUIRED = true;
+    setEgressLedgerRedisForTest(redis as unknown as Parameters<typeof setEgressLedgerRedisForTest>[0]);
+    const duplicate = redis.duplicate.bind(redis);
+    const duplication = spyOn(redis, 'duplicate').mockImplementation(() => {
+      const connection = duplicate();
+      const transaction = {
+        set: () => transaction,
+        exec: async () => null,
+      };
+      spyOn(connection, 'multi').mockImplementation(() => transaction as never);
+      return connection;
+    });
+    try {
+      await createEgressLedger(claims());
+      const readSession = sessionHandle({ dir: 'read', sessionId: 'sess_input' });
+      const response = await gatewayFetch(`/sessions/${readSession}/objects?detail=normalized`, {
+        headers: grantHeader(),
+      });
+      expect(response.status).toBe(503);
+      expect(response.headers.get('X-CodeAPI-Error-Code')).toBe('ledger_conflict');
+      expect(response.headers.get('Retry-After')).toBe('1');
+      expect(upstreamCalls).toHaveLength(0);
+      expect((await assertEgressGrantActive(claims())).request_count).toBe(0);
+    } finally {
+      duplication.mockRestore();
+      setEgressLedgerRedisForTest(null);
+      redis.disconnect();
+      env.EGRESS_LEDGER_REQUIRED = false;
+    }
+  });
+
   test('lists only scoped objects and injects internal credentials', async () => {
     upstreamResponse = Response.json([
       { id: 'file_123', name: 'inputs/data.csv', storage_session_id: 'sess_input' },
@@ -557,6 +590,7 @@ describe('egress gateway routes', () => {
       });
 
       expect(response.status).toBe(403);
+      expect(response.headers.get('X-CodeAPI-Error-Code')).toBe('scope_mismatch');
       expect(upstreamCalls).toHaveLength(0);
     } finally {
       await redis.disconnect();

--- a/service/src/egress-gateway.ts
+++ b/service/src/egress-gateway.ts
@@ -6,6 +6,7 @@ import { Readable } from 'stream';
 import { env } from './config';
 import {
   EGRESS_GRANT_HEADER,
+  EGRESS_ERROR_CODE_HEADER,
   EgressGrantError,
   egressGrantFromExecutionClaims,
   openEgressGrant,
@@ -157,6 +158,7 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 
 function errorStatus(error: EgressGrantError): number {
   if (error.reason === 'missing_secret' || error.reason === 'weak_secret') return 500;
+  if (error.reason === 'ledger_conflict') return 503;
   if (error.reason === 'malformed') return 400;
   if (error.reason === 'expired') return 401;
   return 403;
@@ -165,6 +167,8 @@ function errorStatus(error: EgressGrantError): number {
 function sendEgressError(req: Request, res: Response, error: unknown): Response {
   if (error instanceof EgressGrantError) {
     const statusCode = errorStatus(error);
+    res.setHeader(EGRESS_ERROR_CODE_HEADER, error.reason);
+    if (error.reason === 'ledger_conflict') res.setHeader('Retry-After', '1');
     logger.warn('Rejected egress gateway request', {
       requestId: requestId(res),
       reason: error.reason,

--- a/service/src/egress-grant.ts
+++ b/service/src/egress-grant.ts
@@ -3,6 +3,7 @@ import type { ExecutionManifestClaims, ExecutionManifestInputFile } from './exec
 import type * as t from './types';
 
 export const EGRESS_GRANT_HEADER = 'X-CodeAPI-Egress-Grant';
+export const EGRESS_ERROR_CODE_HEADER = 'X-CodeAPI-Error-Code';
 export const EGRESS_GRANT_VERSION = 1;
 
 const TOKEN_PREFIX = 'ceg1';
@@ -19,7 +20,8 @@ export type EgressGrantErrorReason =
   | 'malformed'
   | 'expired'
   | 'wrong_type'
-  | 'scope_mismatch';
+  | 'scope_mismatch'
+  | 'ledger_conflict';
 
 export class EgressGrantError extends Error {
   readonly reason: EgressGrantErrorReason;

--- a/service/src/egress-ledger.ts
+++ b/service/src/egress-ledger.ts
@@ -264,7 +264,7 @@ async function mutateRecord(
     });
     releaseMutationConnection(client);
   }
-  throw new EgressGrantError('scope_mismatch', 'Egress grant ledger update conflicted');
+  throw new EgressGrantError('ledger_conflict', 'Egress grant ledger update conflicted');
 }
 
 export async function assertEgressGrantActive(grant: EgressGrantClaims): Promise<EgressLedgerRecord> {


### PR DESCRIPTION
## Summary

I preserve retries for transient egress-ledger conflicts while keeping genuine authorization denials fail-fast. The gateway currently uses HTTP 403 for both scope denials and exhausted Redis WATCH conflicts; after #177 stopped all 403 retries, a temporary ledger conflict could terminate input preparation immediately.

- Return HTTP 503 with `ledger_conflict` and `Retry-After` when optimistic ledger updates exhaust their retries.
- Expose `X-CodeAPI-Error-Code` on classified gateway errors so the runner can distinguish permanent scope denials.
- Stop HTTP 403 retries for classified gateway denials and direct-server denials; retain retries for unclassified responses from older gateways in both marker discovery and downloads.
- Forward gateway error classification and retry hints through the worker relay while keeping unrelated headers filtered.
- Honor bounded gateway retry hints during object downloads while preserving exponential backoff and cancellation.
- Preserve HTTP 401 fail-fast behavior, batch failure accounting, and transient download retries.

```text
old gateway -> unclassified 403 -> preserve legacy retry
new gateway -> 503 ledger_conflict -> retry
new gateway -> 403 scope_mismatch -> abort input batch
```

The additive header and retained legacy retry path support both gateway-first and runner-first rollouts. This does not change authorization scope or grant budgets.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Run `cd api && bun test src/download.test.ts src/job-cleanup.test.ts src/inline-prime-atomicity.test.ts src/session-inputs.prime.test.ts`: 39 passed.
- Run `cd service && bun test src/egress-gateway.test.ts src/egress-ledger.test.ts`: 34 passed.
- Force Redis transaction conflicts through the actual gateway/ledger path: verify HTTP 503, retry classification, unchanged accounting, and no upstream file request.
- Verify classified 403 aborts a 240-file gateway batch while legacy 403 recovers on retry, including marker discovery before priming.
- Compile relay source/tests with TypeScript and run with Node: 12 passed, including classified-denial and ledger-conflict forwarding.
- Run package workspace typechecking: 11 diagnostics from unavailable native dependencies also reproduce on the untouched baseline; targeted relay compilation passes.
- Run `npx tsc --noEmit` in API and service: eight API and six service diagnostics also reproduce on the untouched baseline with the same dependencies, with no additional diagnostics (line-number shifts normalized).
- Run `git diff --check`: passed.

### Test Configuration

macOS, Bun 1.3.13, existing API/service dependencies; local HTTP listeners and Redis transaction-conflict injection.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
