### PR TITLE
fix: Exit Cleanly When Native Executor Shuts Down Concurrently

### DIFF
--- a/packages/code/src/native-process-child.test.ts
+++ b/packages/code/src/native-process-child.test.ts
@@ -33,7 +33,7 @@ for (const signal of ['SIGINT', 'SIGHUP', 'SIGTERM'] as const) {
       // installation finished without requiring platform SRT dependencies.
       child.once('message', () => child.kill(signal));
       child.send({ id: 'startup-probe', type: 'probe' });
-      assert.deepEqual(await exited, { code: 1, signal: null });
+      assert.deepEqual(await exited, { code: 0, signal: null });
     },
   );
 }

--- a/packages/code/src/native-process-child.ts
+++ b/packages/code/src/native-process-child.ts
@@ -25,7 +25,10 @@ const shutdown = () => {
   if (shuttingDown) return;
   shuttingDown = true;
   active?.controller.abort();
-  void (sandbox?.close() ?? Promise.resolve()).finally(() => process.exit(1));
+  void (sandbox?.close() ?? Promise.resolve()).then(
+    () => process.exit(0),
+    () => process.exit(1),
+  );
   setTimeout(() => process.exit(1), 5000);
 };
 process.on('disconnect', shutdown);

--- a/packages/code/src/native-process.test.ts
+++ b/packages/code/src/native-process.test.ts
@@ -301,6 +301,47 @@ test('executor close drains an active command before closing IPC', async () => {
   await assert.rejects(sandbox.execute(request), /unavailable/);
 });
 
+test('executor close resolves when the child exits during the close handshake', async () => {
+  const fake = fixture();
+  const sandbox = new NativeProcessWorkspaceCommandSandbox(
+    { workspaceRoot: '/workspace' },
+    fake.fork,
+  );
+  await sandbox.prepare();
+  Object.assign(fake.child, {
+    send(message: Record<string, any>, callback: (error: null) => void) {
+      fake.messages.push(message);
+      callback(null);
+      queueMicrotask(() => {
+        Object.assign(fake.child, { connected: false });
+        fake.child.emit('exit', 1, null);
+        fake.child.emit('disconnect');
+      });
+      return true;
+    },
+  });
+  await sandbox.close();
+  assert.equal(fake.messages.filter((m) => m.type === 'close').length, 1);
+  await assert.rejects(sandbox.execute(request), /unavailable/);
+});
+
+test('executor close skips the handshake once the child is already lost', async () => {
+  const fake = fixture();
+  const sandbox = new NativeProcessWorkspaceCommandSandbox(
+    { workspaceRoot: '/workspace' },
+    fake.fork,
+  );
+  await sandbox.prepare();
+  Object.assign(fake.child, { connected: false });
+  fake.child.emit('exit', 1, null);
+  await sandbox.close();
+  assert.equal(
+    fake.messages.some((m) => m.type === 'close'),
+    false,
+  );
+  await assert.rejects(sandbox.execute(request), /unavailable/);
+});
+
 test('executor startup loss is not reported as an applied mutation', async () => {
   const fake = fixture();
   const sandbox = new NativeProcessWorkspaceCommandSandbox(

--- a/packages/code/src/native-process.test.ts
+++ b/packages/code/src/native-process.test.ts
@@ -325,6 +325,35 @@ test('executor close resolves when the child exits during the close handshake', 
   await assert.rejects(sandbox.execute(request), /unavailable/);
 });
 
+test('executor close still reports a cleanup failure the child replies with', async () => {
+  const fake = fixture();
+  const sandbox = new NativeProcessWorkspaceCommandSandbox(
+    { workspaceRoot: '/workspace' },
+    fake.fork,
+  );
+  await sandbox.prepare();
+  Object.assign(fake.child, {
+    send(message: Record<string, any>, callback: (error: null) => void) {
+      fake.messages.push(message);
+      callback(null);
+      queueMicrotask(() =>
+        fake.child.emit('message', {
+          id: message.id,
+          ok: false,
+          code: 'COMMAND_UNAVAILABLE',
+          errorMessage: 'scratch cleanup failed',
+          mutation: false,
+          requiresQuarantine: false,
+        }),
+      );
+      return true;
+    },
+  });
+  await assert.rejects(sandbox.close(), /scratch cleanup failed/);
+  assert.equal(fake.killCalls, 1);
+  await assert.rejects(sandbox.execute(request), /unavailable/);
+});
+
 test('executor close skips the handshake once the child is already lost', async () => {
   const fake = fixture();
   const sandbox = new NativeProcessWorkspaceCommandSandbox(

--- a/packages/code/src/native-process.ts
+++ b/packages/code/src/native-process.ts
@@ -340,12 +340,15 @@ export class NativeProcessWorkspaceCommandSandbox
     return this.closing;
   }
 
+  /** Best-effort shutdown handshake. An executor that exits, disconnects, or
+   * stalls while closing is terminated regardless, and once the active
+   * command has drained nothing left in flight can mutate the workspace. */
   private async stop(): Promise<void> {
     await this.active?.catch(() => undefined);
     await this.ready?.catch(() => undefined);
     try {
       if (this.child?.connected && !this.failed)
-        await this.rpc('close', {}, 10_000, false);
+        await this.rpc('close', {}, 10_000, false).catch(() => undefined);
     } finally {
       this.failed = true;
       this.terminate();

--- a/packages/code/src/native-process.ts
+++ b/packages/code/src/native-process.ts
@@ -73,6 +73,15 @@ export function nativeExecutorEnvironment(
   );
 }
 
+/** The executor process was lost, refused a send, or stalled past its
+ * deadline, as opposed to a failure the executor reported explicitly. */
+class NativeExecutorUnavailableError extends WorkspaceToolError {
+  constructor(mutation: boolean) {
+    super('Native executor is unavailable', 'COMMAND_UNAVAILABLE', mutation);
+    this.name = 'NativeExecutorUnavailableError';
+  }
+}
+
 /** One persistent, process-isolated SRT manager per workspace. No automatic
  * restart/replay: losing IPC after execution starts is an ambiguous mutation. */
 export class NativeProcessWorkspaceCommandSandbox
@@ -109,11 +118,7 @@ export class NativeProcessWorkspaceCommandSandbox
   }
 
   private unavailable(mutation: boolean): WorkspaceToolError {
-    return new WorkspaceToolError(
-      'Native executor is unavailable',
-      'COMMAND_UNAVAILABLE',
-      mutation,
-    );
+    return new NativeExecutorUnavailableError(mutation);
   }
 
   private async start(): Promise<void> {
@@ -340,15 +345,17 @@ export class NativeProcessWorkspaceCommandSandbox
     return this.closing;
   }
 
-  /** Best-effort shutdown handshake. An executor that exits, disconnects, or
-   * stalls while closing is terminated regardless, and once the active
-   * command has drained nothing left in flight can mutate the workspace. */
+  /** An executor that exits, disconnects, or stalls while closing is
+   * terminated in `finally` regardless, and the active command has already
+   * drained, so only a failure the executor reports explicitly is surfaced. */
   private async stop(): Promise<void> {
     await this.active?.catch(() => undefined);
     await this.ready?.catch(() => undefined);
     try {
       if (this.child?.connected && !this.failed)
-        await this.rpc('close', {}, 10_000, false).catch(() => undefined);
+        await this.rpc('close', {}, 10_000, false).catch((error: unknown) => {
+          if (!(error instanceof NativeExecutorUnavailableError)) throw error;
+        });
     } finally {
       this.failed = true;
       this.terminate();


### PR DESCRIPTION
## Summary

A native BYOM worker running under systemd with `KillMode=control-group` exited with status 1 on an ordinary `systemctl stop` or `restart`, even while idle, and the journal recorded `Native executor is unavailable`. The worker restarted and reconnected fine, so every deploy looked like a service failure without being one. Closes #190.

**What raced.** systemd delivers SIGTERM to the parent CLI and the forked SRT executor at the same moment. The child marks itself shutting down, begins closing its SRT sandbox, and ignores further IPC. The parent aborts the worker loop and reaches `nativeCommandSandbox.close()` in the CLI `finally` almost immediately. If the child is still connected at that point, `stop()` sends the `close` RPC, the child drops it, and when the child finally exits the `lost` handler rejects the pending RPC with `Native executor is unavailable`. That rejection propagated through `close()`, the CLI `finally`, and `main().catch()` into exit status 1. The same sequence applies to Ctrl-C and any supervisor that signals the whole process group.

- Tolerate a lost, refused, or stalled `close` handshake in `NativeProcessWorkspaceCommandSandbox.stop()`. The child is terminated in `finally` whether or not it replies, and `stop()` has already drained any active command, so those cases carry no mutation ambiguity. A negative `close` reply from the executor, such as a failed SRT reset or scratch cleanup, is a real failure and still rejects so `NativeWorkspaceCommandPool.close()` can aggregate it. Quarantine decisions live on the execute path and are unchanged.
- Report exit status 0 from the executor child when its own SRT teardown succeeds on a signal-driven shutdown, and keep status 1 for a failed or timed-out teardown. The parent never inspected this code, so this only makes the journal honest.

## Tests

- New: `close()` resolves when the child exits during the close handshake without replying. This fails on `main` with the same `unavailable` rejection seen in the issue.
- New: `close()` skips the handshake entirely once the child is already lost, and later `execute()` calls remain fenced.
- New: `close()` still rejects with the executor's own message when the child replies with an explicit cleanup failure, and the child is terminated.
- Updated: the child signal-routing test now expects exit status 0 for SIGINT, SIGHUP, and SIGTERM.
- Existing coverage for draining an active command before closing IPC, shutdown-receipt fencing, and pre-dispatch atomicity is unchanged and passes.

`npm test` in `packages/code` passes 382 of 386 locally. The 4 failures are storage tests that create fixtures under `/mnt/c`, a WSL DrvFS mount with mode 777, and are unrelated to this change.

## Note

The commits on this branch are unsigned because GPG could not prompt for a passphrase in the environment it was authored from.
