### PR TITLE
feat: Add Trusted VM Command Policy

### DIFF
--- a/docs/adr/001-stateful-code-environments.md
+++ b/docs/adr/001-stateful-code-environments.md
@@ -60,8 +60,10 @@ worker replacement; the UI and operator documentation must not imply otherwise.
   pairing secures the transport identity but does not make the host a sandbox.
   An operator may explicitly delegate network and local-socket restrictions to
   an approved outer VM boundary through a named, digested worker policy. That
-  delegation must retain workspace filesystem confinement, worker-identity and
-  credential protection, cancellation, and resource limits.
+  delegation retains direct workspace filesystem rules, cancellation, and
+  resource limits. The operator is responsible for preventing permitted host
+  services (for example, a privileged container socket) from bypassing those
+  rules and exposing worker identity or credential material.
 - A compromised worker can lie about advertised capabilities. Capability
   labels and policy digests are audit signals until enforcement is coupled to
   an attested sandbox or trusted host policy.

--- a/docs/adr/001-stateful-code-environments.md
+++ b/docs/adr/001-stateful-code-environments.md
@@ -56,8 +56,12 @@ worker replacement; the UI and operator documentation must not imply otherwise.
   revocation.
 - Pairing codes and credentials are stored by digest where lookup permits.
 - One configured worker has at most one active fenced assignment.
-- Sandbox isolation and default-deny egress remain mandatory; pairing secures
-  the transport identity but does not make the host a sandbox.
+- Sandbox isolation and default-deny egress remain the mandatory default;
+  pairing secures the transport identity but does not make the host a sandbox.
+  An operator may explicitly delegate network and local-socket restrictions to
+  an approved outer VM boundary through a named, digested worker policy. That
+  delegation must retain workspace filesystem confinement, worker-identity and
+  credential protection, cancellation, and resource limits.
 - A compromised worker can lie about advertised capabilities. Capability
   labels and policy digests are audit signals until enforcement is coupled to
   an attested sandbox or trusted host policy.
@@ -65,7 +69,8 @@ worker replacement; the UI and operator documentation must not imply otherwise.
 ## Consequences
 
 - `@librechat/code` owns the provider-neutral protocol, identity handling, and
-  worker CLI; Code API owns enrollment, scheduling, and execution policy.
+  worker CLI, including machine-local execution-policy presets; Code API owns
+  enrollment, scheduling, and execution policy.
 - LibreChat owns environment persistence, ownership, RBAC, and user experience.
 - The Agents SDK keeps only its adapter until a second concrete consumer proves
   which coding-tool abstractions are genuinely provider neutral.

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -215,9 +215,10 @@ LIBRECHAT_CODE_COMMAND_SANDBOX=native-srt librechat-code run \
 
 The native SRT backend can be made intentionally permissive when the selected
 machine already supplies an administrator-approved outer security boundary.
-The `trusted-vm` preset keeps SRT filesystem confinement, credential masking,
-private scratch storage, cancellation, time limits, and output limits, while
-allowing unmatched outbound destinations, local port binding, and Unix sockets:
+The `trusted-vm` preset keeps SRT's direct filesystem rules, credential
+masking, private scratch storage, cancellation, time limits, and output limits,
+while allowing unmatched outbound destinations, local port binding, and Unix
+sockets:
 
 ```bash
 librechat-code run \
@@ -238,9 +239,12 @@ custom sandbox profile label.
 Treat this preset as delegation to the machine's outer security controls. Any
 outbound destination can receive workspace data, local listeners can accept
 connections reachable under host policy, and Unix socket access may expose
-powerful host services such as a container daemon. Register only the intended
-source root. Worker identity, mutation-quarantine state, and configured GitHub
-App key files must remain outside it.
+powerful host services such as a container daemon. A socket that grants host
+privilege can bypass SRT's filesystem rules and reach worker or GitHub identity
+material; the outer VM boundary must prevent that path or explicitly accept
+that trust. Register only the intended source root. Worker identity,
+mutation-quarantine state, and configured GitHub App key files must remain
+outside it.
 
 ## Docker runtime supervisor (optional hardened adapter)
 

--- a/packages/code/README.md
+++ b/packages/code/README.md
@@ -211,6 +211,37 @@ LIBRECHAT_CODE_COMMAND_SANDBOX=native-srt librechat-code run \
   --worker-dir /path/to/project --allow-workspace-commands
 ```
 
+### Trusted VM command policy
+
+The native SRT backend can be made intentionally permissive when the selected
+machine already supplies an administrator-approved outer security boundary.
+The `trusted-vm` preset keeps SRT filesystem confinement, credential masking,
+private scratch storage, cancellation, time limits, and output limits, while
+allowing unmatched outbound destinations, local port binding, and Unix sockets:
+
+```bash
+librechat-code run \
+  --worker-dir /home/ubuntu/src \
+  --allow-workspace-writes \
+  --allow-workspace-commands \
+  --command-policy-preset trusted-vm
+```
+
+`LIBRECHAT_CODE_COMMAND_POLICY_PRESET=trusted-vm` is the environment equivalent.
+The default is `restricted`, which preserves the default-deny network policy.
+The preset configures `native-srt`; it is not an unsandboxed host-shell
+backend. It is rejected unless native workspace commands are enabled. Its
+normalized effective controls are included in the worker policy digest, and
+the worker advertises `anthropic-srt:trusted-vm` unless an operator supplied a
+custom sandbox profile label.
+
+Treat this preset as delegation to the machine's outer security controls. Any
+outbound destination can receive workspace data, local listeners can accept
+connections reachable under host policy, and Unix socket access may expose
+powerful host services such as a container daemon. Register only the intended
+source root. Worker identity, mutation-quarantine state, and configured GitHub
+App key files must remain outside it.
+
 ## Docker runtime supervisor (optional hardened adapter)
 
 `DockerRuntimeSupervisor` is the first self-contained local OCI adapter. It

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -35,6 +35,10 @@
       "types": "./dist/native-sandbox.d.ts",
       "import": "./dist/native-sandbox.js"
     },
+    "./native-policy": {
+      "types": "./dist/native-policy.d.ts",
+      "import": "./dist/native-policy.js"
+    },
     "./github": {
       "types": "./dist/github.d.ts",
       "import": "./dist/github.js"

--- a/packages/code/src/cli.test.ts
+++ b/packages/code/src/cli.test.ts
@@ -94,6 +94,46 @@ test('CLI rejects an unknown command sandbox before entering the run loop', () =
   );
 });
 
+test('CLI rejects an unknown native SRT command policy preset', () => {
+  const result = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL('./cli.js', import.meta.url))],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        LIBRECHAT_CODE_URL: 'https://code.example/v1',
+        LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
+        LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
+        LIBRECHAT_CODE_COMMAND_POLICY_PRESET: 'host-shell',
+      },
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /must be restricted or trusted-vm/);
+});
+
+test('CLI refuses a permissive policy when native commands are unavailable', () => {
+  const result = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL('./cli.js', import.meta.url))],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        LIBRECHAT_CODE_URL: 'https://code.example/v1',
+        LIBRECHAT_CODE_WORKER_TOKEN: 'worker-secret',
+        LIBRECHAT_CODE_WORKER_ID: 'engineering-vm',
+        LIBRECHAT_CODE_COMMAND_POLICY_PRESET: 'trusted-vm',
+      },
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /requires native-srt workspace commands/);
+});
+
 test('CLI rejects incomplete GitHub App authentication before worker registration', () => {
   const result = spawnSync(
     process.execPath,

--- a/packages/code/src/cli.ts
+++ b/packages/code/src/cli.ts
@@ -29,6 +29,10 @@ import {
 import { RuntimeWorkspaceCommandSandbox } from './workspace-runtime.js';
 import { NativeProcessWorkspaceCommandSandbox } from './native-process.js';
 import { NativeWorkspaceCommandPool } from './native-pool.js';
+import {
+  resolveNativeSrtCommandPolicy,
+  serializeNativeSrtCommandPolicy,
+} from './native-policy.js';
 import { workspaceMutationGuard } from './workspace-guards.js';
 import type { NativeProcessSandboxOptions } from './native-process.js';
 import type { LocalWorkspaceConfig } from './workspace.js';
@@ -404,6 +408,19 @@ async function run(
       'LIBRECHAT_CODE_COMMAND_SANDBOX must be native-srt or runtime',
     );
   }
+  const commandPolicy = resolveNativeSrtCommandPolicy(
+    option(args, '--command-policy-preset') ??
+      process.env.LIBRECHAT_CODE_COMMAND_POLICY_PRESET?.trim().toLowerCase() ??
+      'restricted',
+  );
+  if (
+    commandPolicy.preset !== 'restricted' &&
+    (!allowWorkspaceCommands || commandSandboxMode !== 'native-srt')
+  ) {
+    throw new Error(
+      'A permissive command policy preset requires native-srt workspace commands',
+    );
+  }
   const github =
     runtimeSessionId == null
       ? githubCredentials()
@@ -756,6 +773,7 @@ async function run(
         });
   const nativeOptions: NativeProcessSandboxOptions = {
     workspaceRoot: canonicalWorkerDirectory!,
+    commandPolicy,
     protectedPaths: [
       identityPath,
       ...rootQuarantinePaths.values(),
@@ -820,7 +838,9 @@ async function run(
     sandboxProfile:
       process.env.LIBRECHAT_CODE_SANDBOX_PROFILE ??
       (allowWorkspaceCommands && commandSandboxMode === 'native-srt'
-        ? 'anthropic-srt'
+        ? commandPolicy.preset === 'restricted'
+          ? 'anthropic-srt'
+          : `anthropic-srt:${commandPolicy.preset}`
         : runtimeMode.startsWith('docker')
           ? 'oci-docker'
           : 'nsjail'),
@@ -829,7 +849,7 @@ async function run(
       .update(policy)
       .update(
         allowWorkspaceCommands && commandSandboxMode === 'native-srt'
-          ? `\0native-srt\0${commandAllowedDomains.join('\0')}\0${github.policyIdentity}`
+          ? `\0native-srt\0${serializeNativeSrtCommandPolicy(commandPolicy)}\0${commandAllowedDomains.join('\0')}\0${github.policyIdentity}`
           : '',
       )
       .digest('hex'),

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -5,6 +5,7 @@ export * from './storage.js';
 export * from './runtime.js';
 export * from './workspace.js';
 export * from './workspace-runtime.js';
+export * from './native-policy.js';
 export * from './native-sandbox.js';
 export * from './native-process.js';
 export * from './github.js';

--- a/packages/code/src/native-policy.test.ts
+++ b/packages/code/src/native-policy.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  normalizeNativeSrtCommandPolicy,
+  resolveNativeSrtCommandPolicy,
+  serializeNativeSrtCommandPolicy,
+} from './native-policy.js';
+
+test('restricted remains the default native SRT command policy', () => {
+  assert.deepEqual(resolveNativeSrtCommandPolicy(), {
+    version: 1,
+    preset: 'restricted',
+    network: {
+      outbound: 'allowlist',
+      allowLocalBinding: false,
+      allowAllUnixSockets: false,
+    },
+  });
+});
+
+test('trusted-vm resolves to explicit permissive network controls', () => {
+  assert.deepEqual(resolveNativeSrtCommandPolicy('trusted-vm'), {
+    version: 1,
+    preset: 'trusted-vm',
+    network: {
+      outbound: 'unrestricted',
+      allowLocalBinding: true,
+      allowAllUnixSockets: true,
+    },
+  });
+});
+
+test('unknown and forged native policies fail closed', () => {
+  assert.throws(
+    () => resolveNativeSrtCommandPolicy('host-shell'),
+    /must be restricted or trusted-vm/,
+  );
+  assert.throws(
+    () =>
+      normalizeNativeSrtCommandPolicy({
+        ...resolveNativeSrtCommandPolicy('restricted'),
+        network: {
+          ...resolveNativeSrtCommandPolicy('restricted').network,
+          allowAllUnixSockets: true,
+        },
+      }),
+    /does not match its preset/,
+  );
+});
+
+test('serialized policy is stable and includes effective controls', () => {
+  const first = serializeNativeSrtCommandPolicy(
+    resolveNativeSrtCommandPolicy('trusted-vm'),
+  );
+  const second = serializeNativeSrtCommandPolicy(
+    resolveNativeSrtCommandPolicy('trusted-vm'),
+  );
+  assert.equal(first, second);
+  assert.match(first, /"outbound":"unrestricted"/);
+  assert.match(first, /"allowLocalBinding":true/);
+  assert.match(first, /"allowAllUnixSockets":true/);
+});

--- a/packages/code/src/native-policy.ts
+++ b/packages/code/src/native-policy.ts
@@ -1,0 +1,86 @@
+export const NATIVE_SRT_COMMAND_POLICY_PRESETS = [
+  'restricted',
+  'trusted-vm',
+] as const;
+
+export type NativeSrtCommandPolicyPreset =
+  typeof NATIVE_SRT_COMMAND_POLICY_PRESETS[number];
+
+export interface NativeSrtCommandPolicy {
+  version: 1;
+  preset: NativeSrtCommandPolicyPreset;
+  network: {
+    outbound: 'allowlist' | 'unrestricted';
+    allowLocalBinding: boolean;
+    allowAllUnixSockets: boolean;
+  };
+}
+
+const PRESETS: Record<NativeSrtCommandPolicyPreset, NativeSrtCommandPolicy> = {
+  restricted: {
+    version: 1,
+    preset: 'restricted',
+    network: {
+      outbound: 'allowlist',
+      allowLocalBinding: false,
+      allowAllUnixSockets: false,
+    },
+  },
+  'trusted-vm': {
+    version: 1,
+    preset: 'trusted-vm',
+    network: {
+      outbound: 'unrestricted',
+      allowLocalBinding: true,
+      allowAllUnixSockets: true,
+    },
+  },
+};
+
+function isPreset(value: unknown): value is NativeSrtCommandPolicyPreset {
+  return (
+    typeof value === 'string' &&
+    NATIVE_SRT_COMMAND_POLICY_PRESETS.some((preset) => preset === value)
+  );
+}
+
+/** Resolve a named convenience preset into the explicit policy SRT enforces. */
+export function resolveNativeSrtCommandPolicy(
+  preset: unknown = 'restricted',
+): NativeSrtCommandPolicy {
+  if (!isPreset(preset)) {
+    throw new Error(
+      'Native SRT command policy preset must be restricted or trusted-vm',
+    );
+  }
+  const policy = PRESETS[preset];
+  return { ...policy, network: { ...policy.network } };
+}
+
+/** Validate a programmatic policy and return canonical preset-owned values. */
+export function normalizeNativeSrtCommandPolicy(
+  policy?: NativeSrtCommandPolicy,
+): NativeSrtCommandPolicy {
+  const normalized = resolveNativeSrtCommandPolicy(
+    policy?.preset ?? 'restricted',
+  );
+  if (
+    policy !== undefined &&
+    (policy.version !== normalized.version ||
+      policy.network?.outbound !== normalized.network.outbound ||
+      policy.network?.allowLocalBinding !==
+        normalized.network.allowLocalBinding ||
+      policy.network?.allowAllUnixSockets !==
+        normalized.network.allowAllUnixSockets)
+  ) {
+    throw new Error('Native SRT command policy does not match its preset');
+  }
+  return normalized;
+}
+
+/** Stable policy material used in the bridge capability digest. */
+export function serializeNativeSrtCommandPolicy(
+  policy: NativeSrtCommandPolicy,
+): string {
+  return JSON.stringify(normalizeNativeSrtCommandPolicy(policy));
+}

--- a/packages/code/src/native-process.test.ts
+++ b/packages/code/src/native-process.test.ts
@@ -108,6 +108,36 @@ test('executor bootstrap excludes bridge credentials and Node injection variable
   await sandbox.close();
 });
 
+test('executor forwards the resolved command policy without worker credentials', async () => {
+  const fake = fixture();
+  const sandbox = new NativeProcessWorkspaceCommandSandbox(
+    {
+      workspaceRoot: '/workspace',
+      commandPolicy: {
+        version: 1,
+        preset: 'trusted-vm',
+        network: {
+          outbound: 'unrestricted',
+          allowLocalBinding: true,
+          allowAllUnixSockets: true,
+        },
+      },
+    },
+    fake.fork,
+  );
+  await sandbox.prepare();
+  assert.deepEqual(fake.messages[0].options.commandPolicy, {
+    version: 1,
+    preset: 'trusted-vm',
+    network: {
+      outbound: 'unrestricted',
+      allowLocalBinding: true,
+      allowAllUnixSockets: true,
+    },
+  });
+  await sandbox.close();
+});
+
 test('executor hands credentials over IPC only for the current command', async () => {
   const fake = fixture();
   const sandbox = new NativeProcessWorkspaceCommandSandbox(

--- a/packages/code/src/native-process.ts
+++ b/packages/code/src/native-process.ts
@@ -182,6 +182,7 @@ export class NativeProcessWorkspaceCommandSandbox
     child.on('disconnect', lost);
     const {
       workspaceRoot,
+      commandPolicy,
       protectedPaths,
       allowedDomains,
       homeDirectory,
@@ -192,6 +193,7 @@ export class NativeProcessWorkspaceCommandSandbox
       {
         options: {
           workspaceRoot,
+          commandPolicy,
           protectedPaths,
           allowedDomains,
           homeDirectory,

--- a/packages/code/src/native-sandbox.test.ts
+++ b/packages/code/src/native-sandbox.test.ts
@@ -19,7 +19,10 @@ import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import test from 'node:test';
 
-import type { SandboxRuntimeConfig } from '@anthropic-ai/sandbox-runtime';
+import type {
+  SandboxAskCallback,
+  SandboxRuntimeConfig,
+} from '@anthropic-ai/sandbox-runtime';
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 
 import { NativeSrtWorkspaceCommandSandbox } from './native-sandbox.js';
@@ -46,6 +49,7 @@ function fakeManager(
   } = {},
 ) {
   let config: SandboxRuntimeConfig | undefined;
+  let askCallback: SandboxAskCallback | undefined;
   let reset = false;
   let credentialSeenDuringWrap: string | undefined;
   let gitLfsRequiredSeenDuringWrap: string | undefined;
@@ -55,8 +59,12 @@ function fakeManager(
     async checkDependenciesAsync() {
       return { warnings: [], errors: options.dependencyErrors ?? [] };
     },
-    async initialize(value: SandboxRuntimeConfig) {
+    async initialize(
+      value: SandboxRuntimeConfig,
+      callback?: SandboxAskCallback,
+    ) {
       config = value;
+      askCallback = callback;
       if (options.initializeError) throw options.initializeError;
     },
     async wrapWithSandboxArgv(command: string) {
@@ -106,6 +114,9 @@ function fakeManager(
     manager,
     get config() {
       return config;
+    },
+    get askCallback() {
+      return askCallback;
     },
     get reset() {
       return reset;
@@ -276,6 +287,8 @@ test('initializes SRT with a default-deny network and scrubbed worker credential
   assert.deepEqual(fake.config?.network.allowedDomains, []);
   assert.equal(fake.config?.network.strictAllowlist, true);
   assert.equal(fake.config?.network.allowAllUnixSockets, false);
+  assert.equal(fake.config?.network.allowLocalBinding, false);
+  assert.equal(fake.askCallback, undefined);
   assert.deepEqual(fake.config?.filesystem.allowRead, [
     canonicalRoot,
     scratchDirectory,
@@ -303,6 +316,39 @@ test('initializes SRT with a default-deny network and scrubbed worker credential
   await sandbox.close();
   assert.equal(fake.reset, true);
   await assert.rejects(access(scratchDirectory!));
+});
+
+test('trusted-vm permits unmatched egress and local development sockets', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'librechat-code-native-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const fake = fakeManager();
+  const sandbox = new NativeSrtWorkspaceCommandSandbox({
+    workspaceRoot: root,
+    commandPolicy: {
+      version: 1,
+      preset: 'trusted-vm',
+      network: {
+        outbound: 'unrestricted',
+        allowLocalBinding: true,
+        allowAllUnixSockets: true,
+      },
+    },
+    manager: fake.manager,
+  });
+  t.after(() => sandbox.close());
+
+  await sandbox.prepare();
+
+  assert.equal(fake.config?.network.strictAllowlist, false);
+  assert.equal(fake.config?.network.allowLocalBinding, true);
+  assert.equal(fake.config?.network.allowAllUnixSockets, true);
+  assert.equal(
+    await fake.askCallback?.({ host: 'packages.example', port: 443 }),
+    true,
+  );
+  assert.deepEqual(fake.config?.filesystem.allowWrite.slice(0, 1), [
+    await realpath(root),
+  ]);
 });
 
 test('provides an isolated scratch directory to commands and restores the host environment', async (t) => {

--- a/packages/code/src/native-sandbox.ts
+++ b/packages/code/src/native-sandbox.ts
@@ -41,7 +41,12 @@ import type {
   ChildProcessWithoutNullStreams,
   SpawnOptionsWithoutStdio,
 } from 'node:child_process';
-import type { SandboxRuntimeConfig } from '@anthropic-ai/sandbox-runtime';
+import type {
+  SandboxAskCallback,
+  SandboxRuntimeConfig,
+} from '@anthropic-ai/sandbox-runtime';
+import { normalizeNativeSrtCommandPolicy } from './native-policy.js';
+import type { NativeSrtCommandPolicy } from './native-policy.js';
 import type {
   WorkspaceExecuteCommandRequest,
   WorkspaceExecuteCommandResult,
@@ -124,7 +129,10 @@ const HOST_TEMPORARY_ROOT = tmpdir();
 interface NativeSandboxManager {
   isSupportedPlatform(): boolean;
   checkDependenciesAsync(): Promise<{ warnings: string[]; errors: string[] }>;
-  initialize(config: SandboxRuntimeConfig): Promise<void>;
+  initialize(
+    config: SandboxRuntimeConfig,
+    sandboxAskCallback?: SandboxAskCallback,
+  ): Promise<void>;
   wrapWithSandboxArgv(
     command: string,
     binShell?: string,
@@ -153,6 +161,7 @@ type SpawnCommand = (
 
 export interface NativeSrtWorkspaceCommandSandboxOptions {
   workspaceRoot: string;
+  commandPolicy?: NativeSrtCommandPolicy;
   /** Trusted worker files that must never become workspace-readable or writable. */
   protectedPaths?: string[];
   allowedDomains?: string[];
@@ -369,13 +378,18 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
         'REGISTRATION_INVALID',
       );
     }
+    const commandPolicy = normalizeNativeSrtCommandPolicy(
+      this.options.commandPolicy,
+    );
+    const unrestrictedNetwork =
+      commandPolicy.network.outbound === 'unrestricted';
     const config: SandboxRuntimeConfig = {
       network: {
         allowedDomains: [...(this.options.allowedDomains ?? [])],
         deniedDomains: [],
-        strictAllowlist: true,
-        allowAllUnixSockets: false,
-        allowLocalBinding: false,
+        strictAllowlist: !unrestrictedNetwork,
+        allowAllUnixSockets: commandPolicy.network.allowAllUnixSockets,
+        allowLocalBinding: commandPolicy.network.allowLocalBinding,
         ...(this.options.maskedEnvironment ? { tlsTerminate: {} } : {}),
       },
       filesystem: {
@@ -439,7 +453,10 @@ export class NativeSrtWorkspaceCommandSandbox implements WorkspaceCommandSandbox
       enableWeakerNetworkIsolation: false,
       git: { safeDirectories: [root] },
     };
-    await this.manager.initialize(config);
+    await this.manager.initialize(
+      config,
+      unrestrictedNetwork ? async () => true : undefined,
+    );
     this.canonicalRoot = root;
   }
 


### PR DESCRIPTION
## Summary

I added an explicit trusted-VM policy preset for native BYOM workers whose machine already provides an administrator-approved outer security boundary.

- Preserve the existing restricted SRT policy as the default.
- Allow unmatched outbound destinations, local port binding, and Unix sockets only when `trusted-vm` is explicitly selected.
- Retain SRT direct workspace rules, private scratch storage, credential masking, cancellation, and command resource bounds.
- Carry the resolved policy into process-isolated workspace executors and include its normalized controls in the worker policy digest.
- Advertise `anthropic-srt:trusted-vm` so operators can distinguish the effective worker posture.
- Reject unknown presets and reject permissive policy when native workspace commands are unavailable.
- Document the trusted outer-boundary threat model, including privileged socket bypass risk, and update the stateful-environment ADR.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- Built `@librechat/code` with TypeScript.
- Ran 85 focused CLI, policy, process-executor, and native-SRT tests.
- Ran `npm pack --dry-run --json` and confirmed the new public `native-policy` export is packaged.
- Ran a real macOS SRT smoke test that wrote within a nested workspace, bound localhost, created a Unix socket, reached an unmatched HTTPS destination, and failed to read a protected worker-identity file.
- Ran isolated Redis + Code API + real native worker bridge tests on ports 26479/23187 and 26480/23188.
- Verified both static and one-time paired worker authentication, advertised `anthropic-srt:trusted-vm`, unrestricted HTTPS egress, nested file mutation, stateful readback, and private identity mode 0600.

### Test Configuration

- macOS native SRT / Seatbelt
- Node.js 24.16.0
- Bun 1.3.13 for the local Code API build
- `@anthropic-ai/sandbox-runtime` 0.0.75

## Checklist

- [x] My code adheres to this projects style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of the code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes