### PR TITLE
fix: Disambiguate Legacy Dotted Object Identities

### DIFF
--- a/service/src/file-object-resolver.test.ts
+++ b/service/src/file-object-resolver.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'bun:test';
-import { canonicalObjectId, FileObjectResolver, mapObjectDetails, storageKeyForUpload } from './file-object-resolver';
+import {
+  canonicalObjectId,
+  canonicalObjectKey,
+  FileObjectResolver,
+  legacyObjectId,
+  mapObjectDetails,
+  storageKeyForUpload,
+} from './file-object-resolver';
 import type { BucketItemStat } from 'minio';
 
 describe('storage object resolution', () => {
@@ -20,6 +27,34 @@ describe('storage object resolution', () => {
 
     expect(await resolver.listFresh('s', 'report.csv')).toEqual([dottedKey]);
     expect(await resolver.listFresh('s', 'report')).toEqual([]);
+  });
+
+  test('legacy extension keys map to exactly one dotted or undotted identity', async () => {
+    const canonicalDotted = canonicalObjectKey('s', 'report.csv');
+    const objects = new Set([
+      's/report.csv',
+      's/report.csv.txt',
+      canonicalDotted,
+    ]);
+    const resolver = new FileObjectResolver({
+      bucket: 'files',
+      list: async function* (prefix) {
+        for (const name of objects) if (name.startsWith(prefix)) yield { name };
+      },
+      stat: async () => ({ metaData: {} } as BucketItemStat),
+    });
+
+    expect(legacyObjectId('s/report.csv', 's')).toBe('report');
+    expect(legacyObjectId('s/report.csv.txt', 's')).toBe('report.csv');
+    expect(legacyObjectId('s/report', 's')).toBe('report');
+    expect(legacyObjectId('other/report.csv', 's')).toBeUndefined();
+    await expect(resolver.remember('s', 'report.csv', 's/report.csv'))
+      .rejects.toThrow('Object key does not match storage identity');
+    expect(await resolver.listFresh('s', 'report')).toEqual(['s/report.csv']);
+    expect(await resolver.listFresh('s', 'report.csv')).toEqual([
+      canonicalDotted,
+      's/report.csv.txt',
+    ]);
   });
 
   test('indexes exact identities while reading fresh version metadata on every request', async () => {

--- a/service/src/file-object-resolver.ts
+++ b/service/src/file-object-resolver.ts
@@ -19,6 +19,18 @@ export function canonicalObjectId(key: string): string | undefined {
   }
 }
 
+/** Legacy objects were stored as `<session>/<id><final filename extension>`.
+ * Derive exactly one identity by removing that final extension when present.
+ * In particular, `session/report.csv` belongs to `report`, while a legacy
+ * `report.csv` identity would be stored as e.g. `session/report.csv.txt`.
+ * Dotted identities without a filename extension use canonical storage. */
+export function legacyObjectId(key: string, session: string): string | undefined {
+  if (path.posix.dirname(key) !== session) return undefined;
+  const basename = path.posix.basename(key);
+  const extension = path.posix.extname(basename);
+  return extension === '' ? basename : basename.slice(0, -extension.length);
+}
+
 export interface ObjectResolverDependencies {
   bucket: string;
   list(prefix: string): AsyncIterable<{ name?: string }>;
@@ -58,8 +70,7 @@ export class FileObjectResolver {
 
   private matches(key: string, session: string, id: string): boolean {
     if (key === canonicalObjectKey(session, id)) return true;
-    return path.posix.dirname(key) === session &&
-      (path.posix.basename(key) === id || path.posix.basename(key, path.posix.extname(key)) === id);
+    return legacyObjectId(key, session) === id;
   }
 
   async remember(session: string, id: string, key: string, replace = true): Promise<void> {

--- a/service/src/file-server.ts
+++ b/service/src/file-server.ts
@@ -1,6 +1,12 @@
 import b from 'busboy';
 import { randomUUID } from 'node:crypto';
-import { canonicalObjectId, FileObjectResolver, mapObjectDetails, storageKeyForUpload } from './file-object-resolver';
+import {
+  canonicalObjectId,
+  FileObjectResolver,
+  legacyObjectId,
+  mapObjectDetails,
+  storageKeyForUpload,
+} from './file-object-resolver';
 import { sendFileDownload } from './file-download';
 import path from 'path';
 import IORedis from 'ioredis';
@@ -573,9 +579,8 @@ function parseObjectName(objectName: string | undefined): { session_id: string; 
   const parts = objectName.split('/');
   if (parts.length < 2) return null;
   const session_id = parts[0];
-  const fileNameWithExt = parts[1];
-  // Remove extension to get file_id
-  const file_id = fileNameWithExt.replace(/\.[^.]+$/, '');
+  const file_id = legacyObjectId(objectName, session_id);
+  if (file_id == null) return null;
   return { session_id, file_id };
 }
 


### PR DESCRIPTION
## Summary

Legacy storage matching treated `session/report.csv` as both the `report` identity with a `.csv` filename extension and the exact dotted identity `report.csv`. Replacement cleanup or DELETE for `report` could therefore remove an adjacent dotted identity's object. I made legacy key decoding single-valued and reused it for resolution and metadata listing. Closes #185.

- Derive one legacy identity by removing the final filename extension when present.
- Keep extensionless legacy keys mapped to their exact basename.
- Preserve exact dotted identities through the canonical encoded object namespace introduced in #182.
- Reuse the same decoder when listing object metadata so reads, cleanup, and deletion agree.
- Cover coexisting `report` and `report.csv` identities across legacy and canonical keys, including rejection of an ambiguous cached locator.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd service && bun test src/file-object-resolver.test.ts` — 11 passed.
- `cd service && bun test ./src/*.test.ts ./src/*.spec.ts ./src/**/*.test.ts ./src/**/*.spec.ts` — 970 passed, 11 integration-only tests skipped, 0 failed.
- `cd service && bun run build` — passed with existing Rollup and TypeScript warnings.
- `cd service && bunx tsc --noEmit` — the local standalone typecheck reports existing errors outside the changed files; no errors reference the resolver or file-server changes.

### **Test Configuration**:

- Bun 1.3.13
- macOS arm64

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
