### PR TITLE
fix: Release Unassigned Workspace Slots When Dispatch Cleanup Fails

### DIFF
--- a/service/src/bridge/concurrent-store.test.ts
+++ b/service/src/bridge/concurrent-store.test.ts
@@ -384,6 +384,46 @@ test('queued cancellation never leases and does not block another root', async (
   ).toBeUndefined();
 });
 
+test('unassigned slot releases even when dispatch cleanup fails', async () => {
+  await register();
+  const originalIncr = redis.incr.bind(redis);
+  const originalSet = redis.set.bind(redis);
+  const set = originalSet as (...args: unknown[]) => unknown;
+  redis.incr = ((key: string) =>
+    key.endsWith(':generation')
+      ? Promise.reject(new Error('injected generation outage'))
+      : originalIncr(key)) as typeof redis.incr;
+  redis.set = ((key: string, ...args: unknown[]) =>
+    key.endsWith(':cancelled')
+      ? Promise.reject(new Error('injected cancellation outage'))
+      : set(key, ...args)) as typeof redis.set;
+  try {
+    // The reservation succeeds, then dispatch fails before storing an assignment.
+    await expect(dispatch('a')).rejects.toThrow('injected cancellation outage');
+  } finally {
+    redis.incr = originalIncr;
+    redis.set = originalSet;
+  }
+  expect(
+    await redis.hlen(`codeapi:bridge:v1:worker:${workerId}:workspace-slots`),
+  ).toBe(0);
+  expect(
+    await redis.get(`codeapi:bridge:v1:worker:${workerId}:lock`),
+  ).toBeNull();
+  const next = dispatch('a');
+  const assignment = (await store.lease(
+    workerId,
+    incarnationId,
+    1000,
+    undefined,
+    undefined,
+    0,
+  ))!;
+  expect(assignment.request).toMatchObject({ workspaceId: 'a' });
+  await settle(assignment);
+  await expect(next).resolves.toMatchObject({ status: 'rejected' });
+});
+
 test('late quarantine releases its slot after caller cancellation and retains only its root fence', async () => {
   await register();
   const controller = new AbortController();

--- a/service/src/bridge/store.ts
+++ b/service/src/bridge/store.ts
@@ -1060,19 +1060,14 @@ export class RedisBridgeStore {
           // already committed result rather than turning cleanup availability
           // into a client-visible failure that could prompt duplicate work.
         }
+      } else if (workspaceSlots != null && assignment == null) {
+        await this.cleanupUnassignedSlot(
+          args.workerId,
+          lockIncarnationId,
+          assignmentId,
+        );
       } else {
         await this.cleanupDispatch(args.workerId, assignmentId, assignment);
-      }
-      if (workspaceSlots != null && assignment == null) {
-        await boundedCommand(
-          workspaceSlots.release(
-            args.workerId,
-            lockIncarnationId,
-            assignmentId,
-          ),
-          this.redisCommandTimeoutMs,
-          'Bridge unassigned slot cleanup',
-        );
       }
     }
   }
@@ -2136,6 +2131,29 @@ export class RedisBridgeStore {
           )
         : this.cleanup(assignment),
     ]);
+  }
+
+  private async cleanupUnassignedSlot(
+    workerId: string,
+    incarnationId: string,
+    assignmentId: string,
+  ): Promise<void> {
+    // No stored assignment owns this reservation, so a cancellation outage
+    // must not leave the slot and its root busy until TTL expiry.
+    const [cleanup, release] = await Promise.allSettled([
+      this.cleanupDispatch(workerId, assignmentId, undefined),
+      boundedCommand(
+        new BridgeWorkspaceSlots(this.redis).release(
+          workerId,
+          incarnationId,
+          assignmentId,
+        ),
+        this.redisCommandTimeoutMs,
+        'Bridge unassigned slot cleanup',
+      ),
+    ]);
+    if (cleanup.status === 'rejected') throw cleanup.reason;
+    if (release.status === 'rejected') throw release.reason;
   }
 
   private async commitPendingWorkspace(


### PR DESCRIPTION
## Summary

When a worker advertises more than one workspace lease slot (#167), a dispatch reserves a slot before it stores an assignment. If the dispatch then failed before storing the assignment, the `finally` block ran dispatch cleanup (cancellation marker plus lock release) and only afterwards released the reserved slot. A cleanup failure, such as a Redis timeout while writing the cancellation marker, exited `finally` before the release. The slot and its workspace root stayed busy until TTL expiry, so later requests for that root queued behind a reservation nothing owned. Closes #170.

- Release an unassigned slot in a dedicated `cleanupUnassignedSlot` step that runs dispatch cleanup and slot release concurrently with `Promise.allSettled`, so a failure in one never skips the other.
- Keep the primary cleanup error: a dispatch cleanup failure is rethrown first, and a slot release failure surfaces only when cleanup succeeded (the previous behavior for release-only failures).
- Leave committed results and stored assignments on their existing paths. `cleanup(assignment)` already releases slots owned by a stored assignment.
- Keep the explicit throws out of `finally` so `no-unsafe-finally` stays clean.

```
before                                    after
finally:                                  finally:
  await cleanupDispatch()  ── throws ─┐     allSettled([
  await slots.release()    (skipped)  │       cleanupDispatch(),
                                      ▼       slots.release(),   ← always attempted
                          slot busy until TTL ])
                                            rethrow cleanup error, else release error
```

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Added `unassigned slot releases even when dispatch cleanup fails` to `service/src/bridge/concurrent-store.test.ts`. A concurrent reservation succeeds, generation allocation fails before assignment storage, and the cancellation write also fails. The test asserts the cancellation error surfaces, the slot hash and aggregate worker lock are cleared, and a new request for the same root leases slot 0 immediately. It fails on `main` with 4 slot fields left behind and passes with this change.
- `cd service && bun test src/bridge/concurrent-store.test.ts src/bridge/store.test.ts src/bridge/concurrent-worker.test.ts` — 72 passed, 0 failed.
- `cd service && bun run test` — 938 passed, 11 skipped, 33 failed. All failures are in `egress-gateway`, `egress-ledger`, `egress-ledger-reconnect`, `tool-input-signature`, and `lambda-microvm`. Those five files fail identically on unmodified `main` in this environment (109 passed, 32 failed either way) and do not touch the bridge store.
- The full `src/bridge/` directory run is timing-sensitive under load. Unmodified `main` also failed intermittently (2 of 6 runs, different tests each time).
- `cd service && npx tsc --noEmit` — 5 existing errors in egress, replay-state, and sandbox-backend files; none in the changed files.
- ESLint reports no findings on the changed lines.

### **Test Configuration**:

- Bun 1.4.0
- Linux x86_64 (WSL2), ioredis-mock

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
