### PR TITLE
📌 fix: Honor Requested Sandbox Destinations

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -67,6 +67,7 @@ components:
       properties:
         name:
           type: string
+          description: Relative path where the file is mounted in the sandbox.
         id:
           type: string
         content:

--- a/api/src/download.test.ts
+++ b/api/src/download.test.ts
@@ -18,12 +18,8 @@ import {
 
 /**
  * Integration tests for `Job.downloadAndWriteFile` against a real HTTP
- * listener. These exercise the cross-repo round-trip: the file-server
- * (codeapi/service) emits `Content-Disposition: attachment;
- * filename*=UTF-8''<percent-encoded-path>` for nested artifacts, and the
- * sandbox-side parser must recover the path so the file lands at the same
- * nested location on the next prime(). Hitting a real listener (not a
- * mocked Response) catches anything fetch-level that a unit test would miss.
+ * listener. Hitting a real listener verifies that response metadata cannot
+ * redirect a caller-validated sandbox destination.
  */
 
 interface DownloadInternals {
@@ -176,21 +172,16 @@ afterEach(async () => {
   await fsp.rm(tmpDir, { recursive: true, force: true });
 });
 
-describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
-  it('writes a nested-path artifact at the encoded location', async () => {
-    /* Simulates the matplotlib-bug shape: codeapi previously returned a
-     * flat `file.name` and the original path was carried only by the
-     * server's `filename*=` header. The fix is: parser recovers the path,
-     * `mkdir { recursive: true }` creates the parent dir, file ends up
-     * where the user expects to `cat` it on the next turn. */
+describe('downloadAndWriteFile destinations', () => {
+  it('writes a nested-path artifact at the requested location', async () => {
     const file: TFile = {
       id: 'nested-id',
       storage_session_id: 'prev-session',
-      name: 'flat-fallback.txt',
+      name: 'proj/notes.txt',
     };
     routes.set(`/sessions/${encodeURIComponent(file.storage_session_id!)}/objects/${encodeURIComponent(file.id!)}`, {
       status: 200,
-      contentDisposition: "attachment; filename*=UTF-8''proj%2Fnotes.txt",
+      contentDisposition: "attachment; filename*=UTF-8''stored-original.txt",
       body: 'hello from a nested artifact\n',
     });
 
@@ -212,7 +203,7 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
     const file: TFile = {
       id: 'opaque-object-handle',
       storage_session_id: 'opaque-session-handle',
-      name: 'gateway-fallback.txt',
+      name: 'gateway.txt',
     };
     let sawGrantHeader = false;
     let sawRelayToken = false;
@@ -275,14 +266,11 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
     expect((await fsp.stat(path.join(tmpDir, 'readonly.txt'))).mode & 0o777).toBe(SANDBOX_READONLY_FILE_MODE);
   });
 
-  it('falls back to the legacy filename= form when filename*= is absent', async () => {
-    /* Backwards-compat: older file-servers (or proxies that strip RFC
-     * 5987 extended-form headers) still send the legacy quoted form. The
-     * parser must still find a name and write the file. */
+  it('downloads when a legacy filename header matches the requested name', async () => {
     const file: TFile = {
       id: 'legacy-id',
       storage_session_id: 'prev-session',
-      name: 'ignored.txt',
+      name: 'legacy.txt',
     };
     routes.set(`/sessions/${encodeURIComponent(file.storage_session_id!)}/objects/${encodeURIComponent(file.id!)}`, {
       status: 200,
@@ -323,7 +311,7 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
     expect(await fsp.stat(path.join(tmpDir, 'opaque-storage-id.xlsx')).catch(() => null)).toBeNull();
   });
 
-  it('resolves concurrent header destinations without provisional-name false conflicts', async () => {
+  it('keeps concurrent inputs at their requested destinations', async () => {
     const renamed: TFile = {
       id: 'renamed-id',
       storage_session_id: 'prev-session',
@@ -338,8 +326,6 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
       status: 200,
       contentDisposition: 'attachment; filename="actual.txt"',
       body: 'renamed bytes',
-      /* Make the other ref resolve `vacated.txt` while this ref's requested
-       * name would still be provisional under the old reservation scheme. */
       delayMs: 75,
     });
     routes.set(`/sessions/${encodeURIComponent(replacement.storage_session_id!)}/objects/${encodeURIComponent(replacement.id!)}`, {
@@ -356,75 +342,62 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
       await job.prime();
       const submissionDir = asInternals(job).submissionDir;
       expect(await fsp.readFile(path.join(submissionDir, 'actual.txt'), 'utf8'))
-        .toBe('renamed bytes');
-      expect(await fsp.readFile(path.join(submissionDir, 'vacated.txt'), 'utf8'))
         .toBe('replacement bytes');
+      expect(await fsp.readFile(path.join(submissionDir, 'vacated.txt'), 'utf8'))
+        .toBe('renamed bytes');
     } finally {
       config.prime_concurrency = originalPrimeConcurrency;
       await job.cleanup();
     }
   });
 
-  it('rejects concurrent refs that resolve to the same destination before either can overwrite', async () => {
-    const slower: TFile = {
-      id: 'same-slower-id',
+  it('keeps distinct requested names when stored objects share an original filename', async () => {
+    const original: TFile = {
+      id: 'original-id',
       storage_session_id: 'prev-session',
-      name: 'slower-fallback.txt',
+      name: 'data.xlsx',
     };
-    const faster: TFile = {
-      id: 'same-faster-id',
+    const aliased: TFile = {
+      id: 'aliased-id',
       storage_session_id: 'prev-session',
-      name: 'faster-fallback.txt',
+      name: 'data-3f9a2c.xlsx',
     };
-    routes.set(`/sessions/${encodeURIComponent(slower.storage_session_id!)}/objects/${encodeURIComponent(slower.id!)}`, {
+    routes.set(`/sessions/${encodeURIComponent(original.storage_session_id!)}/objects/${encodeURIComponent(original.id!)}`, {
       status: 200,
-      contentDisposition: 'attachment; filename="same.txt"',
-      body: 'slower bytes',
+      contentDisposition: 'attachment; filename="data.xlsx"',
+      body: 'original bytes',
       delayMs: 75,
     });
-    routes.set(`/sessions/${encodeURIComponent(faster.storage_session_id!)}/objects/${encodeURIComponent(faster.id!)}`, {
+    routes.set(`/sessions/${encodeURIComponent(aliased.storage_session_id!)}/objects/${encodeURIComponent(aliased.id!)}`, {
       status: 200,
-      contentDisposition: 'attachment; filename="same.txt"',
-      body: 'faster bytes',
+      contentDisposition: 'attachment; filename="data.xlsx"',
+      body: 'aliased bytes',
     });
 
-    let dirty = false;
     const job = makeJob(
-      [slower, faster],
-      sessionWorkspaceAt(tmpDir, 'rt_concurrent_same_destination', () => { dirty = true; }),
+      [original, aliased],
+      sessionWorkspaceAt(tmpDir, 'rt_shared_original_filename'),
     );
     const originalPrimeConcurrency = config.prime_concurrency;
     config.prime_concurrency = 2;
-    let deadlockTimer: ReturnType<typeof setTimeout> | undefined;
     try {
-      const outcome = await Promise.race([
-        job.prime().then(
-          () => ({ status: 'fulfilled' as const }),
-          error => ({ status: 'rejected' as const, error }),
-        ),
-        new Promise<{ status: 'timeout' }>(resolve => {
-          deadlockTimer = setTimeout(() => resolve({ status: 'timeout' }), 2_000);
-        }),
-      ]);
-      if (deadlockTimer) clearTimeout(deadlockTimer);
-      expect(outcome.status).toBe('rejected');
-      if (outcome.status === 'rejected') {
-        expect(outcome.error).toBeInstanceOf(SessionWorkspaceDirtyError);
-      }
-      expect(dirty).toBe(true);
-      expect(await fsp.readFile(path.join(tmpDir, 'same.txt'), 'utf8')).toBe('faster bytes');
+      await job.prime();
+      const submissionDir = asInternals(job).submissionDir;
+      expect(await fsp.readFile(path.join(submissionDir, 'data.xlsx'), 'utf8'))
+        .toBe('original bytes');
+      expect(await fsp.readFile(path.join(submissionDir, 'data-3f9a2c.xlsx'), 'utf8'))
+        .toBe('aliased bytes');
     } finally {
-      if (deadlockTimer) clearTimeout(deadlockTimer);
       config.prime_concurrency = originalPrimeConcurrency;
       await job.cleanup();
     }
   });
 
-  it('decodes UTF-8 percent-encoded names with non-ASCII characters', async () => {
+  it('keeps a Unicode requested name when the header is percent encoded', async () => {
     const file: TFile = {
       id: 'utf8-id',
       storage_session_id: 'prev-session',
-      name: 'ignored.txt',
+      name: '你好.txt',
     };
     routes.set(`/sessions/${encodeURIComponent(file.storage_session_id!)}/objects/${encodeURIComponent(file.id!)}`, {
       status: 200,
@@ -645,11 +618,7 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
     await expect(fsp.access(path.join(tmpDir, 'should-not-exist.txt'))).rejects.toThrow();
   });
 
-  it('rejects a server-supplied filename that escapes the submission dir', async () => {
-    /* Companion guarantee for the path-preserving sanitizer on the
-     * LibreChat side: if a malicious / misconfigured server tries to
-     * smuggle a `..` traversal via Content-Disposition, the codeapi-side
-     * `validateFilePath` aborts before any write happens. */
+  it('ignores a server-supplied filename that escapes the submission dir', async () => {
     const file: TFile = {
       id: 'evil-id',
       storage_session_id: 'prev-session',
@@ -658,16 +627,14 @@ describe('downloadAndWriteFile / RFC 5987 round-trip', () => {
     routes.set(`/sessions/${encodeURIComponent(file.storage_session_id!)}/objects/${encodeURIComponent(file.id!)}`, {
       status: 200,
       contentDisposition: "attachment; filename*=UTF-8''..%2F..%2Fescape.txt",
-      body: 'should never be written',
+      body: 'safe bytes',
     });
 
     const job = makeJob([file]);
     asInternals(job).submissionDir = tmpDir;
 
-    /* downloadAndWriteFile rethrows ValidationError fast (no retries) so
-     * `expect(...).rejects` is the right assertion. */
-    await expect(job.downloadAndWriteFile(file)).rejects.toThrow();
-    /* Defensive: nothing escaped to a parent dir. */
+    await expect(job.downloadAndWriteFile(file)).resolves.toBe('innocent.txt');
+    expect(await fsp.readFile(path.join(tmpDir, 'innocent.txt'), 'utf8')).toBe('safe bytes');
     const parent = path.dirname(tmpDir);
     await expect(fsp.access(path.join(parent, 'escape.txt'))).rejects.toThrow();
   });

--- a/api/src/job-helpers.test.ts
+++ b/api/src/job-helpers.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
-  resolveOriginalName,
+  resolveInputDestination,
   isNormalizedObjectForSession,
   markerConflictsWithExplicitFile,
   aggregateBashExtras,
@@ -41,168 +41,19 @@ function makeRuntime(overrides: Partial<Runtime> & { language: string; pkgdir: s
   };
 }
 
-describe('resolveOriginalName', () => {
-  function responseWithHeader(value?: string): Response {
-    const headers = new Headers();
-    if (value !== undefined) headers.set('content-disposition', value);
-    return new Response(null, { headers });
-  }
-
-  it('returns file.name when no Content-Disposition is present', () => {
-    expect(
-      resolveOriginalName(responseWithHeader(), { name: 'script.py', id: 'abc' }),
-    ).toBe('script.py');
+describe('resolveInputDestination', () => {
+  it('uses the caller-requested sandbox path', () => {
+    expect(resolveInputDestination({ name: 'nested/script.py', id: 'abc' }))
+      .toBe('nested/script.py');
   });
 
-  it('extracts quoted filename from Content-Disposition', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader('attachment; filename="server-name.py"'),
-        { name: 'client-name.py', id: 'abc' },
-      ),
-    ).toBe('server-name.py');
+  it('falls back to the object id when no name exists', () => {
+    expect(resolveInputDestination({ name: '', id: 'file-id-123' }))
+      .toBe('file-id-123');
   });
 
-  it('extracts unquoted filename from Content-Disposition', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader('attachment; filename=plain.txt'),
-        { name: 'ignored.txt', id: 'abc' },
-      ),
-    ).toBe('plain.txt');
-  });
-
-  it('falls back to file.id when file.name is empty and no header exists', () => {
-    expect(
-      resolveOriginalName(responseWithHeader(), { name: '', id: 'file-id-123' }),
-    ).toBe('file-id-123');
-  });
-
-  it('falls back to file.name when header is malformed (no filename token)', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader('attachment'),
-        { name: 'fallback.py', id: 'abc' },
-      ),
-    ).toBe('fallback.py');
-  });
-
-  it('stops at the closing quote when the quoted filename is followed by more params', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader('attachment; filename="foo.txt"; size=123'),
-        { name: 'ignored', id: 'abc' },
-      ),
-    ).toBe('foo.txt');
-  });
-
-  it('stops at a semicolon when the unquoted filename is followed by more params', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader('attachment; filename=foo.txt; size=123'),
-        { name: 'ignored', id: 'abc' },
-      ),
-    ).toBe('foo.txt');
-  });
-
-  it('stops at whitespace when the unquoted filename is followed by whitespace-separated params', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader('attachment; filename=foo.txt extra'),
-        { name: 'ignored', id: 'abc' },
-      ),
-    ).toBe('foo.txt');
-  });
-
-  it('returns empty string when both name and id are absent', () => {
-    expect(resolveOriginalName(responseWithHeader(), { name: '' })).toBe('');
-  });
-
-  it('returns empty string when name is empty, id is absent, and header is malformed', () => {
-    expect(
-      resolveOriginalName(responseWithHeader('attachment'), { name: '' }),
-    ).toBe('');
-  });
-
-  it('decodes RFC 5987 filename*= preserving slashes for nested artifact paths', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader("attachment; filename*=UTF-8''test_folder%2Ftest_file.txt"),
-        { name: 'test_file.txt', id: 'abc' },
-      ),
-    ).toBe('test_folder/test_file.txt');
-  });
-
-  it('decodes RFC 5987 filename*= with a UTF-8 charset that includes a language tag', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader("attachment; filename*=UTF-8'en'foo%20bar.txt"),
-        { name: 'ignored', id: 'abc' },
-      ),
-    ).toBe('foo bar.txt');
-  });
-
-  it('decodes RFC 5987 filename*= with non-ASCII characters', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader("attachment; filename*=UTF-8''%E4%BD%A0%E5%A5%BD.txt"),
-        { name: 'ignored', id: 'abc' },
-      ),
-    ).toBe('你好.txt');
-  });
-
-  it('tolerates a filename*= form missing the UTF-8 prefix', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader('attachment; filename*=plain.txt'),
-        { name: 'ignored', id: 'abc' },
-      ),
-    ).toBe('plain.txt');
-  });
-
-  it('falls through to legacy filename= when filename*= is malformed', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader("attachment; filename*=UTF-8''bad%ZZ; filename=\"legacy.txt\""),
-        { name: 'ignored', id: 'abc' },
-      ),
-    ).toBe('legacy.txt');
-  });
-
-  it('prefers filename*= over a legacy filename= present in the same header', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader("attachment; filename=\"legacy.txt\"; filename*=UTF-8''nested%2Ffile.txt"),
-        { name: 'ignored', id: 'abc' },
-      ),
-    ).toBe('nested/file.txt');
-  });
-
-  it('keeps the requested name when an old file server advertises the opaque object basename', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader("attachment; filename*=UTF-8''storage-id.xlsx"),
-        { name: 'Sample_-_Superstore.xlsx', id: 'storage-id' },
-      ),
-    ).toBe('Sample_-_Superstore.xlsx');
-  });
-
-  it('keeps the requested name for a legacy opaque filename header', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader('attachment; filename="storage-id.csv"'),
-        { name: 'original.csv', id: 'storage-id' },
-      ),
-    ).toBe('original.csv');
-  });
-
-  it('keeps an authoritative nested filename even when its basename matches the object id', () => {
-    expect(
-      resolveOriginalName(
-        responseWithHeader("attachment; filename*=UTF-8''exports%2Fstorage-id.csv"),
-        { name: 'original.csv', id: 'storage-id' },
-      ),
-    ).toBe('exports/storage-id.csv');
+  it('returns an empty path when both name and id are absent', () => {
+    expect(resolveInputDestination({ name: '' })).toBe('');
   });
 });
 

--- a/api/src/job.ts
+++ b/api/src/job.ts
@@ -173,52 +173,12 @@ export function ensureNodeModulesSymlink(
 }
 
 /**
- * Extracts the on-disk filename from a Content-Disposition response header,
- * falling back to the request-supplied `file.name` (or `file.id` if no name
- * was provided). Pure; exported for unit testing.
- *
- * Matches RFC 5987 / 8187 `filename*=UTF-8''<percent-encoded>` first because
- * the file server emits that form for UTF-8-safe transport of arbitrary
- * names — including paths with `/` separators that the legacy `filename=`
- * form would mangle. Falls back to the legacy quoted (`filename="..."`) or
- * unquoted (`filename=...`) forms, each stopping at the closing quote or
- * the first whitespace/semicolon so trailing params like
- * `attachment; filename="foo.txt"; size=123` correctly yield `foo.txt`.
+ * Resolves the on-disk destination for a by-reference input. The request owns
+ * the sandbox path; object response metadata must not redirect the write.
+ * Pure; exported for unit testing.
  */
-export function resolveOriginalName(response: Response, file: TFile): string {
-  const fallback = file.name || (file.id ?? '');
-  const header = response.headers.get('content-disposition');
-  if (!header) return fallback;
-
-  const preferRequestedName = (candidate: string): string => {
-    /* Older file servers advertised path.basename(objectName) when an
-     * S3-compatible backend omitted original-filename user metadata. That
-     * basename is `<file.id><extension>`, so it is a storage identifier rather
-     * than an authoritative destination. Preserve the caller's requested name
-     * during rolling upgrades instead of exposing the opaque id in /mnt/data. */
-    const opaqueStem = path.basename(candidate, path.extname(candidate));
-    const isFlatObjectBasename = candidate === path.basename(candidate);
-    return file.name && file.id && isFlatObjectBasename && opaqueStem === file.id
-      ? file.name
-      : candidate;
-  };
-
-  const star = header.match(/filename\*=(?:UTF-8'[^']*')?([^;]+)/i);
-  if (star) {
-    const raw = star[1].trim();
-    try {
-      return preferRequestedName(decodeURIComponent(raw));
-    } catch {
-      /* Malformed percent-encoding (e.g. `%ZZ`) — fall through to the legacy
-       * forms. The same header may emit both `filename*=` and a legacy
-       * `filename=` per RFC 5987 §4.3, so a corrupt extended form should
-       * not poison a valid fallback. */
-    }
-  }
-
-  const match = header.match(/filename="([^"]+)"/i)
-    ?? header.match(/filename=([^\s;]+)/i);
-  return match ? preferRequestedName(match[1]) : fallback;
+export function resolveInputDestination(file: TFile): string {
+  return file.name || (file.id ?? '');
 }
 
 /**
@@ -959,12 +919,9 @@ export class Job {
         );
       }
       requestedDestinations.set(file.name, file);
-      /* Inline destinations are final, so keep them reserved while reference
-       * downloads resolve their authoritative Content-Disposition names.
-       * A ref's requested name is only a fallback, not a real destination yet:
-       * reserving every ref here makes concurrent swaps/order-dependent
-       * renames falsely conflict before the owning response has resolved. */
-      if (!file.id) this.inputDestinations.set(file.name, file);
+      /* The request owns every sandbox destination. Reserve it before parallel
+       * priming begins so object metadata cannot redirect a later write. */
+      this.inputDestinations.set(file.name, file);
     }
 
     if (this.session) {
@@ -1083,10 +1040,8 @@ export class Job {
   ): Promise<void> {
     throwIfAborted(context.signal);
     if (this.session && file.id && (await this.reusePrimedInput(file, context))) {
-      /* Reuse has no response header to pass through downloadAndWriteFile, so
-       * its requested name becomes authoritative only after the on-disk copy
-       * has been verified. Reserve it before another concurrent ref can claim
-       * and overwrite that path. */
+      /* Inherited markers are registered after prime's initial reservation
+       * pass, so reserve the verified requested path here as well. */
       this.reserveInputDestination(file, file.name);
       return;
     }
@@ -1345,10 +1300,10 @@ export class Job {
           throw new Error(`HTTP error: ${response.status}`);
         }
 
-        const originalName = resolveOriginalName(response, file);
-        validateFilePath(originalName, operation.submissionDir);
-        this.reserveInputDestination(file, originalName);
-        const finalPath = path.join(operation.submissionDir, originalName);
+        const destination = resolveInputDestination(file);
+        validateFilePath(destination, operation.submissionDir);
+        this.reserveInputDestination(file, destination);
+        const finalPath = path.join(operation.submissionDir, destination);
         const finalParent = path.dirname(finalPath);
         /* Persistent-session workspaces can hold a prior turn's symlink, so build
          * ancestors no-follow; a fresh per-job workspace can use plain mkdir -p. */
@@ -1376,7 +1331,7 @@ export class Job {
           operation.signal,
         );
         const readOnly = response.headers.get('x-read-only')?.toLowerCase() === 'true';
-        this.inputFileHashes.set(originalName, {
+        this.inputFileHashes.set(destination, {
           originalId: file.id,
           originalSessionId: file.storage_session_id!,
           hash,
@@ -1389,15 +1344,8 @@ export class Job {
           await applyReadOnlyInputPermissions(finalPath);
         }
 
-        /* Keep the in-memory TFile in sync with the on-disk name so that
-         * inputByName lookups in handleSessionFiles match walkDir's
-         * path.relative() output. Otherwise a Content-Disposition override
-         * would leave file.name pointing at the client-submitted name while
-         * the file lives under originalName on disk. */
-        if (originalName !== file.name) file.name = originalName;
-
-        this.log.info({ file: originalName, hash: hash.substring(0, 8) }, 'Downloaded file');
-        return originalName;
+        this.log.info({ file: destination, hash: hash.substring(0, 8) }, 'Downloaded file');
+        return destination;
       } catch (error: unknown) {
         if (response?.body && !response.bodyUsed) {
           await response.body.cancel().catch(() => {});


### PR DESCRIPTION
## Summary

CodeAPI replaced the caller-provided `files[].name` with the stored object's `Content-Disposition` filename. When two objects shared an original filename but the caller assigned distinct destinations, both downloads converged on one path and `/exec` failed with `Conflicting input destinations`. I made the requested name authoritative so each validated destination remains stable through download and priming. Closes #175.

- Use `files[].name` as the sandbox destination for by-reference inputs, independent of storage response metadata.
- Reserve every requested destination before parallel priming starts.
- Remove the response-header filename parser and its order-dependent destination behavior.
- Document `files[].name` as the sandbox-relative mount path.
- Cover two objects reporting `data.xlsx` while the request mounts one as `data-3f9a2c.xlsx`, plus nested, Unicode, concurrent, and traversal-shaped header cases.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd api && env -u AWS_CA_BUNDLE bun test` — 414 passed, 16 platform-specific tests skipped, 0 failed.
- `cd api && bun run build` — passed.
- `cd api && bunx tsc --noEmit` — the local Bun type environment reports existing errors in hosted-app, session-input, job-cleanup, tool-call proxy, and workspace-isolation files; no errors reference the changed files.

### **Test Configuration**:

- Bun 1.3.13
- macOS arm64

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
