### PR TITLE
perf: enable authorized input reuse by default

### DIFF
--- a/api/src/config-defaults.test.ts
+++ b/api/src/config-defaults.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'bun:test';
+import path from 'node:path';
+
+function readHttpInputCacheDefault(value?: string): boolean {
+  const env = { ...process.env };
+  if (value === undefined) delete env.SANDBOX_HTTP_INPUT_CACHE_ENABLED;
+  else env.SANDBOX_HTTP_INPUT_CACHE_ENABLED = value;
+  const script = [
+    `const { config } = await import(${JSON.stringify(path.resolve(process.cwd(), 'src/config.ts'))})`,
+    'process.stdout.write(JSON.stringify(config.http_input_cache_enabled))',
+  ].join(';');
+  const result = Bun.spawnSync({ cmd: [process.execPath, '--eval', script], env });
+  expect(result.exitCode).toBe(0);
+  return JSON.parse(result.stdout.toString()) as boolean;
+}
+
+test('authorized HTTP input reuse defaults on and retains an explicit rollback switch', () => {
+  expect(readHttpInputCacheDefault()).toBe(true);
+  expect(readHttpInputCacheDefault('false')).toBe(false);
+  expect(readHttpInputCacheDefault('true')).toBe(true);
+});

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -122,7 +122,8 @@ export const config = {
   /* Ceiling for the pushed input cache (session-inputs.ts). Eviction is
    * always safe — a miss simply re-pushes on the next probe — so this is a
    * disk guard, not a correctness knob. */
-  http_input_cache_enabled: process.env.SANDBOX_HTTP_INPUT_CACHE_ENABLED === 'true',
+  http_input_cache_enabled:
+    (process.env.SANDBOX_HTTP_INPUT_CACHE_ENABLED ?? 'true') === 'true',
   http_input_cache_max_objects: safeInt(process.env.SANDBOX_HTTP_INPUT_CACHE_MAX_OBJECTS, 4096),
   http_input_cache_max_inflight: safeInt(process.env.SANDBOX_HTTP_INPUT_CACHE_MAX_INFLIGHT, 16),
   input_cache_max_bytes: safeInt(

--- a/docs/INPUT_REUSE.md
+++ b/docs/INPUT_REUSE.md
@@ -48,7 +48,7 @@ sequenceDiagram
 | `egressGrant.inputManifestTimeoutMs` | `CODEAPI_INPUT_MANIFEST_TIMEOUT_MS` | `10000` |
 | `fileServer.objectIndexEnabled` | `CODEAPI_FILE_OBJECT_INDEX_ENABLED` | `false` |
 | `fileServer.metadataConcurrency` | `CODEAPI_FILE_METADATA_CONCURRENCY` | `1` |
-| `workerSandbox.sandbox.httpInputCacheEnabled` | `SANDBOX_HTTP_INPUT_CACHE_ENABLED` | `false` |
+| `workerSandbox.sandbox.httpInputCacheEnabled` | `SANDBOX_HTTP_INPUT_CACHE_ENABLED` | `true` |
 | `workerSandbox.sandbox.httpInputCacheMaxInflight` | `SANDBOX_HTTP_INPUT_CACHE_MAX_INFLIGHT` | `16` |
 | `workerSandbox.sandbox.httpInputCacheMaxObjects` | `SANDBOX_HTTP_INPUT_CACHE_MAX_OBJECTS` | `4096` |
 | `workerSandbox.sandbox.inputCacheMaxBytes` | `SANDBOX_INPUT_CACHE_MAX_BYTES` | `536870912` |
@@ -61,14 +61,14 @@ Metadata listing concurrency preserves order and is capped at 64. A canary can u
 
 ## Rollout and rollback
 
-1. Deploy the new binaries with feature flags off. Atomic accounting supports existing JSON ledgers, and legacy downloads retain metadata compatibility. The new file server stamps future uploads with versions.
+1. Deploy the new binaries with HTTP input reuse enabled by default. Mixed-version requests remain compatible: older gateways and relays fall back to normal downloads, while older unversioned objects return `cacheable: false`. The new file server stamps future uploads with versions. Set `workerSandbox.sandbox.httpInputCacheEnabled=false` only when a staged rollout requires the immediate rollback path.
 2. Update **all** egress-gateway replicas before enabling compact ledgers. New binaries read both formats regardless of the creation flag. Older binaries cannot read compact hashes. To roll back to an older binary, disable compact creation, drain active grants, and wait their maximum TTL plus grace; never delete active ledgers to force a rollback.
 3. Update all file-server writers before enabling the object-key index. Otherwise an older writer can change a locator without updating the index. Keep file-server replicas consistent during an indexed rollout.
-4. Update the gateway, relay, runner, and launcher before enabling HTTP reuse on a small runner canary. Older gateway/relay metadata routes return 404/405 and fall back safely. Older files return `cacheable: false`. Keep the feature disabled for storage adapters that cannot return user metadata on GET.
+4. Canary the default-on HTTP reuse path after updating the gateway, relay, runner, and launcher. Keep the feature explicitly disabled for storage adapters that cannot return user metadata on GET.
 5. Observe `codeapi_sandbox_http_input_cache_events_total` (bounded event labels, no identities), cold and warm preparation latency, storage/Redis operations, admission fairness, request budgets, and memory/disk pressure before widening the rollout. A successful manifest consumes one read request for the batch, matching the existing list-request accounting unit. Per-file compatibility preflights each consume a read request; each cold miss consumes an additional download request. Do not disable budget enforcement to accommodate a workload.
 6. Disable HTTP reuse to return to normal downloads immediately. Cached files can age out normally; no workspace deletion or migration is needed.
 
-The creation flags default off. No deployment or object retention policy is changed by this code. Command grouping and persistent sessions remain independent options, not prerequisites for content reuse. Nothing deletes user inputs or infers shell dependencies.
+HTTP input reuse defaults on. Compact-ledger creation and the object-key index remain off until their mixed-version rollout requirements are satisfied. No object retention policy is changed by this code. Command grouping and persistent sessions remain independent options, not prerequisites for content reuse. Nothing deletes user inputs or infers shell dependencies.
 
 ## Validation
 

--- a/helm/codeapi/values.yaml
+++ b/helm/codeapi/values.yaml
@@ -273,7 +273,7 @@ workerSandbox:
     # Defaults to maxConcurrentJobs when unset.
     jobUidCount: null
     workspaceReaperMaxAgeSeconds: 3600
-    httpInputCacheEnabled: false
+    httpInputCacheEnabled: true
     httpInputCacheMaxInflight: 16
     httpInputCacheMaxObjects: 4096
     inputCacheMaxBytes: 536870912


### PR DESCRIPTION
## Summary

I enable authorized HTTP input reuse by default so repeated stateless executions do not continue re-downloading the same conversation files unless an operator explicitly disables the feature. The default now matches the bounded, version-checked behavior added in #180 while retaining `false` as an immediate rollback setting.

- Default the runner configuration and Helm value to HTTP input reuse enabled.
- Preserve safe mixed-version behavior: older gateways fall back to normal downloads and unversioned objects remain uncached.
- Keep compact Redis ledgers and the file-object index opt-in because they require coordinated rollout steps and are not needed to stop repeated content downloads.
- Update rollout documentation to describe the default-on canary and explicit rollback path.
- Add a configuration regression covering the unset, enabled, and disabled environment-variable states.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

- Run 13 focused API tests covering the configuration default, explicit rollback, 240-file content reuse, legacy fallback, version races, authorization isolation, coalescing, cancellation, and cache bounds.
- Render the Helm chart with local values and verify `SANDBOX_HTTP_INPUT_CACHE_ENABLED` is `"true"`.
- Run `npx tsc --noEmit` in `api`; the eight diagnostics reproduce from the existing baseline and none reference this change.
- Run `git diff --check` successfully.

### **Test Configuration**:

- macOS
- Bun 1.3.13
- Helm with the chart's local values

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
